### PR TITLE
fix: dns and file errors

### DIFF
--- a/execution/src/evm.rs
+++ b/execution/src/evm.rs
@@ -128,8 +128,9 @@ impl<R: Rpc> Evm<R> {
         let mut account_map = HashMap::new();
         accounts.iter().for_each(|account| {
             let addr = account.0;
-            let account = account.1.as_ref().unwrap().clone();
-            account_map.insert(addr, account);
+            if let Ok(account) = &account.1 {
+                account_map.insert(addr, account.clone());
+            }
         });
 
         Ok(account_map)

--- a/execution/src/rpc/http_rpc.rs
+++ b/execution/src/rpc/http_rpc.rs
@@ -32,8 +32,8 @@ impl Clone for HttpRpc {
 impl Rpc for HttpRpc {
     fn new(rpc: &str) -> Result<Self> {
         let http = Http::from_str(rpc)?;
-        let mut client = RetryClient::new(http, Box::new(HttpRateLimitRetryPolicy), 100, 10);
-        client.set_compute_units(250);
+        let mut client = RetryClient::new(http, Box::new(HttpRateLimitRetryPolicy), 100, 250);
+        client.set_compute_units(100);
         let provider = Provider::new(client);
         Ok(HttpRpc {
             url: rpc.to_string(),


### PR DESCRIPTION
It seems that this was because I had only set a 10ms wait between rate limited rpc requests. Upping that to 250ms seems to make these errors go away. I've also silenced all errors that occur due to failure to fetch accounts during the batch fetching with state lists portion. This does not effect the functionality of the node, since it will just fetch that account on the fly.

Closes #51 