### PR TITLE
fix: specify precise nightly version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2023-01-23


### PR DESCRIPTION
Today seems as good a day as any. This will cause reinstallation of the nightly tool chain, and cache misses on first build. I have built locally and run cargo fmt using this toolchain file.