### PR TITLE
feat : add eth_getTransactionCount implementation

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -398,6 +398,14 @@ impl<DB: Database> Client<DB> {
         self.node.read().await.get_logs(filter).await
     }
 
+    pub async fn get_transaction_count(&self, address: &Address, block: BlockTag) -> Result<U256> {
+        self.node
+            .read()
+            .await
+            .get_transaction_count(address, block)
+            .await
+    }
+
     pub async fn get_gas_price(&self) -> Result<U256> {
         self.node.read().await.get_gas_price()
     }

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -233,6 +233,15 @@ impl Node {
         self.execution.get_logs(filter, &self.payloads).await
     }
 
+    pub async fn get_transaction_count(&self, address: &Address, block: BlockTag) -> Result<U256> {
+        self.check_blocktag_age(&block)?;
+
+        let payload = self.get_payload(block)?;
+        self.execution
+            .get_transaction_count(address, payload.block_number)
+            .await
+    }
+
     // assumes tip of 1 gwei to prevent having to prove out every tx in the block
     pub fn get_gas_price(&self) -> Result<U256> {
         self.check_head_age()?;

--- a/execution/src/execution.rs
+++ b/execution/src/execution.rs
@@ -119,6 +119,10 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         self.rpc.send_raw_transaction(bytes).await
     }
 
+    pub async fn get_transaction_count(&self, address: &Address, block: u64) -> Result<U256> {
+        self.rpc.get_transaction_count(address, block).await
+    }
+
     pub async fn get_block(
         &self,
         payload: &ExecutionPayload,

--- a/execution/src/rpc/http_rpc.rs
+++ b/execution/src/rpc/http_rpc.rs
@@ -128,4 +128,12 @@ impl ExecutionRpc for HttpRpc {
             .await
             .map_err(|e| RpcError::new("get_logs", e))?)
     }
+
+    async fn get_transaction_count(&self, address: &Address, block: u64) -> Result<U256> {
+        Ok(self
+            .provider
+            .get_transaction_count(*address, Some(BlockId::from(block)))
+            .await
+            .map_err(|e| RpcError::new("get_transaction_count", e))?)
+    }
 }

--- a/execution/src/rpc/mock_rpc.rs
+++ b/execution/src/rpc/mock_rpc.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use common::utils::hex_str_to_bytes;
 use ethers::types::{
     transaction::eip2930::AccessList, Address, EIP1186ProofResponse, Filter, Log, Transaction,
-    TransactionReceipt, H256,
+    TransactionReceipt, H256, U256,
 };
 use eyre::{eyre, Result};
 
@@ -60,5 +60,9 @@ impl ExecutionRpc for MockRpc {
     async fn get_logs(&self, _filter: &Filter) -> Result<Vec<Log>> {
         let logs = read_to_string(self.path.join("logs.json"))?;
         Ok(serde_json::from_str(&logs)?)
+    }
+
+    async fn get_transaction_count(&self, _address: &Address, _block: u64) -> Result<U256> {
+        Ok(U256::from_str_radix("123", 16).unwrap())
     }
 }

--- a/execution/src/rpc/mod.rs
+++ b/execution/src/rpc/mod.rs
@@ -1,11 +1,10 @@
+use crate::types::CallOpts;
 use async_trait::async_trait;
 use ethers::types::{
     transaction::eip2930::AccessList, Address, EIP1186ProofResponse, Filter, Log, Transaction,
-    TransactionReceipt, H256,
+    TransactionReceipt, H256, U256,
 };
 use eyre::Result;
-
-use crate::types::CallOpts;
 
 pub mod http_rpc;
 pub mod mock_rpc;
@@ -26,6 +25,7 @@ pub trait ExecutionRpc: Send + Clone + Sync + 'static {
     async fn create_access_list(&self, opts: &CallOpts, block: u64) -> Result<AccessList>;
     async fn get_code(&self, address: &Address, block: u64) -> Result<Vec<u8>>;
     async fn send_raw_transaction(&self, bytes: &[u8]) -> Result<H256>;
+    async fn get_transaction_count(&self, address: &Address, block: u64) -> Result<U256>;
     async fn get_transaction_receipt(&self, tx_hash: &H256) -> Result<Option<TransactionReceipt>>;
     async fn get_transaction(&self, tx_hash: &H256) -> Result<Option<Transaction>>;
     async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>>;

--- a/execution/tests/execution.rs
+++ b/execution/tests/execution.rs
@@ -220,3 +220,20 @@ async fn test_get_tx_by_block_hash_and_index() {
         .unwrap();
     assert_eq!(tx.hash(), tx_hash);
 }
+
+#[tokio::test]
+async fn test_get_transaction_count() {
+    let execution = get_client();
+    let address = Address::from_str("14f9D4aF749609c1438528C0Cce1cC3f6D411c47").unwrap();
+    let payload = ExecutionPayload {
+        block_number: 12345,
+        ..ExecutionPayload::default()
+    };
+
+    let tx_count = execution
+        .get_transaction_count(&address, payload.block_number)
+        .await
+        .unwrap();
+
+    assert_eq!(tx_count, U256::from_str_radix("123", 16).unwrap());
+}


### PR DESCRIPTION
Hello, this pr implements the following

-  Add get_transaction_count to client
-  Add the same function in node, which calls ExecutionClient
-  Implement this RPC method on ExecutionRPC which calls the provider that sends a request to the `eth_getTransactionCount` endpoint
-  Added a test for this functionality in execution/tests/execution.rs
