### PR TITLE
build(github CI): replace `actions/cache@v2` with `Swatinem/rust-cach…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,7 @@ jobs:
       - name: install target
         run: rustup target add aarch64-apple-darwin
 
-      - name: cargo cache artifacts
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: build
         run: cargo build --package cli --release --target aarch64-apple-darwin
@@ -66,14 +59,7 @@ jobs:
       - name: install target
         run: rustup target add x86_64-apple-darwin
 
-      - name: cargo cache artifacts
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: build
         run: cargo build --package cli --release --target x86_64-apple-darwin	
@@ -118,14 +104,7 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
-      - name: cargo cache artifacts
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: build
         run: cargo build --package cli --release --target aarch64-unknown-linux-gnu
@@ -164,14 +143,7 @@ jobs:
       - name: install target
         run: rustup target add x86_64-unknown-linux-gnu
 
-      - name: cargo cache artifacts
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: build
         run: cargo build --package cli --release --target x86_64-unknown-linux-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -38,13 +32,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -61,13 +49,7 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -84,13 +66,7 @@ jobs:
           toolchain: nightly
           override: true
           components: clippy
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: clippy


### PR DESCRIPTION
…e@v2`

---
1. `actions/cache@v2` seems no longer working for cargo 
<img width="469" alt="image" src="https://user-images.githubusercontent.com/37070449/205166021-35afbad7-3b78-425e-83d6-1491b4721387.png">


2. before vs after:
<img width="849" alt="image" src="https://user-images.githubusercontent.com/37070449/205163132-89bee8e4-7e9e-4036-9cb5-373f1f29967e.png">

<img width="851" alt="image" src="https://user-images.githubusercontent.com/37070449/205165230-80bba974-31c0-4e5e-8a46-717277c10945.png">

