### PR TITLE
Fix: Optional CallOpts Recipient

### DIFF
--- a/execution/src/evm.rs
+++ b/execution/src/evm.rs
@@ -131,7 +131,7 @@ impl<'a, R: ExecutionRpc> Evm<'a, R> {
         };
 
         let to_access_entry = AccessListItem {
-            address: opts_moved.to,
+            address: opts_moved.to.unwrap_or_default(),
             storage_keys: Vec::default(),
         };
 
@@ -172,7 +172,7 @@ impl<'a, R: ExecutionRpc> Evm<'a, R> {
         let mut env = Env::default();
         let payload = &self.evm.db.as_ref().unwrap().current_payload;
 
-        env.tx.transact_to = TransactTo::Call(opts.to);
+        env.tx.transact_to = TransactTo::Call(opts.to.unwrap_or_default());
         env.tx.caller = opts.from.unwrap_or(Address::zero());
         env.tx.value = opts.value.unwrap_or(U256::from(0));
         env.tx.data = Bytes::from(opts.data.clone().unwrap_or_default());

--- a/execution/src/rpc/http_rpc.rs
+++ b/execution/src/rpc/http_rpc.rs
@@ -63,7 +63,7 @@ impl ExecutionRpc for HttpRpc {
         let block = Some(BlockId::from(block));
 
         let mut raw_tx = Eip1559TransactionRequest::new();
-        raw_tx.to = Some(opts.to.into());
+        raw_tx.to = Some(opts.to.unwrap_or_default().into());
         raw_tx.from = opts.from;
         raw_tx.value = opts.value;
         raw_tx.gas = Some(opts.gas.unwrap_or(U256::from(100_000_000)));

--- a/execution/src/types.rs
+++ b/execution/src/types.rs
@@ -64,7 +64,7 @@ pub enum Transactions {
 #[serde(rename_all = "camelCase")]
 pub struct CallOpts {
     pub from: Option<Address>,
-    pub to: Address,
+    pub to: Option<Address>,
     pub gas: Option<U256>,
     pub gas_price: Option<U256>,
     pub value: Option<U256>,
@@ -90,7 +90,7 @@ where
     let bytes: Option<String> = serde::Deserialize::deserialize(deserializer)?;
     match bytes {
         Some(bytes) => {
-            let bytes = hex::decode(bytes.strip_prefix("0x").unwrap()).unwrap();
+            let bytes = hex::decode(bytes.strip_prefix("0x").unwrap_or("")).unwrap_or_default();
             Ok(Some(bytes.to_vec()))
         }
         None => Ok(None),


### PR DESCRIPTION
**Overview**

Fixes #206 and #205

Marks `CallOpts` `to` field as optional and gracefully handles deserialization for data bytes.