### PR TITLE
RPC call : eth_getTransactionByBlockHashAndIndex Implementation

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -434,6 +434,18 @@ impl<DB: Database> Client<DB> {
             .await
     }
 
+    pub async fn get_transaction_by_block_hash_and_index(
+        &self,
+        block_hash: &Vec<u8>,
+        index: usize,
+    ) -> Result<Option<Transaction>> {
+        self.node
+            .read()
+            .await
+            .get_transaction_by_block_hash_and_index(block_hash, index)
+            .await
+    }
+
     pub async fn chain_id(&self) -> u64 {
         self.node.read().await.chain_id()
     }

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -217,6 +217,19 @@ impl Node {
             .await
     }
 
+    pub async fn get_transaction_by_block_hash_and_index(
+        &self,
+        hash: &Vec<u8>,
+        index: usize,
+    ) -> Result<Option<Transaction>> {
+        let payload = self.get_payload_by_hash(hash)?;
+
+        Ok(self
+            .execution
+            .get_transaction_by_block_hash_and_index(payload.1, index)
+            .await?)
+    }
+
     pub async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>> {
         self.execution.get_logs(filter, &self.payloads).await
     }

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -224,10 +224,9 @@ impl Node {
     ) -> Result<Option<Transaction>> {
         let payload = self.get_payload_by_hash(hash)?;
 
-        Ok(self
-            .execution
+        self.execution
             .get_transaction_by_block_hash_and_index(payload.1, index)
-            .await?)
+            .await
     }
 
     pub async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>> {

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -270,7 +270,6 @@ impl EthRpcServer for RpcInner {
                 .await,
         )
     }
-
     async fn get_logs(&self, filter: Filter) -> Result<Vec<Log>, Error> {
         let node = self.node.read().await;
         convert_err(node.get_logs(&filter).await)

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -97,6 +97,12 @@ trait EthRpc {
     ) -> Result<Option<TransactionReceipt>, Error>;
     #[method(name = "getTransactionByHash")]
     async fn get_transaction_by_hash(&self, hash: &str) -> Result<Option<Transaction>, Error>;
+    #[method(name = "getTransactionByBlockHashAndIndex")]
+    async fn get_transaction_by_block_hash_and_index(
+        &self,
+        hash: &str,
+        index: usize,
+    ) -> Result<Option<Transaction>, Error>;
     #[method(name = "getLogs")]
     async fn get_logs(&self, filter: Filter) -> Result<Vec<Log>, Error>;
     #[method(name = "getStorageAt")]
@@ -250,6 +256,19 @@ impl EthRpcServer for RpcInner {
         let node = self.node.read().await;
         let hash = H256::from_slice(&convert_err(hex_str_to_bytes(hash))?);
         convert_err(node.get_transaction_by_hash(&hash).await)
+    }
+
+    async fn get_transaction_by_block_hash_and_index(
+        &self,
+        hash: &str,
+        index: usize,
+    ) -> Result<Option<Transaction>, Error> {
+        let hash = convert_err(hex_str_to_bytes(hash))?;
+        let node = self.node.read().await;
+        convert_err(
+            node.get_transaction_by_block_hash_and_index(&hash, index)
+                .await,
+        )
     }
 
     async fn get_logs(&self, filter: Filter) -> Result<Vec<Log>, Error> {

--- a/execution/src/execution.rs
+++ b/execution/src/execution.rs
@@ -184,18 +184,15 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         payload: &ExecutionPayload,
         index: usize,
     ) -> Result<Option<Transaction>> {
-
-
         let tx = payload.transactions[index].clone();
         let tx_hash = H256::from_slice(&keccak256(tx));
         let mut payloads = BTreeMap::new();
         payloads.insert(payload.block_number, payload.clone());
         let tx_option = self.get_transaction(&tx_hash, &payloads).await?;
         let tx = tx_option.ok_or(eyre::eyre!("not reachable"))?;
-    
-        Ok(Some(tx))
 
-    }    
+        Ok(Some(tx))
+    }
 
     pub async fn get_transaction_receipt(
         &self,
@@ -248,7 +245,6 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         hash: &H256,
         payloads: &BTreeMap<u64, ExecutionPayload>,
     ) -> Result<Option<Transaction>> {
-        
         let tx = self.rpc.get_transaction(hash).await?;
         if tx.is_none() {
             return Ok(None);

--- a/execution/src/execution.rs
+++ b/execution/src/execution.rs
@@ -179,6 +179,24 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         })
     }
 
+    pub async fn get_transaction_by_block_hash_and_index(
+        &self,
+        payload: &ExecutionPayload,
+        index: usize,
+    ) -> Result<Option<Transaction>> {
+
+
+        let tx = payload.transactions[index].clone();
+        let tx_hash = H256::from_slice(&keccak256(tx));
+        let mut payloads = BTreeMap::new();
+        payloads.insert(payload.block_number, payload.clone());
+        let tx_option = self.get_transaction(&tx_hash, &payloads).await?;
+        let tx = tx_option.ok_or(eyre::eyre!("not reachable"))?;
+    
+        Ok(Some(tx))
+
+    }    
+
     pub async fn get_transaction_receipt(
         &self,
         tx_hash: &H256,
@@ -230,6 +248,7 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         hash: &H256,
         payloads: &BTreeMap<u64, ExecutionPayload>,
     ) -> Result<Option<Transaction>> {
+        
         let tx = self.rpc.get_transaction(hash).await?;
         if tx.is_none() {
             return Ok(None);
@@ -260,7 +279,6 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         if !txs_encoded.contains(&tx_encoded) {
             return Err(ExecutionError::MissingTransaction(hash.to_string()).into());
         }
-
         Ok(Some(tx))
     }
 

--- a/execution/tests/execution.rs
+++ b/execution/tests/execution.rs
@@ -208,13 +208,15 @@ async fn test_get_tx_by_block_hash_and_index() {
         H256::from_str("2dac1b27ab58b493f902dda8b63979a112398d747f1761c0891777c0983e591f").unwrap();
 
     let mut payload = ExecutionPayload {
-            block_number: 7530933,
-            ..ExecutionPayload::default()
-        };
+        block_number: 7530933,
+        ..ExecutionPayload::default()
+    };
     payload.transactions.push(List::from_iter(hex_str_to_bytes("0x02f8b20583623355849502f900849502f91082ea6094326c977e6efc84e512bb9c30f76e30c160ed06fb80b844a9059cbb0000000000000000000000007daccf9b3c1ae2fa5c55f1c978aeef700bc83be0000000000000000000000000000000000000000000000001158e460913d00000c080a0e1445466b058b6f883c0222f1b1f3e2ad9bee7b5f688813d86e3fa8f93aa868ca0786d6e7f3aefa8fe73857c65c32e4884d8ba38d0ecfb947fbffb82e8ee80c167").unwrap()));
 
-
-    let tx = execution.get_transaction_by_block_hash_and_index(&payload, 0).await.unwrap().unwrap();
+    let tx = execution
+        .get_transaction_by_block_hash_and_index(&payload, 0)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(tx.hash(), tx_hash);
-
 }

--- a/execution/tests/execution.rs
+++ b/execution/tests/execution.rs
@@ -200,3 +200,21 @@ async fn test_get_block() {
 
     assert_eq!(block.number, 12345);
 }
+
+#[tokio::test]
+async fn test_get_tx_by_block_hash_and_index() {
+    let execution = get_client();
+    let tx_hash =
+        H256::from_str("2dac1b27ab58b493f902dda8b63979a112398d747f1761c0891777c0983e591f").unwrap();
+
+    let mut payload = ExecutionPayload {
+            block_number: 7530933,
+            ..ExecutionPayload::default()
+        };
+    payload.transactions.push(List::from_iter(hex_str_to_bytes("0x02f8b20583623355849502f900849502f91082ea6094326c977e6efc84e512bb9c30f76e30c160ed06fb80b844a9059cbb0000000000000000000000007daccf9b3c1ae2fa5c55f1c978aeef700bc83be0000000000000000000000000000000000000000000000001158e460913d00000c080a0e1445466b058b6f883c0222f1b1f3e2ad9bee7b5f688813d86e3fa8f93aa868ca0786d6e7f3aefa8fe73857c65c32e4884d8ba38d0ecfb947fbffb82e8ee80c167").unwrap()));
+
+
+    let tx = execution.get_transaction_by_block_hash_and_index(&payload, 0).await.unwrap().unwrap();
+    assert_eq!(tx.hash(), tx_hash);
+
+}


### PR DESCRIPTION
- Add get_transaction_by_block_hash_and_index to client
- Add the same function in node, which calls execution's version of it (get_transaction_by_block_hash_and_index) 
 OBS: Decided to implement on execution level and use block data from payload and get_transaction from rpc's
- Implement this new RPC method on RpcInner (the server) by calling into Client::getTransactionByBlockHashAndIndex()
- Added a test for this functionality in execution/tests/execution.rs

Issue: #151 