### PR TITLE
fix: add missing fields to beacon block body

### DIFF
--- a/consensus/src/types.rs
+++ b/consensus/src/types.rs
@@ -332,9 +332,10 @@ where
     D: serde::Deserializer<'de>,
 {
     let val: String = serde::Deserialize::deserialize(deserializer)?;
-    // TODO: support larger values
-    let i = val.parse::<u64>().map_err(D::Error::custom)?;
-    Ok(U256::from(i))
+    let x = ethers::types::U256::from_dec_str(&val).map_err(D::Error::custom)?;
+    let mut x_bytes = [0; 32];
+    x.to_little_endian(&mut x_bytes);
+    Ok(U256::from_bytes_le(x_bytes))
 }
 
 fn bytes32_deserialize<'de, D>(deserializer: D) -> Result<Bytes32, D::Error>


### PR DESCRIPTION
closes #19 