### PR TITLE
feat: Checkpoint Fallbacks [RFC]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,7 @@ dependencies = [
  "eyre",
  "figment",
  "hex",
+ "log",
  "reqwest",
  "serde",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,9 +598,12 @@ dependencies = [
  "eyre",
  "figment",
  "hex",
+ "reqwest",
  "serde",
+ "serde_yaml",
  "ssz-rs",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2900,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "base64 0.13.1",
  "bytes",
@@ -3378,6 +3381,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3979,6 +3995,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "ssz-rs",
+ "strum",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "ethers",
  "eyre",
  "figment",
+ "futures",
  "hex",
  "log",
  "reqwest",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Helios
+
 [![build](https://github.com/a16z/helios/actions/workflows/test.yml/badge.svg)](https://github.com/a16z/helios/actions/workflows/test.yml) [![license: MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT) [![chat](https://img.shields.io/badge/chat-telegram-blue)](https://t.me/+IntDY_gZJSRkNTJj)
 
 Helios is a fully trustless, efficient, and portable Ethereum light client written in Rust.
@@ -10,14 +11,17 @@ The entire size of Helios's binary is 13Mb and should be easy to compile into We
 ## Installing
 
 First install `heliosup`, Helios's installer:
+
 ```
 curl https://raw.githubusercontent.com/a16z/helios/master/heliosup/install | bash
 ```
+
 To install Helios, run `heliosup`.
 
 ## Usage
 
 To run Helios, run the below command, replacing `$ETH_RPC_URL` with an RPC provider URL such as Alchemy or Infura:
+
 ```
 helios --execution-rpc $ETH_RPC_URL
 ```
@@ -42,15 +46,25 @@ Helios is still experimental software. While we hope you try it out, we do not s
 
 `--data-dir` or `-d` sets the directory that Helios should use to store cached weak subjectivity checkpoints in. Each network only stores the latest checkpoint, which is just 32 bytes.
 
-`--checkpoint-fallback` or `-f` sets the checkpoint fallback url. This is only used if the checkpoint provided by the `--checkpoint` flag is too outdated for Helios to use to sync. If none is provided and the `--load-checkpoint-fallback` flag is not set, Helios will error.
+`--fallback` or `-f` sets the checkpoint fallback url (a string). This is only used if the checkpoint provided by the `--checkpoint` flag is too outdated for Helios to use to sync.
+If none is provided and the `--load-checkpoint-fallback` flag is not set, Helios will error.
+For example, you can specify the fallback like so: `helios --fallback "https://sync-mainnet.beaconcha.in"` (or using shorthand like so: `helios -f "https://sync-mainnet.beaconcha.in"`)
 
-`--load-checkpoint-fallback` or `-l` enables weak subjectivity checkpoint fallback. For example, say you set a checkpoint value that is too outdated and Helios cannot sync to it. If this flag is set, Helios will query all network apis in the community-maintained list at [ethpandaops/checkpoint-synz-health-checks](https://github.com/ethpandaops/checkpoint-sync-health-checks/blob/master/_data/endpoints.yaml) for their latest slots. The list of slots is filtered for healthy apis and the most frequent checkpoint occuring in the latest epoch will be returned. Note: this is a community-maintained list and thus no security guarantees are provided. Use this is a last resort if your checkpoint passed into `--checkpoint` fails. This is not recommened as malicious checkpoints can be returned from the listed apis, even if they are considered _healthy_.
+`--load-external-fallback` or `-l` enables weak subjectivity checkpoint fallback (no value needed).
+For example, say you set a checkpoint value that is too outdated and Helios cannot sync to it.
+If this flag is set, Helios will query all network apis in the community-maintained list
+at [ethpandaops/checkpoint-synz-health-checks](https://github.com/ethpandaops/checkpoint-sync-health-checks/blob/master/_data/endpoints.yaml) for their latest slots.
+The list of slots is filtered for healthy apis and the most frequent checkpoint occuring in the latest epoch will be returned.
+Note: this is a community-maintained list and thus no security guarantees are provided. Use this is a last resort if your checkpoint passed into `--checkpoint` fails.
+This is not recommened as malicious checkpoints can be returned from the listed apis, even if they are considered _healthy_.
+This can be run like so: `helios --load-external-fallback` (or `helios -l` with the shorthand).
 
 `--help` or `-h` prints the help message.
 
 ### Configuration Files
 
 All configuration options can be set on a per-network level in `~/.helios/helios.toml`. Here is an example config file:
+
 ```toml
 [mainnet]
 consensus_rpc = "https://www.lightclientdata.org"
@@ -126,10 +140,13 @@ async fn main() -> Result<()> {
 ```
 
 ## Contributing
+
 All contributions to Helios are welcome. Before opening a PR, please submit an issue detailing the bug or feature. When opening a PR, please ensure that your contribution builds on the nightly rust toolchain, has been linted with `cargo fmt`, and contains tests when applicable.
 
 ## Telegram
+
 If you are having trouble with Helios or are considering contributing, feel free to join our telegram [here](https://t.me/+IntDY_gZJSRkNTJj).
 
 ## Disclaimer
+
 _This code is being provided as is. No guarantee, representation or warranty is being made, express or implied, as to the safety or correctness of the code. It has not been audited and as such there can be no assurance it will work as intended, and users may experience delays, failures, errors, omissions or loss of transmitted information. Nothing in this repo should be construed as investment advice or legal advice for any particular facts or circumstances and is not meant to replace competent counsel. It is strongly advised for you to contact a reputable attorney in your jurisdiction for any questions or concerns with respect thereto. a16z is not liable for any use of the foregoing, and users should proceed with caution and use at their own risk. See a16z.com/disclosures for more info._

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Helios is still experimental software. While we hope you try it out, we do not s
 `--data-dir` or `-d` sets the directory that Helios should use to store cached weak subjectivity checkpoints in. Each network only stores the latest checkpoint, which is just 32 bytes.
 
 `--fallback` or `-f` sets the checkpoint fallback url (a string). This is only used if the checkpoint provided by the `--checkpoint` flag is too outdated for Helios to use to sync.
-If none is provided and the `--load-checkpoint-fallback` flag is not set, Helios will error.
+If none is provided and the `--load-external-fallback` flag is not set, Helios will error.
 For example, you can specify the fallback like so: `helios --fallback "https://sync-mainnet.beaconcha.in"` (or using shorthand like so: `helios -f "https://sync-mainnet.beaconcha.in"`)
 
 `--load-external-fallback` or `-l` enables weak subjectivity checkpoint fallback (no value needed).

--- a/README.md
+++ b/README.md
@@ -120,22 +120,20 @@ Below we demonstrate fetching checkpoints from the community-maintained list of 
 
 ```rust
 use eyre::Result;
-use helios::config::checkpoints;
+use helios::config::{checkpoints, networks};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Construct the checkpoint fallback services
-    let mut list = checkpoints::CheckpointFallbackList::new();
-    list.construct().await.unwrap();
+    let cf = checkpoints::CheckpointFallback::new().build().await.unwrap();
 
     // Fetch the latest goerli checkpoint
-    let goerli_checkpoint = list.fetch_latest_goerli_checkpoint().await.unwrap();
+    let goerli_checkpoint = cf.fetch_latest_checkpoint(&networks::Network::GOERLI).await.unwrap();
     println!("Fetched latest goerli checkpoint: {}", goerli_checkpoint);
 
     // Fetch the latest mainnet checkpoint
-    let mainnet_checkpoint = list.fetch_latest_goerli_checkpoint().await.unwrap();
+    let mainnet_checkpoint = cf.fetch_latest_checkpoint(&networks::Network::MAINNET).await.unwrap();
     println!("Fetched latest mainnet checkpoint: {}", mainnet_checkpoint);
-
 }
 ```
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -86,9 +86,9 @@ struct Cli {
     #[clap(short, long, env)]
     data_dir: Option<String>,
     #[clap(short = 'f', long, env)]
-    checkpoint_fallback: Option<String>,
-    #[clap(short = 'z', long, env)]
-    load_checkpoint_fallback: bool,
+    fallback: Option<String>,
+    #[clap(short = 'l', long, env)]
+    load_external_fallback: bool,
 }
 
 impl Cli {
@@ -104,8 +104,8 @@ impl Cli {
             consensus_rpc: self.consensus_rpc.clone(),
             data_dir: self.get_data_dir(),
             rpc_port: self.rpc_port,
-            checkpoint_fallback: self.checkpoint_fallback.clone(),
-            load_checkpoint_fallback: self.load_checkpoint_fallback,
+            fallback: self.fallback.clone(),
+            load_external_fallback: self.load_external_fallback,
         }
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -85,6 +85,10 @@ struct Cli {
     consensus_rpc: Option<String>,
     #[clap(short, long, env)]
     data_dir: Option<String>,
+    #[clap(short = 'f', long, env)]
+    checkpoint_fallback: Option<String>,
+    #[clap(short = 'z', long, env)]
+    load_checkpoint_fallback: bool,
 }
 
 impl Cli {
@@ -100,6 +104,8 @@ impl Cli {
             consensus_rpc: self.consensus_rpc.clone(),
             data_dir: self.get_data_dir(),
             rpc_port: self.rpc_port,
+            checkpoint_fallback: self.checkpoint_fallback.clone(),
+            load_checkpoint_fallback: self.load_checkpoint_fallback,
         }
     }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -164,6 +164,9 @@ impl<DB: Database> Client<DB> {
             rpc.start().await?;
         }
 
+        // TODO: node will error here when calling consensus getting ConsensusError::CheckpointTooOld.into()
+        // TODO: we need to use the fallback checkpoint if we see this error
+        // TODO: if none is provided or the fallback also fails, we should error here
         let res = self.node.write().await.sync().await;
         if let Err(err) = res {
             warn!("consensus error: {}", err);

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -8,7 +8,7 @@ use eyre::{eyre, Result};
 
 use common::types::BlockTag;
 use config::Config;
-use consensus::types::Header;
+use consensus::{types::Header, ConsensusClient};
 use execution::types::{CallOpts, ExecutionBlock};
 use log::{info, warn};
 use tokio::spawn;
@@ -19,27 +19,6 @@ use crate::database::{Database, FileDB};
 use crate::node::Node;
 use crate::rpc::Rpc;
 
-pub struct Client<DB: Database> {
-    node: Arc<RwLock<Node>>,
-    rpc: Option<Rpc>,
-    db: Option<DB>,
-}
-
-impl Client<FileDB> {
-    fn new(config: Config) -> Result<Self> {
-        let config = Arc::new(config);
-        let node = Node::new(config.clone())?;
-        let node = Arc::new(RwLock::new(node));
-
-        let rpc = config.rpc_port.map(|port| Rpc::new(node.clone(), port));
-
-        let data_dir = config.data_dir.clone();
-        let db = data_dir.map(FileDB::new);
-
-        Ok(Client { node, rpc, db })
-    }
-}
-
 #[derive(Default)]
 pub struct ClientBuilder {
     network: Option<Network>,
@@ -49,6 +28,8 @@ pub struct ClientBuilder {
     rpc_port: Option<u16>,
     data_dir: Option<PathBuf>,
     config: Option<Config>,
+    fallback: Option<String>,
+    load_external_fallback: bool,
 }
 
 impl ClientBuilder {
@@ -89,6 +70,16 @@ impl ClientBuilder {
 
     pub fn config(mut self, config: Config) -> Self {
         self.config = Some(config);
+        self
+    }
+
+    pub fn fallback(mut self, fallback: &str) -> Self {
+        self.fallback = Some(fallback.to_string());
+        self
+    }
+
+    pub fn load_external_fallback(mut self) -> Self {
+        self.load_external_fallback = true;
         self
     }
 
@@ -143,6 +134,20 @@ impl ClientBuilder {
             None
         };
 
+        let fallback = if self.fallback.is_some() {
+            self.fallback
+        } else if let Some(config) = &self.config {
+            config.fallback.clone()
+        } else {
+            None
+        };
+
+        let load_external_fallback = if let Some(config) = &self.config {
+            self.load_external_fallback || config.load_external_fallback
+        } else {
+            self.load_external_fallback
+        };
+
         let config = Config {
             consensus_rpc,
             execution_rpc,
@@ -152,9 +157,40 @@ impl ClientBuilder {
             chain: base_config.chain,
             forks: base_config.forks,
             max_checkpoint_age: base_config.max_checkpoint_age,
+            fallback,
+            load_external_fallback,
         };
 
         Client::new(config)
+    }
+}
+
+pub struct Client<DB: Database> {
+    node: Arc<RwLock<Node>>,
+    rpc: Option<Rpc>,
+    db: Option<DB>,
+    fallback: Option<String>,
+    load_external_fallback: bool,
+}
+
+impl Client<FileDB> {
+    fn new(config: Config) -> Result<Self> {
+        let config = Arc::new(config);
+        let node = Node::new(config.clone())?;
+        let node = Arc::new(RwLock::new(node));
+
+        let rpc = config.rpc_port.map(|port| Rpc::new(node.clone(), port));
+
+        let data_dir = config.data_dir.clone();
+        let db = data_dir.map(FileDB::new);
+
+        Ok(Client {
+            node,
+            rpc,
+            db,
+            fallback: config.fallback.clone(),
+            load_external_fallback: config.load_external_fallback,
+        })
     }
 }
 
@@ -164,12 +200,84 @@ impl<DB: Database> Client<DB> {
             rpc.start().await?;
         }
 
-        // TODO: node will error here when calling consensus getting ConsensusError::CheckpointTooOld.into()
-        // TODO: we need to use the fallback checkpoint if we see this error
-        // TODO: if none is provided or the fallback also fails, we should error here
         let res = self.node.write().await.sync().await;
         if let Err(err) = res {
-            warn!("consensus error: {}", err);
+            warn!(
+                "failed to sync consensus node with checkpoint: {:?}. Error: {}",
+                self.node.read().await.config.checkpoint,
+                err
+            );
+            let fallback = if let Some(fallback) = &self.fallback {
+                info!("attempting to load checkpoint from fallback {}", fallback);
+
+                let checkpoint =
+                    config::checkpoints::CheckpointFallbackList::fetch_checkpoint_from_api(
+                        fallback,
+                    )
+                    .await
+                    .map_err(|_| {
+                        eyre::eyre!("Failed to fetch checkpoint from fallback: {}", fallback)
+                    })?;
+
+                info!(
+                    "external fallbacks responded with checkpoint {:?}",
+                    checkpoint
+                );
+
+                // Try to sync again with the new checkpoint by reconstructing the consensus client
+                // We fail fast here since the node is unrecoverable at this point
+                let config = self.node.read().await.config.clone();
+                let consensus = ConsensusClient::new(
+                    &config.consensus_rpc,
+                    checkpoint.as_bytes(),
+                    config.clone(),
+                )?;
+                self.node.write().await.consensus = consensus;
+                self.node.write().await.sync().await?;
+
+                Ok(())
+            } else {
+                Err("missing fallback")
+            };
+
+            if fallback.is_err() && self.load_external_fallback {
+                info!("attempting to fetch checkpoint from external fallbacks...");
+                // Fetch the checkpoint from the external fallbacks
+                let mut list = config::checkpoints::CheckpointFallbackList::new();
+                list.construct().await.map_err(|_| {
+                    eyre::eyre!("Failed to construct external checkpoint sync fallbacks")
+                })?;
+
+                let checkpoint = if self.node.read().await.config.chain.chain_id == 5 {
+                    list.fetch_latest_goerli_checkpoint().await.map_err(|_| {
+                        eyre::eyre!(
+                            "Failed to fetch latest goerli checkpoint from external fallbacks"
+                        )
+                    })?
+                } else {
+                    list.fetch_latest_mainnet_checkpoint().await.map_err(|_| {
+                        eyre::eyre!(
+                            "Failed to fetch latest mainnet checkpoint from external fallbacks"
+                        )
+                    })?
+                };
+
+                info!(
+                    "external fallbacks responded with checkpoint {:?}",
+                    checkpoint
+                );
+
+                // Try to sync again with the new checkpoint by reconstructing the consensus client
+                // We fail fast here since the node is unrecoverable at this point
+                let config = self.node.read().await.config.clone();
+                let consensus = ConsensusClient::new(
+                    &config.consensus_rpc,
+                    checkpoint.as_bytes(),
+                    config.clone(),
+                )?;
+                self.node.write().await.consensus = consensus;
+                self.node.write().await.sync().await?;
+            }
         }
 
         let node = self.node.clone();

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -54,6 +54,9 @@ impl Node {
     }
 
     pub async fn sync(&mut self) -> Result<(), NodeError> {
+        // TODO: if this errors with ConsensusError::CheckpointTooOld.into()
+        // TODO: we need to switch the checkpoint to the fallback if configured,
+        // TODO: otherwise, error
         self.consensus
             .sync()
             .await

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -20,12 +20,12 @@ use execution::ExecutionClient;
 use crate::errors::NodeError;
 
 pub struct Node {
-    consensus: ConsensusClient<NimbusRpc>,
-    execution: Arc<ExecutionClient<HttpRpc>>,
-    config: Arc<Config>,
+    pub consensus: ConsensusClient<NimbusRpc>,
+    pub execution: Arc<ExecutionClient<HttpRpc>>,
+    pub config: Arc<Config>,
     payloads: BTreeMap<u64, ExecutionPayload>,
     finalized_payloads: BTreeMap<u64, ExecutionPayload>,
-    history_size: usize,
+    pub history_size: usize,
 }
 
 impl Node {
@@ -54,9 +54,6 @@ impl Node {
     }
 
     pub async fn sync(&mut self) -> Result<(), NodeError> {
-        // TODO: if this errors with ConsensusError::CheckpointTooOld.into()
-        // TODO: we need to switch the checkpoint to the fallback if configured,
-        // TODO: otherwise, error
         self.consensus
             .sync()
             .await

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -14,3 +14,8 @@ figment = { version = "0.10.7", features = ["toml", "env"] }
 thiserror = "1.0.37"
 
 common = { path = "../common" }
+reqwest = "0.11.13"
+serde_yaml = "0.9.14"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+tokio = { version = "1", features = ["full"] }
 eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }
 hex = "0.4.3"
@@ -18,6 +19,6 @@ common = { path = "../common" }
 reqwest = "0.11.13"
 serde_yaml = "0.9.14"
 strum = "0.24.1"
+futures = "0.3.25"
 
-[dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4.17"
 common = { path = "../common" }
 reqwest = "0.11.13"
 serde_yaml = "0.9.14"
+strum = "0.24.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -12,6 +12,7 @@ ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f18ca919cc1
 ethers = "1.0.0"
 figment = { version = "0.10.7", features = ["toml", "env"] }
 thiserror = "1.0.37"
+log = "0.4.17"
 
 common = { path = "../common" }
 reqwest = "0.11.13"

--- a/config/src/base.rs
+++ b/config/src/base.rs
@@ -1,0 +1,19 @@
+use serde::Serialize;
+
+use crate::types::{ChainConfig, Forks};
+use crate::utils::bytes_serialize;
+
+/// The base configuration for a network.
+#[derive(Serialize, Default)]
+pub struct BaseConfig {
+    pub rpc_port: u16,
+    pub consensus_rpc: Option<String>,
+    #[serde(
+        deserialize_with = "bytes_deserialize",
+        serialize_with = "bytes_serialize"
+    )]
+    pub checkpoint: Vec<u8>,
+    pub chain: ChainConfig,
+    pub forks: Forks,
+    pub max_checkpoint_age: u64,
+}

--- a/config/src/checkpoints.rs
+++ b/config/src/checkpoints.rs
@@ -93,7 +93,6 @@ impl CheckpointFallback {
 
         // Parse the yaml content results.
         let list: serde_yaml::Value = serde_yaml::from_str(&yaml)?;
-        println!("Got services: {:?}", list);
 
         // Construct the services mapping from network <> list of services
         let mut services = HashMap::new();

--- a/config/src/checkpoints.rs
+++ b/config/src/checkpoints.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+
+use ethers::types::H256;
+use serde::{Deserialize, Serialize};
+
+/// The location where the list of checkpoint services are stored.
+pub const CHECKPOINT_SYNC_SERVICES_LIST: &str = "https://raw.githubusercontent.com/ethpandaops/checkpoint-sync-health-checks/master/_data/endpoints.yaml";
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RawSlotResponse {
+    pub data: RawSlotResponseData,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RawSlotResponseData {
+    pub slots: Vec<Slot>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Slot {
+    pub slot: u64,
+    pub block_root: H256,
+    pub state_root: H256,
+    pub epoch: u64,
+    pub time: StartEndTime,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StartEndTime {
+    /// An ISO 8601 formatted UTC timestamp.
+    pub start: String,
+    /// An ISO 8601 formatted UTC timestamp.
+    pub end: u64,
+}
+
+/// A health check for the checkpoint sync service.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Health {
+    /// If the node is healthy.
+    pub result: bool,
+    /// An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) UTC timestamp.
+    pub date: String,
+}
+
+/// A checkpoint fallback service.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointFallback {
+    /// The endpoint for the checkpoint sync service.
+    pub endpoint: String,
+    /// The checkpoint sync service name.
+    pub name: String,
+    /// The service state.
+    pub state: bool,
+    /// If the service is verified.
+    pub verification: bool,
+    /// Contact information for the service maintainers.
+    pub contacts: Option<serde_yaml::Value>,
+    /// Service Notes
+    pub notes: Option<serde_yaml::Value>,
+    /// The service health check.
+    pub health: Vec<Health>,
+}
+
+/// The CheckpointFallbackList is a list of checkpoint fallback services.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointFallbackList {
+    /// The list of mainnet checkpoint fallback services.
+    pub mainnet: Vec<CheckpointFallback>,
+    /// The list of goerli checkpoint fallback services.
+    pub goerli: Vec<CheckpointFallback>,
+}
+
+impl CheckpointFallbackList {
+    /// Constructs a new checkpoint fallback service.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct the checkpoint fallback service from the community-maintained list by [ethPandaOps](https://github.com/ethpandaops).
+    ///
+    /// The list is defined in [ethPandaOps/checkpoint-fallback-service](https://github.com/ethpandaops/checkpoint-sync-health-checks/blob/master/_data/endpoints.yaml).
+    pub async fn construct(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let client = reqwest::Client::new();
+        let res = client.get(CHECKPOINT_SYNC_SERVICES_LIST).send().await?;
+
+        let yaml = res.text().await?;
+
+        // Parse the yaml content results.
+        let list: CheckpointFallbackList = serde_yaml::from_str(&yaml)?;
+        self.mainnet = list.mainnet;
+        self.goerli = list.goerli;
+        Ok(())
+    }
+
+    /// Fetch the latests mainnet checkpoint sync service checkpoint.
+    pub async fn fetch_latest_mainnet_checkpoint(
+        &self,
+    ) -> Result<H256, Box<dyn std::error::Error>> {
+        Self::fetch_latest_checkpoint(&self.mainnet).await
+    }
+
+    /// Fetch the latests goerli checkpoint sync service checkpoint.
+    pub async fn fetch_latest_goerli_checkpoint(&self) -> Result<H256, Box<dyn std::error::Error>> {
+        Self::fetch_latest_checkpoint(&self.goerli).await
+    }
+
+    /// Fetch the latest checkpoint sync service health check.
+    pub async fn fetch_latest_checkpoint(
+        services: &[CheckpointFallback],
+    ) -> Result<H256, Box<dyn std::error::Error>> {
+        let client = reqwest::Client::new();
+        let mut slots = Vec::new();
+
+        // Iterate over all mainnet checkpoint sync services and get the latest checkpoint slot for each.
+        // TODO: We can execute this in parallel and collect results into a slots vector.
+        for service in services.iter() {
+            let constructed_url = Self::construct_url(&service.endpoint);
+            let res = client.get(&constructed_url).send().await?;
+            let raw: RawSlotResponse = res.json().await?;
+            if raw.data.slots.is_empty() {
+                continue;
+            }
+            slots.push(raw.data.slots[0].clone());
+        }
+
+        // Get the max epoch
+        let max_epoch_slot = slots
+            .iter()
+            .max_by_key(|x| x.epoch)
+            .ok_or("Failed to find max epoch from checkpoint slots")?;
+        let max_epoch = max_epoch_slot.epoch;
+
+        // Filter out all the slots that are not the max epoch.
+        let slots = slots
+            .into_iter()
+            .filter(|x| x.epoch == max_epoch)
+            .collect::<Vec<_>>();
+
+        // Return the most commonly verified checkpoint.
+        let checkpoints = slots.iter().map(|x| x.state_root).collect::<Vec<_>>();
+        let mut m: HashMap<H256, usize> = HashMap::new();
+        for c in checkpoints {
+            *m.entry(c).or_default() += 1;
+        }
+        let most_common = m.into_iter().max_by_key(|(_, v)| *v).map(|(k, _)| k);
+
+        // Return the most commonly verified checkpoint for the latest epoch.
+        most_common.ok_or_else(|| "No checkpoint found".into())
+    }
+
+    /// Associated function to construct the checkpoint fallback service url.
+    pub fn construct_url(endpoint: &str) -> String {
+        format!("{}/checkpointz/v1/beacon/slots", endpoint)
+    }
+
+    /// Returns a list of mainnet checkpoint fallback urls.
+    pub fn mainnet_urls_unsafe(&self) -> Vec<String> {
+        self.mainnet
+            .iter()
+            .map(|service| service.endpoint.clone())
+            .collect()
+    }
+
+    /// Returns a list of healthchecked mainnet checkpoint fallback urls.
+    pub fn mainnet_urls(&self) -> Vec<String> {
+        self.mainnet
+            .iter()
+            .filter(|service| service.state)
+            .map(|service| service.endpoint.clone())
+            .collect()
+    }
+
+    /// Returns a list of goerli checkpoint fallback urls.
+    pub fn goerli_urls_unsafe(&self) -> Vec<String> {
+        self.goerli
+            .iter()
+            .map(|service| service.endpoint.clone())
+            .collect()
+    }
+
+    /// Returns a list of healthchecked goerli checkpoint fallback urls.
+    pub fn goerli_urls(&self) -> Vec<String> {
+        self.goerli
+            .iter()
+            .filter(|service| service.state)
+            .map(|service| service.endpoint.clone())
+            .collect()
+    }
+}

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -1,0 +1,40 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use figment::{providers::Serialized, value::Value};
+use serde::Serialize;
+
+/// Cli Config
+#[derive(Serialize)]
+pub struct CliConfig {
+    pub execution_rpc: Option<String>,
+    pub consensus_rpc: Option<String>,
+    pub checkpoint: Option<Vec<u8>>,
+    pub rpc_port: Option<u16>,
+    pub data_dir: PathBuf,
+}
+
+impl CliConfig {
+    pub fn as_provider(&self, network: &str) -> Serialized<HashMap<&str, Value>> {
+        let mut user_dict = HashMap::new();
+
+        if let Some(rpc) = &self.execution_rpc {
+            user_dict.insert("execution_rpc", Value::from(rpc.clone()));
+        }
+
+        if let Some(rpc) = &self.consensus_rpc {
+            user_dict.insert("consensus_rpc", Value::from(rpc.clone()));
+        }
+
+        if let Some(checkpoint) = &self.checkpoint {
+            user_dict.insert("checkpoint", Value::from(hex::encode(checkpoint)));
+        }
+
+        if let Some(port) = self.rpc_port {
+            user_dict.insert("rpc_port", Value::from(port));
+        }
+
+        user_dict.insert("data_dir", Value::from(self.data_dir.to_str().unwrap()));
+
+        Serialized::from(user_dict, network)
+    }
+}

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -11,6 +11,8 @@ pub struct CliConfig {
     pub checkpoint: Option<Vec<u8>>,
     pub rpc_port: Option<u16>,
     pub data_dir: PathBuf,
+    pub checkpoint_fallback: Option<String>,
+    pub load_checkpoint_fallback: bool,
 }
 
 impl CliConfig {
@@ -34,6 +36,18 @@ impl CliConfig {
         }
 
         user_dict.insert("data_dir", Value::from(self.data_dir.to_str().unwrap()));
+
+        if let Some(checkpoint_fallback) = &self.checkpoint_fallback {
+            user_dict.insert(
+                "checkpoint_fallback",
+                Value::from(checkpoint_fallback.clone()),
+            );
+        }
+
+        user_dict.insert(
+            "load_checkpoint_fallback",
+            Value::from(self.load_checkpoint_fallback),
+        );
 
         Serialized::from(user_dict, network)
     }

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -11,8 +11,8 @@ pub struct CliConfig {
     pub checkpoint: Option<Vec<u8>>,
     pub rpc_port: Option<u16>,
     pub data_dir: PathBuf,
-    pub checkpoint_fallback: Option<String>,
-    pub load_checkpoint_fallback: bool,
+    pub fallback: Option<String>,
+    pub load_external_fallback: bool,
 }
 
 impl CliConfig {
@@ -37,16 +37,13 @@ impl CliConfig {
 
         user_dict.insert("data_dir", Value::from(self.data_dir.to_str().unwrap()));
 
-        if let Some(checkpoint_fallback) = &self.checkpoint_fallback {
-            user_dict.insert(
-                "checkpoint_fallback",
-                Value::from(checkpoint_fallback.clone()),
-            );
+        if let Some(fallback) = &self.fallback {
+            user_dict.insert("fallback", Value::from(fallback.clone()));
         }
 
         user_dict.insert(
-            "load_checkpoint_fallback",
-            Value::from(self.load_checkpoint_fallback),
+            "load_external_fallback",
+            Value::from(self.load_external_fallback),
         );
 
         Serialized::from(user_dict, network)

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -25,6 +25,8 @@ pub struct Config {
     pub chain: ChainConfig,
     pub forks: Forks,
     pub max_checkpoint_age: u64,
+    pub fallback: Option<String>,
+    pub load_external_fallback: bool,
 }
 
 impl Config {

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1,0 +1,98 @@
+use figment::{
+    providers::{Format, Serialized, Toml},
+    Figment,
+};
+use serde::{Deserialize, Serialize};
+use std::{path::PathBuf, process::exit};
+
+use crate::base::BaseConfig;
+use crate::cli::CliConfig;
+use crate::networks;
+use crate::types::{ChainConfig, Forks};
+use crate::utils::{bytes_deserialize, bytes_serialize};
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct Config {
+    pub consensus_rpc: String,
+    pub execution_rpc: String,
+    pub rpc_port: Option<u16>,
+    #[serde(
+        deserialize_with = "bytes_deserialize",
+        serialize_with = "bytes_serialize"
+    )]
+    pub checkpoint: Vec<u8>,
+    pub data_dir: Option<PathBuf>,
+    pub chain: ChainConfig,
+    pub forks: Forks,
+    pub max_checkpoint_age: u64,
+}
+
+impl Config {
+    pub fn from_file(config_path: &PathBuf, network: &str, cli_config: &CliConfig) -> Self {
+        let base_config = match network {
+            "mainnet" => networks::mainnet(),
+            "goerli" => networks::goerli(),
+            _ => BaseConfig::default(),
+        };
+
+        let base_provider = Serialized::from(base_config, network);
+        let toml_provider = Toml::file(config_path).nested();
+        let cli_provider = cli_config.as_provider(network);
+
+        let config_res = Figment::new()
+            .merge(base_provider)
+            .merge(toml_provider)
+            .merge(cli_provider)
+            .select(network)
+            .extract();
+
+        match config_res {
+            Ok(config) => config,
+            Err(err) => {
+                match err.kind {
+                    figment::error::Kind::MissingField(field) => {
+                        let field = field.replace('_', "-");
+
+                        println!(
+                            "\x1b[91merror\x1b[0m: missing configuration field: {}",
+                            field
+                        );
+
+                        println!(
+                            "\n\ttry supplying the propoper command line argument: --{}",
+                            field
+                        );
+
+                        println!("\talternatively, you can add the field to your helios.toml file or as an environment variable");
+                        println!("\nfor more information, check the github README");
+                    }
+                    _ => println!("cannot parse configuration: {}", err),
+                }
+                exit(1);
+            }
+        }
+    }
+
+    pub fn fork_version(&self, slot: u64) -> Vec<u8> {
+        let epoch = slot / 32;
+
+        if epoch >= self.forks.bellatrix.epoch {
+            self.forks.bellatrix.fork_version.clone()
+        } else if epoch >= self.forks.altair.epoch {
+            self.forks.altair.fork_version.clone()
+        } else {
+            self.forks.genesis.fork_version.clone()
+        }
+    }
+
+    pub fn to_base_config(&self) -> BaseConfig {
+        BaseConfig {
+            rpc_port: self.rpc_port.unwrap_or(8545),
+            consensus_rpc: Some(self.consensus_rpc.clone()),
+            checkpoint: self.checkpoint.clone(),
+            chain: self.chain.clone(),
+            forks: self.forks.clone(),
+            max_checkpoint_age: self.max_checkpoint_age,
+        }
+    }
+}

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,179 +1,26 @@
+/// Base Config
+pub mod base;
+pub use base::*;
+
+/// Core Config
+pub mod config;
+pub use crate::config::*;
+
+/// Checkpoint Config
+pub mod checkpoints;
+pub use checkpoints::*;
+
+/// Cli Config
+pub mod cli;
+pub use cli::*;
+
+/// Network Configuration
 pub mod networks;
+pub use networks::*;
 
-use std::{collections::HashMap, path::PathBuf, process::exit};
+/// Generic Config Types
+pub mod types;
+pub use types::*;
 
-use eyre::Result;
-use figment::{
-    providers::{Format, Serialized, Toml},
-    value::Value,
-    Figment,
-};
-use networks::BaseConfig;
-use serde::{Deserialize, Serialize};
-
-use common::utils::hex_str_to_bytes;
-
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub struct Config {
-    pub consensus_rpc: String,
-    pub execution_rpc: String,
-    pub rpc_port: Option<u16>,
-    #[serde(
-        deserialize_with = "bytes_deserialize",
-        serialize_with = "bytes_serialize"
-    )]
-    pub checkpoint: Vec<u8>,
-    pub data_dir: Option<PathBuf>,
-    pub chain: ChainConfig,
-    pub forks: Forks,
-    pub max_checkpoint_age: u64,
-}
-
-impl Config {
-    pub fn from_file(config_path: &PathBuf, network: &str, cli_config: &CliConfig) -> Self {
-        let base_config = match network {
-            "mainnet" => networks::mainnet(),
-            "goerli" => networks::goerli(),
-            _ => BaseConfig::default(),
-        };
-
-        let base_provider = Serialized::from(base_config, network);
-        let toml_provider = Toml::file(config_path).nested();
-        let cli_provider = cli_config.as_provider(network);
-
-        let config_res = Figment::new()
-            .merge(base_provider)
-            .merge(toml_provider)
-            .merge(cli_provider)
-            .select(network)
-            .extract();
-
-        match config_res {
-            Ok(config) => config,
-            Err(err) => {
-                match err.kind {
-                    figment::error::Kind::MissingField(field) => {
-                        let field = field.replace('_', "-");
-
-                        println!(
-                            "\x1b[91merror\x1b[0m: missing configuration field: {}",
-                            field
-                        );
-
-                        println!(
-                            "\n\ttry supplying the propoper command line argument: --{}",
-                            field
-                        );
-
-                        println!("\talternatively, you can add the field to your helios.toml file or as an environment variable");
-                        println!("\nfor more information, check the github README");
-                    }
-                    _ => println!("cannot parse configuration: {}", err),
-                }
-                exit(1);
-            }
-        }
-    }
-
-    pub fn fork_version(&self, slot: u64) -> Vec<u8> {
-        let epoch = slot / 32;
-
-        if epoch >= self.forks.bellatrix.epoch {
-            self.forks.bellatrix.fork_version.clone()
-        } else if epoch >= self.forks.altair.epoch {
-            self.forks.altair.fork_version.clone()
-        } else {
-            self.forks.genesis.fork_version.clone()
-        }
-    }
-
-    pub fn to_base_config(&self) -> BaseConfig {
-        BaseConfig {
-            rpc_port: self.rpc_port.unwrap_or(8545),
-            consensus_rpc: Some(self.consensus_rpc.clone()),
-            checkpoint: self.checkpoint.clone(),
-            chain: self.chain.clone(),
-            forks: self.forks.clone(),
-            max_checkpoint_age: self.max_checkpoint_age,
-        }
-    }
-}
-
-#[derive(Serialize)]
-pub struct CliConfig {
-    pub execution_rpc: Option<String>,
-    pub consensus_rpc: Option<String>,
-    pub checkpoint: Option<Vec<u8>>,
-    pub rpc_port: Option<u16>,
-    pub data_dir: PathBuf,
-}
-
-impl CliConfig {
-    fn as_provider(&self, network: &str) -> Serialized<HashMap<&str, Value>> {
-        let mut user_dict = HashMap::new();
-
-        if let Some(rpc) = &self.execution_rpc {
-            user_dict.insert("execution_rpc", Value::from(rpc.clone()));
-        }
-
-        if let Some(rpc) = &self.consensus_rpc {
-            user_dict.insert("consensus_rpc", Value::from(rpc.clone()));
-        }
-
-        if let Some(checkpoint) = &self.checkpoint {
-            user_dict.insert("checkpoint", Value::from(hex::encode(checkpoint)));
-        }
-
-        if let Some(port) = self.rpc_port {
-            user_dict.insert("rpc_port", Value::from(port));
-        }
-
-        user_dict.insert("data_dir", Value::from(self.data_dir.to_str().unwrap()));
-
-        Serialized::from(user_dict, network)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
-pub struct ChainConfig {
-    pub chain_id: u64,
-    pub genesis_time: u64,
-    #[serde(
-        deserialize_with = "bytes_deserialize",
-        serialize_with = "bytes_serialize"
-    )]
-    pub genesis_root: Vec<u8>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
-pub struct Forks {
-    pub genesis: Fork,
-    pub altair: Fork,
-    pub bellatrix: Fork,
-}
-
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
-pub struct Fork {
-    pub epoch: u64,
-    #[serde(
-        deserialize_with = "bytes_deserialize",
-        serialize_with = "bytes_serialize"
-    )]
-    pub fork_version: Vec<u8>,
-}
-
-fn bytes_deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let bytes: String = serde::Deserialize::deserialize(deserializer)?;
-    Ok(hex_str_to_bytes(&bytes).unwrap())
-}
-
-fn bytes_serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    let bytes_string = hex::encode(bytes);
-    serializer.serialize_str(&bytes_string)
-}
+/// Generic Utilities
+pub mod utils;

--- a/config/src/networks.rs
+++ b/config/src/networks.rs
@@ -1,7 +1,7 @@
-use serde::Serialize;
-
-use crate::{bytes_serialize, ChainConfig, Fork, Forks};
 use common::utils::hex_str_to_bytes;
+
+use crate::base::BaseConfig;
+use crate::types::{ChainConfig, Fork, Forks};
 
 pub enum Network {
     MAINNET,
@@ -15,20 +15,6 @@ impl Network {
             Self::GOERLI => goerli(),
         }
     }
-}
-
-#[derive(Serialize, Default)]
-pub struct BaseConfig {
-    pub rpc_port: u16,
-    pub consensus_rpc: Option<String>,
-    #[serde(
-        deserialize_with = "bytes_deserialize",
-        serialize_with = "bytes_serialize"
-    )]
-    pub checkpoint: Vec<u8>,
-    pub chain: ChainConfig,
-    pub forks: Forks,
-    pub max_checkpoint_age: u64,
 }
 
 pub fn mainnet() -> BaseConfig {

--- a/config/src/networks.rs
+++ b/config/src/networks.rs
@@ -1,8 +1,24 @@
 use common::utils::hex_str_to_bytes;
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumIter};
 
 use crate::base::BaseConfig;
 use crate::types::{ChainConfig, Fork, Forks};
 
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    EnumIter,
+    Display,
+    Hash,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+)]
 pub enum Network {
     MAINNET,
     GOERLI,

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+use crate::utils::{bytes_deserialize, bytes_serialize};
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct ChainConfig {
+    pub chain_id: u64,
+    pub genesis_time: u64,
+    #[serde(
+        deserialize_with = "bytes_deserialize",
+        serialize_with = "bytes_serialize"
+    )]
+    pub genesis_root: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct Forks {
+    pub genesis: Fork,
+    pub altair: Fork,
+    pub bellatrix: Fork,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct Fork {
+    pub epoch: u64,
+    #[serde(
+        deserialize_with = "bytes_deserialize",
+        serialize_with = "bytes_serialize"
+    )]
+    pub fork_version: Vec<u8>,
+}

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -1,0 +1,17 @@
+use common::utils::hex_str_to_bytes;
+
+pub fn bytes_deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let bytes: String = serde::Deserialize::deserialize(deserializer)?;
+    Ok(hex_str_to_bytes(&bytes).unwrap())
+}
+
+pub fn bytes_serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let bytes_string = hex::encode(bytes);
+    serializer.serialize_str(&bytes_string)
+}

--- a/config/tests/checkpoints.rs
+++ b/config/tests/checkpoints.rs
@@ -1,26 +1,68 @@
+use config::networks;
 use ethers::types::H256;
 
 #[tokio::test]
+async fn test_checkpoint_fallback() {
+    let cf = config::checkpoints::CheckpointFallback::new();
+
+    assert_eq!(cf.services.get(&networks::Network::MAINNET), None);
+    assert_eq!(cf.services.get(&networks::Network::GOERLI), None);
+
+    assert_eq!(
+        cf.networks,
+        [networks::Network::MAINNET, networks::Network::GOERLI].to_vec()
+    );
+}
+
+#[tokio::test]
 async fn test_construct_checkpoints() {
-    let mut list = config::checkpoints::CheckpointFallbackList::new();
-    list.construct().await.unwrap();
+    let cf = config::checkpoints::CheckpointFallback::new()
+        .build()
+        .await
+        .unwrap();
 
-    assert!(list.mainnet.len() > 1);
-    assert!(list.goerli.len() > 1);
+    assert!(cf.services[&networks::Network::MAINNET].len() > 1);
+    assert!(cf.services[&networks::Network::GOERLI].len() > 1);
 }
 
 #[tokio::test]
-async fn test_fetch_latest_mainnet_checkpoints() {
-    let mut list = config::checkpoints::CheckpointFallbackList::new();
-    list.construct().await.unwrap();
-    let checkpoint = list.fetch_latest_mainnet_checkpoint().await.unwrap();
+async fn test_fetch_latest_checkpoints() {
+    let cf = config::checkpoints::CheckpointFallback::new()
+        .build()
+        .await
+        .unwrap();
+    let checkpoint = cf
+        .fetch_latest_checkpoint(&networks::Network::GOERLI)
+        .await
+        .unwrap();
+    assert!(checkpoint != H256::zero());
+    let checkpoint = cf
+        .fetch_latest_checkpoint(&networks::Network::MAINNET)
+        .await
+        .unwrap();
     assert!(checkpoint != H256::zero());
 }
 
 #[tokio::test]
-async fn test_fetch_latest_goerli_checkpoints() {
-    let mut list = config::checkpoints::CheckpointFallbackList::new();
-    list.construct().await.unwrap();
-    let checkpoint = list.fetch_latest_goerli_checkpoint().await.unwrap();
-    assert!(checkpoint != H256::zero());
+async fn test_get_all_fallback_endpoints() {
+    let cf = config::checkpoints::CheckpointFallback::new()
+        .build()
+        .await
+        .unwrap();
+    let urls = cf.get_all_fallback_endpoints(&networks::Network::MAINNET);
+    assert!(urls.len() > 0);
+    let urls = cf.get_all_fallback_endpoints(&networks::Network::GOERLI);
+    assert!(urls.len() > 0);
+}
+
+#[tokio::test]
+async fn test_get_healthy_fallback_endpoints() {
+    let cf = config::checkpoints::CheckpointFallback::new()
+        .build()
+        .await
+        .unwrap();
+    let urls = cf.get_healthy_fallback_endpoints(&networks::Network::MAINNET);
+    assert!(urls.len() > 0);
+    let urls = cf.get_healthy_fallback_endpoints(&networks::Network::GOERLI);
+    assert!(urls.len() > 0);
 }

--- a/config/tests/checkpoints.rs
+++ b/config/tests/checkpoints.rs
@@ -1,0 +1,8 @@
+#[tokio::test]
+async fn test_construct_checkpoints() {
+    let mut list = config::checkpoints::CheckpointFallbackList::new();
+    list.construct().await.unwrap();
+
+    assert!(list.mainnet.len() > 1);
+    assert!(list.goerli.len() > 1);
+}

--- a/config/tests/checkpoints.rs
+++ b/config/tests/checkpoints.rs
@@ -1,3 +1,5 @@
+use ethers::types::H256;
+
 #[tokio::test]
 async fn test_construct_checkpoints() {
     let mut list = config::checkpoints::CheckpointFallbackList::new();
@@ -5,4 +7,20 @@ async fn test_construct_checkpoints() {
 
     assert!(list.mainnet.len() > 1);
     assert!(list.goerli.len() > 1);
+}
+
+#[tokio::test]
+async fn test_fetch_latest_mainnet_checkpoints() {
+    let mut list = config::checkpoints::CheckpointFallbackList::new();
+    list.construct().await.unwrap();
+    let checkpoint = list.fetch_latest_mainnet_checkpoint().await.unwrap();
+    assert!(checkpoint != H256::zero());
+}
+
+#[tokio::test]
+async fn test_fetch_latest_goerli_checkpoints() {
+    let mut list = config::checkpoints::CheckpointFallbackList::new();
+    list.construct().await.unwrap();
+    let checkpoint = list.fetch_latest_goerli_checkpoint().await.unwrap();
+    assert!(checkpoint != H256::zero());
 }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -94,6 +94,10 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
     }
 
     pub async fn sync(&mut self) -> Result<()> {
+        info!(
+            "Consensus client in sync with checkpoint: {:?}",
+            hex::encode(&self.initial_checkpoint)
+        );
         self.bootstrap().await?;
 
         let current_period = calc_sync_period(self.store.finalized_header.slot);

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -95,7 +95,7 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
 
     pub async fn sync(&mut self) -> Result<()> {
         info!(
-            "Consensus client in sync with checkpoint: {:?}",
+            "Consensus client in sync with checkpoint: 0x{}",
             hex::encode(&self.initial_checkpoint)
         );
         self.bootstrap().await?;


### PR DESCRIPTION
## Overview

Introduces lazy checkpoint fallback services.

### CLI Flags

The following two cli flags are introduced in this pr.

- `--fallback` or `-f` sets the checkpoint fallback url (a string). This is only used if the checkpoint provided by the `--checkpoint` flag is too outdated for Helios to use to sync.
If none is provided and the `--load-external-fallback` flag is not set, Helios will error.
For example, you can specify the fallback like so: `helios --fallback "https://sync-mainnet.beaconcha.in"` (or using shorthand like so: `helios -f "https://sync-mainnet.beaconcha.in"`)
- `--load-external-fallback` or `-l` enables weak subjectivity checkpoint fallback (no value needed).
For example, say you set a checkpoint value that is too outdated and Helios cannot sync to it.
If this flag is set, Helios will query all network apis in the community-maintained list
at [ethpandaops/checkpoint-synz-health-checks](https://github.com/ethpandaops/checkpoint-sync-health-checks/blob/master/_data/endpoints.yaml) for their latest slots.
The list of slots is filtered for healthy apis and the most frequent checkpoint occuring in the latest epoch will be returned.
Note: this is a community-maintained list and thus no security guarantees are provided. Use this is a last resort if your checkpoint passed into `--checkpoint` fails.
This is not recommened as malicious checkpoints can be returned from the listed apis, even if they are considered _healthy_.
This can be run like so: `helios --load-external-fallback` (or `helios -l` with the shorthand).
