### PR TITLE
chore: bump to version 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "clap",
  "client",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "common",
  "config",
@@ -654,7 +654,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "common"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "common",
  "ethers",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "consensus"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1705,7 +1705,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "execution"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2233,7 +2233,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "helios"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "client",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helios"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 autobenches = false
 exclude = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["different-binary-name"]
 
 [package]
 name = "cli"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 [[bin]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "config"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "consensus"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/execution/Cargo.toml
+++ b/execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "execution"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
#222 bumps ethers to `2.0.2` which is a major version increase. Since ethers types are used in Helios's public interfaces, this is a breaking change. We should bump the minor version here to reflect that.