### PR TITLE
feat: surface revert errors to RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "revm",
  "serde",
  "ssz-rs",
+ "thiserror",
  "tokio",
  "toml",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3.23"
 toml = "0.5.9"
 log = "0.4.17"
 openssl = { version = "0.10", features = ["vendored"] }
+thiserror = "1.0.37"
 
 common = { path = "../common" }
 consensus = { path = "../consensus" }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -215,11 +215,21 @@ impl<DB: Database> Client<DB> {
     }
 
     pub async fn call(&self, opts: &CallOpts, block: BlockTag) -> Result<Vec<u8>> {
-        self.node.read().await.call(opts, block).await.map_err(|err| err.into())
+        self.node
+            .read()
+            .await
+            .call(opts, block)
+            .await
+            .map_err(|err| err.into())
     }
 
     pub async fn estimate_gas(&self, opts: &CallOpts) -> Result<u64> {
-        self.node.read().await.estimate_gas(opts).await.map_err(|err| err.into())
+        self.node
+            .read()
+            .await
+            .estimate_gas(opts)
+            .await
+            .map_err(|err| err.into())
     }
 
     pub async fn get_balance(&self, address: &Address, block: BlockTag) -> Result<U256> {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -215,11 +215,11 @@ impl<DB: Database> Client<DB> {
     }
 
     pub async fn call(&self, opts: &CallOpts, block: BlockTag) -> Result<Vec<u8>> {
-        self.node.read().await.call(opts, block).await
+        self.node.read().await.call(opts, block).await.map_err(|err| err.into())
     }
 
     pub async fn estimate_gas(&self, opts: &CallOpts) -> Result<u64> {
-        self.node.read().await.estimate_gas(opts).await
+        self.node.read().await.estimate_gas(opts).await.map_err(|err| err.into())
     }
 
     pub async fn get_balance(&self, address: &Address, block: BlockTag) -> Result<U256> {

--- a/client/src/errors.rs
+++ b/client/src/errors.rs
@@ -31,7 +31,7 @@ pub enum NodeError {
     ConsensusSyncError(Report),
 
     #[error(transparent)]
-    BlockNotFoundError(#[from] BlockNotFoundError)
+    BlockNotFoundError(#[from] BlockNotFoundError),
 }
 
 impl NodeError {

--- a/client/src/errors.rs
+++ b/client/src/errors.rs
@@ -1,9 +1,9 @@
+use common::errors::BlockNotFoundError;
 use execution::errors::EvmError;
-use jsonrpsee::tracing::info;
-use thiserror::Error;
 use eyre::Report;
+use thiserror::Error;
 
-/// Errors that can occur during evm.rs calls
+/// Errors that can occur during Node calls
 #[derive(Debug, Error)]
 pub enum NodeError {
     #[error(transparent)]
@@ -12,17 +12,30 @@ pub enum NodeError {
     #[error("out of sync: {0} slots behind")]
     OutOfSync(u64),
 
-    #[error("node error: {0:?}")]
-    Generic (String),
+    #[error("consensus payload error: {0}")]
+    ConsensusPayloadError(Report),
 
-    // Casting existing errors
+    #[error("execution payload error: {0}")]
+    ExecutionPayloadError(Report),
+
+    #[error("consensus client creation error: {0}")]
+    ConsensusClientCreationError(Report),
+
+    #[error("execution client creation error: {0}")]
+    ExecutionClientCreationError(Report),
+
+    #[error("consensus advance error: {0}")]
+    ConsensusAdvanceError(Report),
+
+    #[error("consensus sync error: {0}")]
+    ConsensusSyncError(Report),
+
     #[error(transparent)]
-    Eyre(#[from] Report),
+    BlockNotFoundError(#[from] BlockNotFoundError)
 }
 
 impl NodeError {
     pub fn to_json_rpsee_error(self) -> jsonrpsee::core::Error {
-        info!("to_json_rpsee_error");
         match self {
             NodeError::ExecutionError(evm_err) => match evm_err {
                 EvmError::Revert(data) => {
@@ -30,16 +43,17 @@ impl NodeError {
                     if let Some(reason) = data.as_ref().and_then(EvmError::decode_revert_reason) {
                         msg = format!("{msg}: {reason}")
                     }
-                    jsonrpsee::core::Error::Call(
-                        jsonrpsee::types::error::CallError::Custom(
-                            jsonrpsee::types::error::ErrorObject::owned(
-                                3, 
-                                msg, 
-                                data.map(|data| format!("0x{}", hex::encode(data))))))
+                    jsonrpsee::core::Error::Call(jsonrpsee::types::error::CallError::Custom(
+                        jsonrpsee::types::error::ErrorObject::owned(
+                            3,
+                            msg,
+                            data.map(|data| format!("0x{}", hex::encode(data))),
+                        ),
+                    ))
                 }
-                _ => jsonrpsee::core::Error::Custom(evm_err.to_string())
-            }
-            _ => jsonrpsee::core::Error::Custom(self.to_string())
+                _ => jsonrpsee::core::Error::Custom(evm_err.to_string()),
+            },
+            _ => jsonrpsee::core::Error::Custom(self.to_string()),
         }
     }
 }

--- a/client/src/errors.rs
+++ b/client/src/errors.rs
@@ -1,0 +1,45 @@
+use execution::errors::EvmError;
+use jsonrpsee::tracing::info;
+use thiserror::Error;
+use eyre::Report;
+
+/// Errors that can occur during evm.rs calls
+#[derive(Debug, Error)]
+pub enum NodeError {
+    #[error(transparent)]
+    ExecutionError(#[from] EvmError),
+
+    #[error("out of sync: {0} slots behind")]
+    OutOfSync(u64),
+
+    #[error("node error: {0:?}")]
+    Generic (String),
+
+    // Casting existing errors
+    #[error(transparent)]
+    Eyre(#[from] Report),
+}
+
+impl NodeError {
+    pub fn to_json_rpsee_error(self) -> jsonrpsee::core::Error {
+        info!("to_json_rpsee_error");
+        match self {
+            NodeError::ExecutionError(evm_err) => match evm_err {
+                EvmError::Revert(data) => {
+                    let mut msg = "execution reverted".to_string();
+                    if let Some(reason) = data.as_ref().and_then(EvmError::decode_revert_reason) {
+                        msg = format!("{msg}: {reason}")
+                    }
+                    jsonrpsee::core::Error::Call(
+                        jsonrpsee::types::error::CallError::Custom(
+                            jsonrpsee::types::error::ErrorObject::owned(
+                                3, 
+                                msg, 
+                                data.map(|data| format!("0x{}", hex::encode(data))))))
+                }
+                _ => jsonrpsee::core::Error::Custom(evm_err.to_string())
+            }
+            _ => jsonrpsee::core::Error::Custom(self.to_string())
+        }
+    }
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -4,7 +4,7 @@ mod client;
 pub use crate::client::*;
 
 pub mod database;
-pub mod rpc;
 pub mod errors;
+pub mod rpc;
 
 mod node;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -5,5 +5,6 @@ pub use crate::client::*;
 
 pub mod database;
 pub mod rpc;
+pub mod errors;
 
 mod node;

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -54,12 +54,18 @@ impl Node {
     }
 
     pub async fn sync(&mut self) -> Result<(), NodeError> {
-        self.consensus.sync().await.map_err(NodeError::ConsensusSyncError)?;
+        self.consensus
+            .sync()
+            .await
+            .map_err(NodeError::ConsensusSyncError)?;
         self.update_payloads().await
     }
 
     pub async fn advance(&mut self) -> Result<(), NodeError> {
-        self.consensus.advance().await.map_err(NodeError::ConsensusAdvanceError)?;
+        self.consensus
+            .advance()
+            .await
+            .map_err(NodeError::ConsensusAdvanceError)?;
         self.update_payloads().await
     }
 

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -13,7 +13,7 @@ use jsonrpsee::{
     proc_macros::rpc,
 };
 
-use crate::node::Node;
+use crate::{node::Node, errors::NodeError};
 
 use common::{
     types::BlockTag,
@@ -134,14 +134,16 @@ impl EthRpcServer for RpcInner {
 
     async fn call(&self, opts: CallOpts, block: BlockTag) -> Result<String, Error> {
         let node = self.node.read().await;
-        let res = convert_err(node.call(&opts, block).await)?;
+
+        // TODO: Make sure we have clean way of surfacing the error here
+        let res = node.call(&opts, block).await.map_err(NodeError::to_json_rpsee_error)?;
 
         Ok(format!("0x{}", hex::encode(res)))
     }
 
     async fn estimate_gas(&self, opts: CallOpts) -> Result<String, Error> {
         let node = self.node.read().await;
-        let gas = convert_err(node.estimate_gas(&opts).await)?;
+        let gas = node.estimate_gas(&opts).await.map_err(NodeError::to_json_rpsee_error)?;
 
         Ok(u64_to_hex_string(gas))
     }

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -13,7 +13,7 @@ use jsonrpsee::{
     proc_macros::rpc,
 };
 
-use crate::{node::Node, errors::NodeError};
+use crate::{errors::NodeError, node::Node};
 
 use common::{
     types::BlockTag,
@@ -136,14 +136,20 @@ impl EthRpcServer for RpcInner {
         let node = self.node.read().await;
 
         // TODO: Make sure we have clean way of surfacing the error here
-        let res = node.call(&opts, block).await.map_err(NodeError::to_json_rpsee_error)?;
+        let res = node
+            .call(&opts, block)
+            .await
+            .map_err(NodeError::to_json_rpsee_error)?;
 
         Ok(format!("0x{}", hex::encode(res)))
     }
 
     async fn estimate_gas(&self, opts: CallOpts) -> Result<String, Error> {
         let node = self.node.read().await;
-        let gas = node.estimate_gas(&opts).await.map_err(NodeError::to_json_rpsee_error)?;
+        let gas = node
+            .estimate_gas(&opts)
+            .await
+            .map_err(NodeError::to_json_rpsee_error)?;
 
         Ok(u64_to_hex_string(gas))
     }

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -135,7 +135,6 @@ impl EthRpcServer for RpcInner {
     async fn call(&self, opts: CallOpts, block: BlockTag) -> Result<String, Error> {
         let node = self.node.read().await;
 
-        // TODO: Make sure we have clean way of surfacing the error here
         let res = node
             .call(&opts, block)
             .await

--- a/execution/src/errors.rs
+++ b/execution/src/errors.rs
@@ -1,5 +1,7 @@
-use ethers::types::{Address, H256};
+use ethers::{types::{Address, H256}, abi::AbiDecode};
 use thiserror::Error;
+use eyre::Report;
+use bytes::Bytes;
 
 #[derive(Debug, Error)]
 pub enum ExecutionError {
@@ -13,4 +15,30 @@ pub enum ExecutionError {
     ReceiptRootMismatch(String),
     #[error("missing transaction for tx: {0}")]
     MissingTransaction(String),
+}
+
+/// Errors that can occur during evm.rs calls
+#[derive(Debug, Error)]
+pub enum EvmError {
+    #[error("execution reverted: {0:?}")]
+    Revert(Option<Bytes>),
+
+    #[error("evm error: {0:?}")]
+    Generic (String),
+
+    // Casting existing errors
+    #[error(transparent)]
+    Eyre(#[from] Report)
+}
+
+impl EvmError {
+    pub fn decode_revert_reason(data: impl AsRef<[u8]>) -> Option<String> {
+        let data = data.as_ref();
+
+        // skip function selector
+        if data.len() < 4 {
+            return None;
+        }
+        String::decode(&data[4..]).ok()
+    }
 }

--- a/execution/src/errors.rs
+++ b/execution/src/errors.rs
@@ -1,7 +1,10 @@
-use ethers::{types::{Address, H256}, abi::AbiDecode};
-use thiserror::Error;
-use eyre::Report;
 use bytes::Bytes;
+use ethers::{
+    abi::AbiDecode,
+    types::{Address, H256},
+};
+use eyre::Report;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ExecutionError {
@@ -24,11 +27,13 @@ pub enum EvmError {
     Revert(Option<Bytes>),
 
     #[error("evm error: {0:?}")]
-    Generic (String),
+    Generic(String),
 
-    // Casting existing errors
-    #[error(transparent)]
-    Eyre(#[from] Report)
+    #[error("evm execution failed: {0:?}")]
+    Revm(revm::Return),
+
+    #[error("rpc error: {0:?}")]
+    RpcError(Report),
 }
 
 impl EvmError {


### PR DESCRIPTION
Surface node errors to RPC.

Also swaps the main `Node.rs` error type to a thiserror NodeError from eyre::Report. For now we wrap many of the underlying erye::Report errors in thiserrors and have to use `.map_err` to convert. As the lower level errors are made more specific these can be automatically wrapped with:

```
#[error(transparent)]
SpecificError(#[from] SpecificUnderlyingThisError)
```

Which will allow removal of the `.map_err` everywhere. (as seen with the existing `BlockNotFoundError`)

Moving to this error handling type will allow consumers of Node (RPC and Client) to surface more specific error details, error types and handling.