### PR TITLE
chore: export ExecutionBlock type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub mod config {
 
 pub mod types {
     pub use common::types::BlockTag;
-    pub use execution::types::CallOpts;
+    pub use execution::types::{CallOpts,ExecutionBlock};
 }
 
 pub mod errors {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![warn(missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![doc(test(
-no_crate_inject,
-attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 
 //! # Ethereum light client written in Rust.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![warn(missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![doc(test(
-    no_crate_inject,
-    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+no_crate_inject,
+attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 
 //! # Ethereum light client written in Rust.
@@ -60,7 +60,7 @@ pub mod config {
 
 pub mod types {
     pub use common::types::BlockTag;
-    pub use execution::types::{CallOpts,ExecutionBlock};
+    pub use execution::types::{CallOpts, ExecutionBlock};
 }
 
 pub mod errors {


### PR DESCRIPTION
# Description
Currently execution::types::ExecutionBlock is not exported, and it is needed to be able to use `get_block_by_<x>` functions of Helios client.

## Changes summary
* Updated Helios lib.rs to export `execution::types::{CallOpts, ExecutionBlock}`

Closes https://github.com/a16z/helios/issues/145

