### PR TITLE
fix: Missed Storage Slots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dunce"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,6 +1672,7 @@ dependencies = [
  "common",
  "config",
  "consensus",
+ "dotenv",
  "env_logger",
  "ethers",
  "execution",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,6 +1679,7 @@ dependencies = [
  "eyre",
  "home",
  "log",
+ "serde",
  "tokio",
 ]
 
@@ -3373,9 +3374,9 @@ checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
@@ -3392,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,11 @@ execution = { path = "./execution" }
 tokio = { version = "1", features = ["full"] }
 eyre = "0.6.8"
 home = "0.5.4"
-ethers = "1.0.2"
+ethers = { version = "1.0.2", features = [ "abigen" ] }
 env_logger = "0.9.0"
 log = "0.4.17"
 dotenv = "0.15.0"
+serde = "1.0.149"
 
 [[example]]
 name = "call"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ home = "0.5.4"
 ethers = "1.0.2"
 env_logger = "0.9.0"
 log = "0.4.17"
+dotenv = "0.15.0"
+
+[[example]]
+name = "call"
+path = "examples/call.rs"
 
 [[example]]
 name = "checkpoints"

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -83,6 +83,7 @@ impl Node {
             .get_execution_payload(&Some(latest_header.slot))
             .await
             .map_err(NodeError::ConsensusPayloadError)?;
+        log::debug!("latest payload: {:?}", latest_payload.block_number);
 
         let finalized_header = self.consensus.get_finalized_header();
         let finalized_payload = self
@@ -90,6 +91,7 @@ impl Node {
             .get_execution_payload(&Some(finalized_header.slot))
             .await
             .map_err(NodeError::ConsensusPayloadError)?;
+        log::debug!("finalized payload: {:?}", finalized_payload.block_number);
 
         self.payloads
             .insert(latest_payload.block_number, latest_payload);
@@ -99,6 +101,7 @@ impl Node {
             .insert(finalized_payload.block_number, finalized_payload);
 
         while self.payloads.len() > self.history_size {
+            log::debug!("Popping first payload...");
             self.payloads.pop_first();
         }
 
@@ -107,6 +110,8 @@ impl Node {
         while self.finalized_payloads.len() > usize::max(self.history_size / 32, 1) {
             self.finalized_payloads.pop_first();
         }
+
+        log::debug!("Successfully updated payloads");
 
         Ok(())
     }

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -1,0 +1,104 @@
+#![allow(deprecated)]
+
+use std::str::FromStr;
+
+use dotenv::dotenv;
+
+use env_logger::Env;
+use ethers::prelude::*;
+use eyre::Result;
+use helios::{
+    client::ClientBuilder,
+    config::networks::Network,
+    types::{BlockTag, CallOpts},
+};
+
+// Generate the type-safe contract bindings with an ABI
+// abigen!(
+//     Renderer,
+//     r#"[
+//         function renderBroker(uint256, uint256) external view returns (string memory, uint256)
+//     ]"#,
+//     event_derives(serde::Deserialize, serde::Serialize)
+// );
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Load the .env file
+    dotenv().ok();
+
+    // Initialize the logger
+    env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
+
+    // Load the rpc url using the `ETH_RPC_URL` environment variable
+    let eth_rpc_url = std::env::var("ETH_RPC_URL")?;
+    let consensus_rpc = "https://www.lightclientdata.org";
+    log::info!("Consensus RPC URL: {}", consensus_rpc);
+
+    // Construct the client
+    let mut client = ClientBuilder::new()
+        .network(Network::MAINNET)
+        .consensus_rpc(consensus_rpc)
+        .execution_rpc(&eth_rpc_url)
+        .load_external_fallback()
+        .build()?;
+    log::info!("[\"{}\"] Client built with external checkpoint fallbacks", Network::MAINNET);
+
+    // Start the client
+    client.start().await?;
+
+
+    // Call the erroneous account method
+    // The expected asset is: https://0x8bb9a8baeec177ae55ac410c429cbbbbb9198cac.w3eth.io/renderBroker/5
+    // Retrieved by calling `renderBroker(5)` on the contract: https://etherscan.io/address/0x8bb9a8baeec177ae55ac410c429cbbbbb9198cac#code
+    // let contract = Renderer::new(account, client.clone());
+    let account = "0x8bb9a8baeec177ae55ac410c429cbbbbb9198cac";
+    let method = "renderBroker(uint256)";
+    log::debug!("Calling {}::{}", account, method);
+    let args = vec![ethers::abi::Token::Uint(U256::from(5))];
+    log::debug!("Arguments: {:?}", args);
+    let function: ethers::abi::Function = ethers::abi::Function {
+        name: method.to_string(),
+        inputs: vec![ethers::abi::Param {
+            name: "brokerId".to_string(),
+            kind: ethers::abi::ParamType::Uint(256),
+            internal_type: None
+        }],
+        outputs: vec![ethers::abi::Param {
+            name: "brokerName".to_string(),
+            kind: ethers::abi::ParamType::String,
+            internal_type: Some("memory".to_string())
+        }, ethers::abi::Param {name:"brokerId".to_string(),kind:ethers::abi::ParamType::Uint(256), internal_type: None }],
+        constant: None,
+        state_mutability: ethers::abi::StateMutability::View,
+    };
+    let encoded = function.encode_input(&args)?;
+    log::debug!("Encoded function input: {:?}", encoded);
+    let call_opts = CallOpts {
+        from: None,
+        to: Address::from_str(account)?,
+        gas: None,
+        gas_price: None,
+        value: None,
+        data: Some(encoded.clone()),
+    };
+    log::debug!("Constructed CallOpts: {:?}", call_opts);
+    let block = BlockTag::Latest;
+
+    // Call on ethers-rs client
+    let mut tx = ethers::types::Eip1559TransactionRequest::new();
+    tx = tx.chain_id(1);
+    tx = tx.to(account);
+    tx = tx.data(encoded.clone());
+    let provider = Provider::<Http>::try_from(eth_rpc_url)?;
+    log::debug!("[ETHERS] Calling on block: {:?}", block);
+    let result = provider.call(&tx.into(), None).await?;
+    log::debug!("[ETHERS] {}::{}\n  ->{:?}", account, method, result);
+
+    // Call on helios client
+    log::debug!("[HELIOS] Calling on block: {:?}", block);
+    let result = client.call(&call_opts, block).await?;
+    log::info!("[HELIOS] {}::{}\n  ->{:?}", account, method, result);
+
+    Ok(())
+}

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -1,12 +1,9 @@
 #![allow(deprecated)]
 
-use std::str::FromStr;
-
 use dotenv::dotenv;
-
 use env_logger::Env;
 use ethers::prelude::*;
-use eyre::Result;
+
 use helios::{
     client::ClientBuilder,
     config::networks::Network,
@@ -23,7 +20,7 @@ use helios::{
 // );
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> eyre::Result<()> {
     // Load the .env file
     dotenv().ok();
 
@@ -74,9 +71,11 @@ async fn main() -> Result<()> {
     };
     let encoded = function.encode_input(&args)?;
     log::debug!("Encoded function input: {:?}", encoded);
+    let to = "8bb9a8baeec177ae55ac410c429cbbbbb9198cac".parse::<Address>()?;
+    log::debug!("To: {:?}", to);
     let call_opts = CallOpts {
         from: None,
-        to: Address::from_str(account)?,
+        to,
         gas: None,
         gas_price: None,
         value: None,
@@ -88,7 +87,7 @@ async fn main() -> Result<()> {
     // Call on ethers-rs client
     let mut tx = ethers::types::Eip1559TransactionRequest::new();
     tx = tx.chain_id(1);
-    tx = tx.to(account);
+    tx = tx.to(to);
     tx = tx.data(encoded.clone());
     let provider = Provider::<Http>::try_from(eth_rpc_url)?;
     log::debug!("[ETHERS] Calling on block: {:?}", block);

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -1,9 +1,9 @@
 #![allow(deprecated)]
 
-use std::sync::Arc;
 use dotenv::dotenv;
 use env_logger::Env;
 use ethers::prelude::*;
+use std::sync::Arc;
 
 use helios::{
     client::ClientBuilder,
@@ -41,7 +41,10 @@ async fn main() -> eyre::Result<()> {
         .execution_rpc(&eth_rpc_url)
         .load_external_fallback()
         .build()?;
-    log::info!("[\"{}\"] Client built with external checkpoint fallbacks", Network::MAINNET);
+    log::info!(
+        "[\"{}\"] Client built with external checkpoint fallbacks",
+        Network::MAINNET
+    );
 
     // Start the client
     client.start().await?;
@@ -62,12 +65,21 @@ async fn main() -> eyre::Result<()> {
 
     // Call using abigen
     let provider = Provider::<Http>::try_from(eth_rpc_url)?;
-    let render  = Renderer::new(address, Arc::new(provider.clone()));
+    let render = Renderer::new(address, Arc::new(provider.clone()));
     let result = render.render_broker_0(argument).call().await?;
-    log::info!("[ABIGEN] {account}::{method} -> Response Length: {:?}", result.len());
-    let render  = Renderer::new(address, Arc::new(provider.clone()));
-    let result = render.render_broker_1(argument, U256::from(10)).call().await?;
-    log::info!("[ABIGEN] {account}::{method2} -> Response Length: {:?}", result.len());
+    log::info!(
+        "[ABIGEN] {account}::{method} -> Response Length: {:?}",
+        result.len()
+    );
+    let render = Renderer::new(address, Arc::new(provider.clone()));
+    let result = render
+        .render_broker_1(argument, U256::from(10))
+        .call()
+        .await?;
+    log::info!(
+        "[ABIGEN] {account}::{method2} -> Response Length: {:?}",
+        result.len()
+    );
 
     // Call on helios client
     log::debug!("Calling helios client on block: {block:?}");

--- a/execution/src/errors.rs
+++ b/execution/src/errors.rs
@@ -35,7 +35,7 @@ pub enum EvmError {
     #[error("evm error: {0:?}")]
     Generic(String),
 
-    #[error("evm execution failed: {0:?}")]
+    #[error("revm execution failed: {0:?}")]
     Revm(revm::Return),
 
     #[error("rpc error: {0:?}")]


### PR DESCRIPTION
## Overview

Tracks #133 

#### Context

```markdown
Some calls are causing a very unexpected failure.

For example, calling `renderBroker(5)` on `0x8bb9a8baeec177ae55ac410c429cbbbbb9198cac`
always fails on line 287 of `evm.rs`.
This is very unexpected, since in this case we are just fetching and proving that slot.
Then immediately fetching the slot out of the map and unwrapping it.
```

We can see the asset is successfully fetched using an access point: https://0x8bb9a8baeec177ae55ac410c429cbbbbb9198cac.w3eth.io/renderBroker/5 as a sanity check.

#### Progress

Constructed an example in [examples/call.rs](./examples/call.rs) that calls the given method using both [ethers-rs provider](https://docs.rs/ethers/latest/ethers/providers/struct.Provider.html) as well as the Helios client.

Occasionally errors due to checkpoint sync issue it seems constructing access list when the client isn't fully synced yet.

See screengrabs below (both run within 1 minute of each other, no code changes).

<img width="1059" alt="Screenshot 2022-12-10 at 8 51 58 AM" src="https://user-images.githubusercontent.com/21288394/206866913-45e926db-d89b-4a15-8855-84754a2c8934.png">
<img width="1046" alt="Screenshot 2022-12-10 at 8 51 50 AM" src="https://user-images.githubusercontent.com/21288394/206866915-f84933fb-5953-420f-9e4b-59800e2d4c8a.png">