### PR TITLE
fix(execution/evm): evm panic on slot not found

### DIFF
--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -1,3 +1,4 @@
+use ethers::types::H256;
 use thiserror::Error;
 
 use crate::types::BlockTag;
@@ -11,6 +12,18 @@ pub struct BlockNotFoundError {
 impl BlockNotFoundError {
     pub fn new(block: BlockTag) -> Self {
         Self { block }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("slot not found: {slot:?}")]
+pub struct SlotNotFoundError {
+    slot: H256,
+}
+
+impl SlotNotFoundError {
+    pub fn new(slot: H256) -> Self {
+        Self { slot }
     }
 }
 


### PR DESCRIPTION
**Overview**

Attempts to address #153 

Inside a `storage` call to the `ProofDB`, unwraps were being performed for slot queries. This pr introduces a new error type to gracefully bubble up failed storage reads: `SlotNotFoundError`.