### PR TITLE
chore: export `src/execution` types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub mod config {
 
 pub mod types {
     pub use common::types::BlockTag;
-    pub use execution::types::{CallOpts, ExecutionBlock};
+    pub use execution::types::{Account, CallOpts, ExecutionBlock, Transactions};
 }
 
 pub mod errors {


### PR DESCRIPTION
# Description
Following PR #146, other types need to be exported for external integration.
Currently `execution::types::Transactions` is not exported, and it is needed to be able to use `get_block_by_<x>` functions of Helios client.

To avoid future PRs solving the same problem, I propose to export all types in this file  - i.e. export `Account` and `Transactions`.

## Changes summary
* Updated Helios lib.rs to export `execution::types::{Account, CallOpts, ExecutionBlock, Transactions}`

Closes #147
