### PR TITLE
chore: export CallOpts type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config {
 
 pub mod types {
     pub use common::types::BlockTag;
+    pub use execution::types::CallOpts;
 }
 
 pub mod errors {


### PR DESCRIPTION
## Description

Currently execution::types::CallOpts is not exported, and it is needed to be able to use call function of Helios client.

## Changes summary

- Updated Helios `lib.rs` to export `execution::types::CallOpts`

Closes #117 