### PR TITLE
feat: verify checkpoint has valid age

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -166,6 +166,7 @@ impl ClientBuilder {
             data_dir,
             chain: base_config.chain,
             forks: base_config.forks,
+            checkpoint_duration: base_config.checkpoint_duration,
         };
 
         Client::new(config)

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -166,7 +166,7 @@ impl ClientBuilder {
             data_dir,
             chain: base_config.chain,
             forks: base_config.forks,
-            checkpoint_duration: base_config.checkpoint_duration,
+            max_checkpoint_age: base_config.max_checkpoint_age,
         };
 
         Client::new(config)

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(map_first_last)]
-
 mod client;
 pub use crate::client::*;
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -26,7 +26,7 @@ pub struct Config {
     pub data_dir: Option<PathBuf>,
     pub chain: ChainConfig,
     pub forks: Forks,
-    pub checkpoint_duration: u64,
+    pub max_checkpoint_age: u64,
 }
 
 impl Config {
@@ -94,7 +94,7 @@ impl Config {
             checkpoint: self.checkpoint.clone(),
             chain: self.chain.clone(),
             forks: self.forks.clone(),
-            checkpoint_duration: self.checkpoint_duration.clone(),
+            max_checkpoint_age: self.max_checkpoint_age.clone(),
         }
     }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub data_dir: Option<PathBuf>,
     pub chain: ChainConfig,
     pub forks: Forks,
+    pub checkpoint_duration: u64,
 }
 
 impl Config {
@@ -93,6 +94,7 @@ impl Config {
             checkpoint: self.checkpoint.clone(),
             chain: self.chain.clone(),
             forks: self.forks.clone(),
+            checkpoint_duration: self.checkpoint_duration.clone(),
         }
     }
 }

--- a/config/src/networks.rs
+++ b/config/src/networks.rs
@@ -28,6 +28,7 @@ pub struct BaseConfig {
     pub checkpoint: Vec<u8>,
     pub chain: ChainConfig,
     pub forks: Forks,
+    pub checkpoint_duration: u64,
 }
 
 pub fn mainnet() -> BaseConfig {
@@ -60,6 +61,7 @@ pub fn mainnet() -> BaseConfig {
                 fork_version: hex_str_to_bytes("0x02000000").unwrap(),
             },
         },
+        checkpoint_duration: 1_209_600, // 14 days
     }
 }
 
@@ -93,5 +95,6 @@ pub fn goerli() -> BaseConfig {
                 fork_version: hex_str_to_bytes("0x02001020").unwrap(),
             },
         },
+        checkpoint_duration: 1_209_600, // 14 days
     }
 }

--- a/config/src/networks.rs
+++ b/config/src/networks.rs
@@ -28,7 +28,7 @@ pub struct BaseConfig {
     pub checkpoint: Vec<u8>,
     pub chain: ChainConfig,
     pub forks: Forks,
-    pub checkpoint_duration: u64,
+    pub max_checkpoint_age: u64,
 }
 
 pub fn mainnet() -> BaseConfig {
@@ -61,7 +61,7 @@ pub fn mainnet() -> BaseConfig {
                 fork_version: hex_str_to_bytes("0x02000000").unwrap(),
             },
         },
-        checkpoint_duration: 1_209_600, // 14 days
+        max_checkpoint_age: 1_209_600, // 14 days
     }
 }
 
@@ -95,6 +95,6 @@ pub fn goerli() -> BaseConfig {
                 fork_version: hex_str_to_bytes("0x02001020").unwrap(),
             },
         },
-        checkpoint_duration: 1_209_600, // 14 days
+        max_checkpoint_age: 1_209_600, // 14 days
     }
 }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -507,7 +507,7 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
 
         let slot_age = current_slot_timestamp - blockhash_slot_timestamp;
 
-        slot_age < self.config.checkpoint_duration
+        slot_age < self.config.max_checkpoint_age
     }
 }
 
@@ -597,7 +597,7 @@ mod tests {
             execution_rpc: String::new(),
             chain: base_config.chain,
             forks: base_config.forks,
-            checkpoint_duration: if large_checkpoint_age { 123123123 } else { 123 },
+            max_checkpoint_age: if large_checkpoint_age { 123123123 } else { 123 },
             ..Default::default()
         };
 

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -6,7 +6,6 @@ use blst::min_pk::PublicKey;
 use chrono::Duration;
 use eyre::eyre;
 use eyre::Result;
-use log::warn;
 use log::{debug, info};
 use ssz_rs::prelude::*;
 
@@ -156,7 +155,7 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
 
         let is_valid = self.is_valid_blockhash(bootstrap.header.slot);
         if !is_valid {
-            return Err(ConsensusError::InvalidTimestamp.into());
+            return Err(ConsensusError::CheckpointTooOld.into());
         }
 
         let committee_valid = is_current_committee_proof_valid(
@@ -508,7 +507,7 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
 
         let slot_age = current_slot_timestamp - blockhash_slot_timestamp;
 
-        slot_age < 14 * 86_400 // this is 14 days in seconds
+        slot_age < self.config.checkpoint_duration
     }
 }
 
@@ -598,6 +597,7 @@ mod tests {
             execution_rpc: String::new(),
             chain: base_config.chain,
             forks: base_config.forks,
+            checkpoint_duration: base_config.checkpoint_duration,
             ..Default::default()
         };
 

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -507,10 +507,6 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
         let blockhash_slot_timestamp = self.slot_timestamp(blockhash_slot);
 
         let slot_age = current_slot_timestamp - blockhash_slot_timestamp;
-        warn!(
-            "slot_age: {} current_slot_timestamp: {} blockhash_slot_timestamp: {}",
-            slot_age, current_slot_timestamp, blockhash_slot_timestamp
-        );
 
         slot_age < 14 * 86_400 // this is 14 days in seconds
     }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -598,11 +598,7 @@ mod tests {
             execution_rpc: String::new(),
             chain: base_config.chain,
             forks: base_config.forks,
-            checkpoint_duration: if large_checkpoint_age {
-                123123123
-            } else {
-                123
-            },
+            checkpoint_duration: if large_checkpoint_age { 123123123 } else { 123 },
             ..Default::default()
         };
 

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -579,7 +579,6 @@ mod tests {
     use std::sync::Arc;
 
     use crate::constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES;
-    use log::{debug, info};
     use ssz_rs::Vector;
 
     use crate::{

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -748,4 +748,10 @@ mod tests {
             ConsensusError::InvalidSignature.to_string()
         );
     }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_verify_checkpoint_age_invalid() {
+        get_client(false).await;
+    }
 }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -153,7 +153,7 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
             .await
             .map_err(|_| eyre!("could not fetch bootstrap"))?;
 
-        let is_valid = self.is_valid_blockhash(bootstrap.header.slot);
+        let is_valid = self.is_valid_checkpoint(bootstrap.header.slot);
         if !is_valid {
             return Err(ConsensusError::CheckpointTooOld.into());
         }
@@ -500,7 +500,7 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
     }
 
     // Determines blockhash_slot age and returns true if it is less than 14 days old
-    fn is_valid_blockhash(&self, blockhash_slot: u64) -> bool {
+    fn is_valid_checkpoint(&self, blockhash_slot: u64) -> bool {
         let current_slot = self.expected_current_slot();
         let current_slot_timestamp = self.slot_timestamp(current_slot);
         let blockhash_slot_timestamp = self.slot_timestamp(blockhash_slot);

--- a/consensus/src/errors.rs
+++ b/consensus/src/errors.rs
@@ -22,4 +22,6 @@ pub enum ConsensusError {
     InvalidHeaderHash(String, String),
     #[error("payload not found for slot: {0}")]
     PayloadNotFound(u64),
+    #[error("checkpoint is too old")]
+    CheckpointTooOld,
 }

--- a/consensus/tests/sync.rs
+++ b/consensus/tests/sync.rs
@@ -10,6 +10,7 @@ async fn setup() -> ConsensusClient<MockRpc> {
         execution_rpc: String::new(),
         chain: base_config.chain,
         forks: base_config.forks,
+        checkpoint_duration: 123123123,
         ..Default::default()
     };
 

--- a/consensus/tests/sync.rs
+++ b/consensus/tests/sync.rs
@@ -10,7 +10,7 @@ async fn setup() -> ConsensusClient<MockRpc> {
         execution_rpc: String::new(),
         chain: base_config.chain,
         forks: base_config.forks,
-        checkpoint_duration: 123123123,
+        max_checkpoint_age: 123123123,
         ..Default::default()
     };
 


### PR DESCRIPTION
Addressing issue #98 

Verifies that the blockhash isn't too old (14 days or older according to the issue) by checking timestamps against the current slot. If it's too old, a timestamp error is thrown

note: also removed `#![feature(map_first_last)]` in `lib.rs` as there were some compiler warnings thrown that this has been implemented in stable releases and is no longer required
