### PR TITLE
Reduce Binary Size to 5.3mb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,13 @@ plotters = "0.3.3"
 tempfile = "3.3.0"
 hex = "0.4.3"
 
+[profile.release]
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
+
 ######################################
 # Examples
 ######################################

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Helios is a fully trustless, efficient, and portable Ethereum light client writt
 
 Helios converts an untrusted centralized RPC endpoint into a safe unmanipulable local RPC for its users. It syncs in seconds, requires no storage, and is lightweight enough to run on mobile devices.
 
-The entire size of Helios's binary is 13Mb and should be easy to compile into WebAssembly. This makes it a perfect target to embed directly inside wallets and dapps.
+The entire size of Helios's binary is 5.3Mb and should be easy to compile into WebAssembly. This makes it a perfect target to embed directly inside wallets and dapps.
 
 ## Installing
 


### PR DESCRIPTION
Using some compiler options I managed to reduce the binary to 5.3MB. I consider the tradeoff for helios strictly in favor of size, as it's greatly increases the accessibility of the light client for it to be embedded in webpages and such. 

With the nightly feature `panic_immediate_abort` the binary size can be further reduced and cut out some more panic string formatting. This provides a nice baseline for further size optimizations. 