### PR TITLE
feat: add eth_sendRawTransaction

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -110,6 +110,10 @@ impl Client {
         }
     }
 
+    pub async fn send_raw_transaction(&self, bytes: &Vec<u8>) -> Result<Vec<u8>> {
+        self.execution.send_raw_transaction(bytes).await
+    }
+
     pub fn get_gas_price(&self) -> Result<U256> {
         let payload = self.get_payload(&None)?;
         let base_fee = U256::from_little_endian(&payload.base_fee_per_gas.to_bytes_le());

--- a/execution/src/execution.rs
+++ b/execution/src/execution.rs
@@ -97,6 +97,10 @@ impl ExecutionClient {
         Ok(code)
     }
 
+    pub async fn send_raw_transaction(&self, bytes: &Vec<u8>) -> Result<Vec<u8>> {
+        self.rpc.send_raw_transaction(bytes).await
+    }
+
     pub fn get_block(&self, payload: &ExecutionPayload) -> Result<ExecutionBlock> {
         let empty_nonce = "0x0000000000000000".to_string();
         let empty_uncle_hash = "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";

--- a/execution/src/rpc.rs
+++ b/execution/src/rpc.rs
@@ -44,6 +44,14 @@ impl Rpc {
         hex_str_to_bytes(&code)
     }
 
+    pub async fn send_raw_transaction(&self, bytes: &Vec<u8>) -> Result<Vec<u8>> {
+        let client = self.client()?;
+        let bytes_hex = format!("0x{}", hex::encode(bytes));
+        let params = rpc_params!(bytes_hex);
+        let tx_hash: String = client.request("eth_sendRawTransaction", params).await?;
+        hex_str_to_bytes(&tx_hash)
+    }
+
     fn client(&self) -> Result<HttpClient> {
         Ok(HttpClientBuilder::default().build(&self.rpc)?)
     }


### PR DESCRIPTION
This just passes the request off to the eth1 rpc as it is not possible to verify anything else here