### PR TITLE
feat: Lints, Clippy, and Cleaning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,7 +1207,6 @@ name = "execution"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "blst",
  "bytes",
  "common",
  "consensus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,10 +492,8 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "blst",
- "bytes",
  "common",
  "config",
  "consensus",
@@ -506,14 +504,10 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "log",
- "openssl",
- "reqwest",
- "revm",
  "serde",
  "ssz-rs",
  "thiserror",
  "tokio",
- "toml",
 ]
 
 [[package]]
@@ -1646,7 +1640,7 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "helios"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "client",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helios"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [workspace]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -90,7 +90,7 @@ struct Cli {
 impl Cli {
     fn as_cli_config(&self) -> CliConfig {
         let checkpoint = match &self.checkpoint {
-            Some(checkpoint) => Some(hex_str_to_bytes(&checkpoint).expect("invalid checkpoint")),
+            Some(checkpoint) => Some(hex_str_to_bytes(checkpoint).expect("invalid checkpoint")),
             None => self.get_cached_checkpoint(),
         };
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,26 +1,18 @@
 [package]
 name = "client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }
 hex = "0.4.3"
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
-blst = "0.3.10"
 ethers = "1.0.0"
 jsonrpsee = { version = "0.15.1", features = ["full"] }
-revm = "2.1.0"
-bytes = "1.2.1"
 futures = "0.3.23"
-toml = "0.5.9"
 log = "0.4.17"
-openssl = { version = "0.10", features = ["vendored"] }
 thiserror = "1.0.37"
 
 common = { path = "../common" }

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -117,7 +117,7 @@ impl Node {
         let payload = self.get_payload(block)?;
         let mut evm = Evm::new(
             self.execution.clone(),
-            &payload,
+            payload,
             &self.payloads,
             self.chain_id(),
         );
@@ -130,7 +130,7 @@ impl Node {
         let payload = self.get_payload(BlockTag::Latest)?;
         let mut evm = Evm::new(
             self.execution.clone(),
-            &payload,
+            payload,
             &self.payloads,
             self.chain_id(),
         );
@@ -143,7 +143,7 @@ impl Node {
         self.check_blocktag_age(&block)?;
 
         let payload = self.get_payload(block)?;
-        let account = self.execution.get_account(&address, None, payload).await?;
+        let account = self.execution.get_account(address, None, payload).await?;
         Ok(account.balance)
     }
 
@@ -151,7 +151,7 @@ impl Node {
         self.check_blocktag_age(&block)?;
 
         let payload = self.get_payload(block)?;
-        let account = self.execution.get_account(&address, None, payload).await?;
+        let account = self.execution.get_account(address, None, payload).await?;
         Ok(account.nonce)
     }
 
@@ -159,7 +159,7 @@ impl Node {
         self.check_blocktag_age(&block)?;
 
         let payload = self.get_payload(block)?;
-        let account = self.execution.get_account(&address, None, payload).await?;
+        let account = self.execution.get_account(address, None, payload).await?;
         Ok(account.code)
     }
 
@@ -179,7 +179,7 @@ impl Node {
         }
     }
 
-    pub async fn send_raw_transaction(&self, bytes: &Vec<u8>) -> Result<H256> {
+    pub async fn send_raw_transaction(&self, bytes: &[u8]) -> Result<H256> {
         self.execution.send_raw_transaction(bytes).await
     }
 
@@ -233,11 +233,7 @@ impl Node {
         self.check_blocktag_age(&block)?;
 
         match self.get_payload(block) {
-            Ok(payload) => self
-                .execution
-                .get_block(payload, full_tx)
-                .await
-                .map(|b| Some(b)),
+            Ok(payload) => self.execution.get_block(payload, full_tx).await.map(Some),
             Err(_) => Ok(None),
         }
     }
@@ -257,7 +253,7 @@ impl Node {
             self.execution
                 .get_block(payload_entry.1, full_tx)
                 .await
-                .map(|b| Some(b))
+                .map(Some)
         } else {
             Ok(None)
         }
@@ -290,7 +286,7 @@ impl Node {
             }
             BlockTag::Number(num) => {
                 let payload = self.payloads.get(&num);
-                payload.ok_or(BlockNotFoundError::new(BlockTag::Number(num)).into())
+                payload.ok_or(BlockNotFoundError::new(BlockTag::Number(num)))
             }
         }
     }

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -264,7 +264,7 @@ fn format_hex(num: &U256) -> String {
         .encode_hex()
         .strip_prefix("0x")
         .unwrap()
-        .trim_start_matches("0")
+        .trim_start_matches('0')
         .to_string();
 
     format!("0x{}", stripped)

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -3,8 +3,6 @@ name = "common"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -4,8 +4,6 @@ name = "config"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -53,7 +53,7 @@ impl Config {
             Err(err) => {
                 match err.kind {
                     figment::error::Kind::MissingField(field) => {
-                        let field = field.replace("_", "-");
+                        let field = field.replace('_', "-");
 
                         println!(
                             "\x1b[91merror\x1b[0m: missing configuration field: {}",
@@ -94,7 +94,7 @@ impl Config {
             checkpoint: self.checkpoint.clone(),
             chain: self.chain.clone(),
             forks: self.forks.clone(),
-            max_checkpoint_age: self.max_checkpoint_age.clone(),
+            max_checkpoint_age: self.max_checkpoint_age,
         }
     }
 }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -3,8 +3,6 @@ name = "consensus"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 eyre = "0.6.8"

--- a/consensus/src/rpc/mock_rpc.rs
+++ b/consensus/src/rpc/mock_rpc.rs
@@ -18,7 +18,7 @@ impl ConsensusRpc for MockRpc {
         }
     }
 
-    async fn get_bootstrap(&self, _block_root: &Vec<u8>) -> Result<Bootstrap> {
+    async fn get_bootstrap(&self, _block_root: &'_ [u8]) -> Result<Bootstrap> {
         let bootstrap = read_to_string(self.testdata.join("bootstrap.json"))?;
         Ok(serde_json::from_str(&bootstrap)?)
     }

--- a/consensus/src/rpc/mod.rs
+++ b/consensus/src/rpc/mod.rs
@@ -10,7 +10,7 @@ use crate::types::{BeaconBlock, Bootstrap, FinalityUpdate, OptimisticUpdate, Upd
 #[async_trait]
 pub trait ConsensusRpc {
     fn new(path: &str) -> Self;
-    async fn get_bootstrap(&self, block_root: &Vec<u8>) -> Result<Bootstrap>;
+    async fn get_bootstrap(&self, block_root: &'_ [u8]) -> Result<Bootstrap>;
     async fn get_updates(&self, period: u64, count: u8) -> Result<Vec<Update>>;
     async fn get_finality_update(&self) -> Result<FinalityUpdate>;
     async fn get_optimistic_update(&self) -> Result<OptimisticUpdate>;

--- a/consensus/src/rpc/nimbus_rpc.rs
+++ b/consensus/src/rpc/nimbus_rpc.rs
@@ -31,7 +31,7 @@ impl ConsensusRpc for NimbusRpc {
         }
     }
 
-    async fn get_bootstrap(&self, block_root: &Vec<u8>) -> Result<Bootstrap> {
+    async fn get_bootstrap(&self, block_root: &'_ [u8]) -> Result<Bootstrap> {
         let root_hex = hex::encode(block_root);
         let req = format!(
             "{}/eth/v1/beacon/light_client/bootstrap/0x{}",

--- a/consensus/src/types.rs
+++ b/consensus/src/types.rs
@@ -271,7 +271,7 @@ impl From<&Update> for GenericUpdate {
         Self {
             attested_header: update.attested_header.clone(),
             sync_aggregate: update.sync_aggregate.clone(),
-            signature_slot: update.signature_slot.clone(),
+            signature_slot: update.signature_slot,
             next_sync_committee: Some(update.next_sync_committee.clone()),
             next_sync_committee_branch: Some(update.next_sync_committee_branch.clone()),
             finalized_header: Some(update.finalized_header.clone()),
@@ -285,7 +285,7 @@ impl From<&FinalityUpdate> for GenericUpdate {
         Self {
             attested_header: update.attested_header.clone(),
             sync_aggregate: update.sync_aggregate.clone(),
-            signature_slot: update.signature_slot.clone(),
+            signature_slot: update.signature_slot,
             next_sync_committee: None,
             next_sync_committee_branch: None,
             finalized_header: Some(update.finalized_header.clone()),
@@ -299,7 +299,7 @@ impl From<&OptimisticUpdate> for GenericUpdate {
         Self {
             attested_header: update.attested_header.clone(),
             sync_aggregate: update.sync_aggregate.clone(),
-            signature_slot: update.signature_slot.clone(),
+            signature_slot: update.signature_slot,
             next_sync_committee: None,
             next_sync_committee_branch: None,
             finalized_header: None,
@@ -322,14 +322,13 @@ where
     D: serde::Deserializer<'de>,
 {
     let keys: Vec<String> = serde::Deserialize::deserialize(deserializer)?;
-    Ok(keys
-        .iter()
+    keys.iter()
         .map(|key| {
             let key_bytes = hex_str_to_bytes(key)?;
             Ok(Vector::from_iter(key_bytes))
         })
         .collect::<Result<Vector<BLSPubKey, 512>>>()
-        .map_err(D::Error::custom)?)
+        .map_err(D::Error::custom)
 }
 
 fn bytes_vector_deserialize<'de, D>(deserializer: D) -> Result<Vector<Bytes32, 33>, D::Error>
@@ -337,14 +336,14 @@ where
     D: serde::Deserializer<'de>,
 {
     let elems: Vec<String> = serde::Deserialize::deserialize(deserializer)?;
-    Ok(elems
+    elems
         .iter()
         .map(|elem| {
             let elem_bytes = hex_str_to_bytes(elem)?;
             Ok(Vector::from_iter(elem_bytes))
         })
         .collect::<Result<Vector<Bytes32, 33>>>()
-        .map_err(D::Error::custom)?)
+        .map_err(D::Error::custom)
 }
 
 fn signature_deserialize<'de, D>(deserializer: D) -> Result<SignatureBytes, D::Error>
@@ -361,14 +360,14 @@ where
     D: serde::Deserializer<'de>,
 {
     let branch: Vec<String> = serde::Deserialize::deserialize(deserializer)?;
-    Ok(branch
+    branch
         .iter()
         .map(|elem| {
             let elem_bytes = hex_str_to_bytes(elem)?;
             Ok(Vector::from_iter(elem_bytes))
         })
         .collect::<Result<_>>()
-        .map_err(D::Error::custom)?)
+        .map_err(D::Error::custom)
 }
 
 fn u64_deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>

--- a/consensus/src/utils.rs
+++ b/consensus/src/utils.rs
@@ -15,9 +15,9 @@ pub fn calc_sync_period(slot: u64) -> u64 {
 
 pub fn is_aggregate_valid(sig_bytes: &SignatureBytes, msg: &[u8], pks: &[&PublicKey]) -> bool {
     let dst: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
-    let sig_res = Signature::from_bytes(&sig_bytes);
+    let sig_res = Signature::from_bytes(sig_bytes);
     match sig_res {
-        Ok(sig) => sig.fast_aggregate_verify(true, msg, dst, &pks) == BLST_ERROR::BLST_SUCCESS,
+        Ok(sig) => sig.fast_aggregate_verify(true, msg, dst, pks) == BLST_ERROR::BLST_SUCCESS,
         Err(_) => false,
     }
 }
@@ -25,7 +25,7 @@ pub fn is_aggregate_valid(sig_bytes: &SignatureBytes, msg: &[u8], pks: &[&Public
 pub fn is_proof_valid<L: Merkleized>(
     attested_header: &Header,
     leaf_object: &mut L,
-    branch: &Vec<Bytes32>,
+    branch: &[Bytes32],
     depth: usize,
     index: usize,
 ) -> bool {
@@ -81,7 +81,6 @@ fn compute_fork_data_root(
     current_version: Vector<u8, 4>,
     genesis_validator_root: Bytes32,
 ) -> Result<Node> {
-    let current_version = current_version.try_into()?;
     let mut fork_data = ForkData {
         current_version,
         genesis_validator_root,
@@ -92,6 +91,6 @@ fn compute_fork_data_root(
 pub fn branch_to_nodes(branch: Vec<Bytes32>) -> Result<Vec<Node>> {
     branch
         .iter()
-        .map(|elem| bytes32_to_node(elem))
+        .map(bytes32_to_node)
         .collect::<Result<Vec<Node>>>()
 }

--- a/execution/Cargo.toml
+++ b/execution/Cargo.toml
@@ -3,8 +3,6 @@ name = "execution"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
@@ -13,7 +11,6 @@ serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.85"
 hex = "0.4.3"
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
-blst = "0.3.10"
 ethers = "1.0.0"
 revm = "2.1.0"
 bytes = "1.2.1"

--- a/execution/src/rpc/http_rpc.rs
+++ b/execution/src/rpc/http_rpc.rs
@@ -92,8 +92,8 @@ impl ExecutionRpc for HttpRpc {
         Ok(code.to_vec())
     }
 
-    async fn send_raw_transaction(&self, bytes: &Vec<u8>) -> Result<H256> {
-        let bytes = Bytes::from(bytes.as_slice().to_owned());
+    async fn send_raw_transaction(&self, bytes: &[u8]) -> Result<H256> {
+        let bytes = Bytes::from(bytes.to_owned());
         let tx = self
             .provider
             .send_raw_transaction(bytes)

--- a/execution/src/rpc/mock_rpc.rs
+++ b/execution/src/rpc/mock_rpc.rs
@@ -43,7 +43,7 @@ impl ExecutionRpc for MockRpc {
         hex_str_to_bytes(&code[0..code.len() - 1])
     }
 
-    async fn send_raw_transaction(&self, _bytes: &Vec<u8>) -> Result<H256> {
+    async fn send_raw_transaction(&self, _bytes: &[u8]) -> Result<H256> {
         Err(eyre!("not implemented"))
     }
 

--- a/execution/src/rpc/mod.rs
+++ b/execution/src/rpc/mod.rs
@@ -25,7 +25,7 @@ pub trait ExecutionRpc: Send + Clone + Sync + 'static {
 
     async fn create_access_list(&self, opts: &CallOpts, block: u64) -> Result<AccessList>;
     async fn get_code(&self, address: &Address, block: u64) -> Result<Vec<u8>>;
-    async fn send_raw_transaction(&self, bytes: &Vec<u8>) -> Result<H256>;
+    async fn send_raw_transaction(&self, bytes: &[u8]) -> Result<H256>;
     async fn get_transaction_receipt(&self, tx_hash: &H256) -> Result<Option<TransactionReceipt>>;
     async fn get_transaction(&self, tx_hash: &H256) -> Result<Option<Transaction>>;
     async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>>;

--- a/execution/src/types.rs
+++ b/execution/src/types.rs
@@ -78,7 +78,7 @@ impl fmt::Debug for CallOpts {
             .field("from", &self.from)
             .field("to", &self.to)
             .field("value", &self.value)
-            .field("data", &hex::encode(&self.data.clone().unwrap_or_default()))
+            .field("data", &hex::encode(self.data.clone().unwrap_or_default()))
             .finish()
     }
 }

--- a/heliosup/heliosup
+++ b/heliosup/heliosup
@@ -44,4 +44,4 @@ fi
 TARBALL_URL="https://github.com/$REPO/releases/download/${TAG}/${NAME}_${PLATFORM}_${ARCHITECTURE}.tar.gz"
 curl -L $TARBALL_URL | tar -xzC $BIN_DIR
 
-echo "Installed $NAME" 
+echo "Installed $NAME"


### PR DESCRIPTION
## Overview

Fixes all linting errors raised by nightly with
```bash
cargo check --all && cargo +nightly fmt -- --check && cargo +nightly clippy --all --all-features -- -D warnings && cargo test --all --all-features
```

Additionally removes unused cargo packages in subcrates.

This is preparatory work for further contributions @ncitron  😄 