### PR TITLE
fix(ci): move benchmark ci to seperate action

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,25 @@
+name: benchmarks
+
+on:
+  push:
+    branches: [ "master" ]
+
+env:
+  MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+  GOERLI_RPC_URL: ${{ secrets.GOERLI_RPC_URL }}
+
+jobs:
+  benches:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: bench

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [ "master" ]
 
-env:
-  MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
-  GOERLI_RPC_URL: ${{ secrets.GOERLI_RPC_URL }}
-
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -55,21 +51,6 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
-  benches:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: bench
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Right now, if someone opens up a PR from a fork, the benchmarks will fail. This is because actions triggered from PRs from forks cannot access secrets for security reasons.

One option is to use the `pull_request_target`  trigger, which allows PRs from forks to access secrets. I don't want to do this though in case we add more valuable secrets and forget that this action trigger can expose them to an attacker. Obviously as it stands, I don't really care if someone can steal my alchemy key though.

This PR just switches the benches to a separate action that only triggers on pushes to master. I don't think we often care about the benchmarks for every incoming PR anyway, and we can always manually trigger the benchmark action for a PR if we want.