### PR TITLE
feat: save checkpoint after sync

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -397,9 +397,10 @@ impl<DB: Database> Client<DB> {
     /// Saves last checkpoint of the node.
     async fn save_last_checkpoint(&self) {
         let node = self.node.read().await;
-        let _checkpoint = if let Some(_checkpoint) = node.get_last_checkpoint() {
+
+        if let Some(checkpoint) = node.get_last_checkpoint() {
             info!("saving last checkpoint hash");
-            let res = self.db.save_checkpoint(_checkpoint);
+            let res = self.db.save_checkpoint(checkpoint);
             if res.is_err() {
                 warn!("checkpoint save failed");
             }


### PR DESCRIPTION
The last checkpoint of the node is only saved on `shutdown` from what I have seen.
But for some applications, like Beerus for instance, we are not always stopped gracefully. Which makes us always sync and we never have checkpoint saved into the `data_dir`.

In this PR, I refactorized the save checkpoint logic in the client into a function `save_last_checkpoint`. This function is called in `shutdown` as before, and after the sync with the node. I am not sure about the side effect of this, but this is working fine for us at this moment.

I kept this function private, but there are side effects I don't see and you do, I can propose:

1. Remove the call to `save_last_checkpoint` I made.
2. Make `save_last_checkpoint` public to let the library user decides when to save the checkpoint? Or there is too much internal logic involved, and we will then consider applying hook on signals to have `shutdown` called correctly anyway.

Thank you very much, and please let me know if some side effects are hidden, to better understand what's going on.