### PR TITLE
fix: use thread instead of tokio when compiled for wasm32

### DIFF
--- a/execution/src/evm.rs
+++ b/execution/src/evm.rs
@@ -24,9 +24,6 @@ use consensus::types::ExecutionPayload;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::task::spawn_blocking;
 
-#[cfg(target_arch = "wasm32")]
-use std::thread;
-
 use crate::{
     constants::PARALLEL_QUERY_BATCH_SIZE,
     errors::EvmError,
@@ -244,12 +241,8 @@ impl<'a, R: ExecutionRpc> ProofDB<'a, R> {
         let payload = self.current_payload.clone();
         let slots = slots.to_owned();
 
-        let handle = thread::spawn(move || {
-            let account_fut = execution.get_account(&address, Some(&slots), &payload);
-            block_on(account_fut)
-        });
-
-        handle.join().unwrap()
+        let account_fut = execution.get_account(&address, Some(&slots), &payload);
+        block_on(account_fut)
     }
 }
 


### PR DESCRIPTION
As mentioned in the issue #226, it seems to have a regression for wasm32. At least, in beerus when we compile helios as a dependency for wasm32, we had it working fine. But since the commit mentioned in the issue, it's no longer possible due to the fix made with `tokio` in the `evm.rs` from `execution`.

The error we have is `use of undefined crate or module tokio` at `evm.rs:23:5`, which is `use tokio::task::spawn_blocking`.

Here is a proposition, but I don't know the value of it. Hopefully this is something useful, if not, do not hesitate to tell me and I'll close the PR.

What may be an alternative to that PR then?