### PR TITLE
fix: handle checkpoint overrides correctly

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -260,7 +260,7 @@ impl<DB: Database> Client<DB> {
                         warn!(
                             "failed to sync consensus node with checkpoint: 0x{}",
                             hex::encode(
-                                &self
+                                self
                                     .node
                                     .read()
                                     .await

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -260,8 +260,7 @@ impl<DB: Database> Client<DB> {
                         warn!(
                             "failed to sync consensus node with checkpoint: 0x{}",
                             hex::encode(
-                                self
-                                    .node
+                                self.node
                                     .read()
                                     .await
                                     .config

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -226,8 +226,6 @@ impl<DB: Database> Client<DB> {
         if config.checkpoint.is_none() {
             let checkpoint = db.load_checkpoint()?;
             config.checkpoint = Some(checkpoint);
-        } else {
-            config.checkpoint = Some(config.default_checkpoint.clone());
         }
 
         let config = Arc::new(config);
@@ -261,7 +259,16 @@ impl<DB: Database> Client<DB> {
                     ConsensusError::CheckpointTooOld => {
                         warn!(
                             "failed to sync consensus node with checkpoint: 0x{}",
-                            hex::encode(&self.node.read().await.config.checkpoint.clone().unwrap_or_default()),
+                            hex::encode(
+                                &self
+                                    .node
+                                    .read()
+                                    .await
+                                    .config
+                                    .checkpoint
+                                    .clone()
+                                    .unwrap_or_default()
+                            ),
                         );
 
                         let fallback = self.boot_from_fallback().await;

--- a/client/src/database.rs
+++ b/client/src/database.rs
@@ -28,7 +28,7 @@ impl Database for FileDB {
         if let Some(data_dir) = &config.data_dir {
             return Ok(FileDB {
                 data_dir: data_dir.to_path_buf(),
-                default_checkpoint: config.checkpoint.clone(),
+                default_checkpoint: config.default_checkpoint.clone(),
             });
         }
 
@@ -72,7 +72,7 @@ pub struct ConfigDB {
 impl Database for ConfigDB {
     fn new(config: &Config) -> Result<Self> {
         Ok(Self {
-            checkpoint: config.checkpoint.clone(),
+            checkpoint: config.checkpoint.clone().unwrap_or(config.default_checkpoint.clone()),
         })
     }
 

--- a/client/src/database.rs
+++ b/client/src/database.rs
@@ -72,7 +72,10 @@ pub struct ConfigDB {
 impl Database for ConfigDB {
     fn new(config: &Config) -> Result<Self> {
         Ok(Self {
-            checkpoint: config.checkpoint.clone().unwrap_or(config.default_checkpoint.clone()),
+            checkpoint: config
+                .checkpoint
+                .clone()
+                .unwrap_or(config.default_checkpoint.clone()),
         })
     }
 

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -31,7 +31,7 @@ pub struct Node {
 impl Node {
     pub fn new(config: Arc<Config>) -> Result<Self, NodeError> {
         let consensus_rpc = &config.consensus_rpc;
-        let checkpoint_hash = &config.checkpoint;
+        let checkpoint_hash = &config.checkpoint.as_ref().unwrap();
         let execution_rpc = &config.execution_rpc;
 
         let consensus = ConsensusClient::new(consensus_rpc, checkpoint_hash, config.clone())

--- a/config/src/base.rs
+++ b/config/src/base.rs
@@ -12,7 +12,7 @@ pub struct BaseConfig {
         deserialize_with = "bytes_deserialize",
         serialize_with = "bytes_serialize"
     )]
-    pub checkpoint: Vec<u8>,
+    pub default_checkpoint: Vec<u8>,
     pub chain: ChainConfig,
     pub forks: Forks,
     pub max_checkpoint_age: u64,

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -2,26 +2,25 @@ use figment::{
     providers::{Format, Serialized, Toml},
     Figment,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::{path::PathBuf, process::exit};
 
 use crate::base::BaseConfig;
 use crate::cli::CliConfig;
 use crate::networks;
 use crate::types::{ChainConfig, Forks};
-use crate::utils::{bytes_deserialize, bytes_serialize};
+use crate::utils::{bytes_deserialize, bytes_opt_deserialize};
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default)]
 pub struct Config {
     pub consensus_rpc: String,
     pub execution_rpc: String,
     pub rpc_port: Option<u16>,
-    #[serde(
-        deserialize_with = "bytes_deserialize",
-        serialize_with = "bytes_serialize"
-    )]
+    #[serde(deserialize_with = "bytes_deserialize")]
     pub default_checkpoint: Vec<u8>,
-    pub checkpoint:  Option<Vec<u8>>,
+    #[serde(default)]
+    #[serde(deserialize_with = "bytes_opt_deserialize")]
+    pub checkpoint: Option<Vec<u8>>,
     pub data_dir: Option<PathBuf>,
     pub chain: ChainConfig,
     pub forks: Forks,

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -20,7 +20,8 @@ pub struct Config {
         deserialize_with = "bytes_deserialize",
         serialize_with = "bytes_serialize"
     )]
-    pub checkpoint: Vec<u8>,
+    pub default_checkpoint: Vec<u8>,
+    pub checkpoint:  Option<Vec<u8>>,
     pub data_dir: Option<PathBuf>,
     pub chain: ChainConfig,
     pub forks: Forks,
@@ -86,7 +87,7 @@ impl Config {
         BaseConfig {
             rpc_port: self.rpc_port.unwrap_or(8545),
             consensus_rpc: Some(self.consensus_rpc.clone()),
-            checkpoint: self.checkpoint.clone(),
+            default_checkpoint: self.default_checkpoint.clone(),
             chain: self.chain.clone(),
             forks: self.forks.clone(),
             max_checkpoint_age: self.max_checkpoint_age,

--- a/config/src/networks.rs
+++ b/config/src/networks.rs
@@ -35,7 +35,7 @@ impl Network {
 
 pub fn mainnet() -> BaseConfig {
     BaseConfig {
-        checkpoint: hex_str_to_bytes(
+        default_checkpoint: hex_str_to_bytes(
             "0x766647f3c4e1fc91c0db9a9374032ae038778411fbff222974e11f2e3ce7dadf",
         )
         .unwrap(),
@@ -69,7 +69,7 @@ pub fn mainnet() -> BaseConfig {
 
 pub fn goerli() -> BaseConfig {
     BaseConfig {
-        checkpoint: hex_str_to_bytes(
+        default_checkpoint: hex_str_to_bytes(
             "0xd4344682866dbede543395ecf5adf9443a27f423a4b00f270458e7932686ced1",
         )
         .unwrap(),

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -15,3 +15,15 @@ where
     let bytes_string = hex::encode(bytes);
     serializer.serialize_str(&bytes_string)
 }
+
+pub fn bytes_opt_deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let bytes_opt: Option<String> = serde::Deserialize::deserialize(deserializer)?;
+    if let Some(bytes) = bytes_opt {
+        Ok(Some(hex_str_to_bytes(&bytes).unwrap()))
+    } else {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
Fixes a regression introduced in #182 where manually specified checkpoints were prioritized less than those fetched by the db.