### PR TITLE
fix: handle null rpc responses

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -143,11 +143,11 @@ impl<DB: Database> Client<DB> {
         self.node.read().await.get_block_number()
     }
 
-    pub async fn get_block_by_number(&self, block: &BlockTag) -> Result<ExecutionBlock> {
+    pub async fn get_block_by_number(&self, block: &BlockTag) -> Result<Option<ExecutionBlock>> {
         self.node.read().await.get_block_by_number(block)
     }
 
-    pub async fn get_block_by_hash(&self, hash: &Vec<u8>) -> Result<ExecutionBlock> {
+    pub async fn get_block_by_hash(&self, hash: &Vec<u8>) -> Result<Option<ExecutionBlock>> {
         self.node.read().await.get_block_by_hash(hash)
     }
 


### PR DESCRIPTION
Currently, the light client returns an error if it attempts to fetch a transaction, receipt, or block that cannot be found. The normal behavior for an ethereum node in this case is to return null. This PR changes several of the responses to return an optional, which is interpreted as null when `Option::None` is sent as an rpc response.