### PR TITLE
build: add `rust_toolchain`

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
One may install/use `stable` channel by default locally, and will get 
```
error: failed to load manifest for workspace member `/Users/chris/gitfiles/HAOYUatHZ/helios/cli`

Caused by:
  failed to parse manifest at `/Users/chris/gitfiles/HAOYUatHZ/helios/cli/Cargo.toml`

Caused by:
  the cargo feature `different-binary-name` requires a nightly version of Cargo, but this is the `stable` channel
  See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
  See https://doc.rust-lang.org/cargo/reference/unstable.html#different-binary-name for more information about using this feature.
```
when compiling this project.

Adding `rust-toolchain` to specify a channel can avoid this problem