### PR TITLE
feat: add installer

### DIFF
--- a/lightclientup/install
+++ b/lightclientup/install
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+
+# modified from https://github.com/foundry-rs/foundry/blob/master/foundryup/install
+
+REPO="a16z/lightclient"
+NAME=lightclient
+
+INSTALLER_NAME=${NAME}up
+
+DIR=$HOME/.$NAME
+BIN_DIR=$DIR/bin
+
+BIN_URL="https://raw.githubusercontent.com/$REPO/master/$INSTALLER_NAME/$INSTALLER_NAME"
+BIN_PATH="$BIN_DIR/$INSTALLER_NAME"
+
+# Create the bin directory and binary if it doesn't exist.
+mkdir -p $BIN_DIR
+curl -# -L $BIN_URL -o $BIN_PATH
+chmod +x $BIN_PATH
+
+# Store the correct profile file (i.e. .profile for bash or .zshrc for ZSH).
+case $SHELL in
+*/zsh)
+    PROFILE=$HOME/.zshrc
+    PREF_SHELL=zsh
+    ;;
+*/bash)
+    PROFILE=$HOME/.bashrc
+    PREF_SHELL=bash
+    ;;
+*/fish)
+    PROFILE=$HOME/.config/fish/config.fish
+    PREF_SHELL=fish
+    ;;
+*)
+    echo "$INSTALLER_NAME: could not detect shell, manually add ${BIN_DIR} to your PATH."
+    exit 1
+esac
+
+# Only add installer if it isn't already in PATH.
+if [[ ":$PATH:" != *":${BIN_DIR}:"* ]]; then
+    # Add the foundryup directory to the path and ensure the old PATH variables remain.
+    echo >> $PROFILE && echo "export PATH=\"\$PATH:$BIN_DIR\"" >> $PROFILE
+fi
+
+echo && echo "Detected your preferred shell is ${PREF_SHELL} and added foundryup to PATH. Run 'source ${PROFILE}' or start a new terminal session to use $INSTALLER_NAME."
+echo "Then, simply run '$INSTALLER_NAME' to install $NAME."

--- a/lightclientup/lightclientup
+++ b/lightclientup/lightclientup
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e
+
+# modified from https://github.com/foundry-rs/foundry/blob/master/foundryup/foundryup
+
+REPO="a16z/lightclient"
+NAME=lightclient
+
+DIR=$HOME/.$NAME
+BIN_DIR=$DIR/bin
+
+# delete existing binaries
+rm -f $BIN_DIR/$NAME
+
+TAG=$(curl https://api.github.com/repos/$REPO/releases/latest | grep -o '"tag_name": "[^"]*' | grep -o '[^"]*$')
+
+PLATFORM="$(uname -s)"
+case $PLATFORM in
+  Linux)
+    PLATFORM="linux"
+    ;;
+  Darwin)
+    PLATFORM="darwin"
+    ;;
+  *)
+    err "unsupported platform: $PLATFORM"
+    ;;
+esac
+
+ARCHITECTURE="$(uname -m)"
+if [ "${ARCHITECTURE}" = "x86_64" ]; then
+  # Redirect stderr to /dev/null to avoid printing errors if non Rosetta.
+  if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
+    ARCHITECTURE="arm64" # Rosetta.
+  else
+    ARCHITECTURE="amd64" # Intel.
+  fi
+elif [ "${ARCHITECTURE}" = "arm64" ] ||[ "${ARCHITECTURE}" = "aarch64" ] ; then
+  ARCHITECTURE="arm64" # Arm.
+else
+  ARCHITECTURE="amd64" # Amd.
+fi
+
+TARBALL_URL="https://github.com/$REPO/releases/download/${TAG}/${NAME}_${PLATFORM}_${ARCHITECTURE}.tar.gz"
+curl -L $TARBALL_URL | tar -xzC $BIN_DIR
+
+echo "Installed $NAME" 


### PR DESCRIPTION
closes #25 

This installer is heavily based off foundryup, except I've simplified a lot of it. One important thing to note is that this will install the newest non-prerelease tag.

It is also broken right now since the repo is private, but once we open the repo up it should work. I've tested it out on [this repo](https://github.com/ncitron/installer-test).

Installation instructions:
1. Run `curl https://raw.githubusercontent.com/a16z/lightclient/master/lightclientup/install | sh`
2. Restart terminal or source zshrc/bashrc
3. Run `lightclientup`

The lightclient should then be available by running `lightclient`
