### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helios"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 autobenches = false
 exclude = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["different-binary-name"]
 
 [package]
 name = "cli"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "config"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "consensus"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/execution/Cargo.toml
+++ b/execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "execution"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Cutting a new minor version for Capella support. We will need to cut one more version before mainnet though since the fork epoch has yet to be announced. In the meantime, this version supports goerli.