### PR TITLE
chore: pin git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,7 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "log",
+ "openssl",
  "reqwest",
  "revm",
  "serde",
@@ -593,6 +594,7 @@ dependencies = [
  "eyre",
  "hex",
  "log",
+ "openssl",
  "reqwest",
  "serde",
  "serde_json",
@@ -1145,6 +1147,7 @@ dependencies = [
  "futures",
  "hex",
  "log",
+ "openssl",
  "reqwest",
  "revm",
  "serde",
@@ -2043,7 +2046,7 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 [[package]]
 name = "keccak-hasher"
 version = "0.1.1"
-source = "git+https://github.com/openethereum/parity-ethereum#55c90d4016505317034e3e98f699af07f5404b63"
+source = "git+https://github.com/openethereum/parity-ethereum?rev=55c90d4016505317034e3e98f699af07f5404b63#55c90d4016505317034e3e98f699af07f5404b63"
 dependencies = [
  "ethereum-types 0.8.0",
  "hash-db",
@@ -2322,6 +2325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.24.0+1.1.1s"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +2342,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3336,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=cb08f18ca919cc1b685b861d0fa9e2daabe89737#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
 dependencies = [
  "bitvec 1.0.1",
  "hex",
@@ -3351,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs-derive"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=cb08f18ca919cc1b685b861d0fa9e2daabe89737#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3691,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "triehash-ethereum"
 version = "0.2.0"
-source = "git+https://github.com/openethereum/parity-ethereum#55c90d4016505317034e3e98f699af07f5404b63"
+source = "git+https://github.com/openethereum/parity-ethereum?rev=55c90d4016505317034e3e98f699af07f5404b63#55c90d4016505317034e3e98f699af07f5404b63"
 dependencies = [
  "ethereum-types 0.8.0",
  "keccak-hasher",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "1", features = ["full"] }
 eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }
 hex = "0.4.3"
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs" }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
 blst = "0.3.10"
 ethers = "1.0.0"
 jsonrpsee = { version = "0.15.1", features = ["full"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }
 hex = "0.4.3"
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs" }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
 ethers = "1.0.0"
 thiserror = "1.0.37"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }
 hex = "0.4.3"
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs" }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
 ethers = "1.0.0"
 figment = { version = "0.10.7", features = ["toml", "env"] }
 thiserror = "1.0.37"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -12,7 +12,7 @@ eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.85"
 hex = "0.4.3"
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs" }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
 blst = "0.3.10"
 ethers = "1.0.0"
 bytes = "1.2.1"

--- a/execution/Cargo.toml
+++ b/execution/Cargo.toml
@@ -12,14 +12,14 @@ eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.85"
 hex = "0.4.3"
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs" }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
 blst = "0.3.10"
 ethers = "1.0.0"
 revm = "1.9.0"
 bytes = "1.2.1"
 futures = "0.3.23"
 toml = "0.5.9"
-triehash-ethereum = { git = "https://github.com/openethereum/parity-ethereum" }
+triehash-ethereum = { git = "https://github.com/openethereum/parity-ethereum", rev = "55c90d4016505317034e3e98f699af07f5404b63" }
 async-trait = "0.1.57"
 log = "0.4.17"
 thiserror = "1.0.37"


### PR DESCRIPTION
Pin dependencies of ssz-rs and triehash-ethereum to specific commit hashes. Better for security.