### PR TITLE
fix: check checkpoint file exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "cli"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "clap",
  "client",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "common",
  "config",
@@ -646,7 +646,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "common"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "common",
  "ethers",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "consensus"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1451,7 +1451,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "execution"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1964,7 +1964,7 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "helios"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "client",
  "common",

--- a/client/src/database.rs
+++ b/client/src/database.rs
@@ -50,14 +50,14 @@ impl Database for FileDB {
     }
 
     fn load_checkpoint(&self) -> Result<Vec<u8>> {
-        let mut f = fs::OpenOptions::new()
-            .read(true)
-            .open(self.data_dir.join("checkpoint"))?;
-
         let mut buf = Vec::new();
-        f.read_to_end(&mut buf)?;
 
-        if buf.len() == 32 {
+        let res = fs::OpenOptions::new()
+            .read(true)
+            .open(self.data_dir.join("checkpoint"))
+            .map(|mut f| f.read_to_end(&mut buf));
+
+        if buf.len() == 32 && res.is_ok() {
             Ok(buf)
         } else {
             Ok(self.default_checkpoint.clone())


### PR DESCRIPTION
Fixes regression introduced in #182 where `FileDB` fails to load checkpoint if checkpoint file does not exist.