### PR TITLE
feat: adding support for 32-bit ARM architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,3 +165,51 @@ jobs:
             helios_linux_amd64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-linux-armv7:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: install rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          default: true
+          override: true
+
+      - name: install target
+        run: rustup target add armv7-unknown-linux-gnueabihf
+
+      - name: install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gcc-arm-linux-gnueabihf
+          echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+          ldd --version
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "fresh2"
+
+      - name: build
+        run: cargo build --package cli --release --target armv7-unknown-linux-gnueabihf
+
+      - name: archive
+        run: tar -czvf "helios_linux_armv7.tar.gz" -C ./target/armv7-unknown-linux-gnueabihf/release helios
+
+      - name: generate tag name
+        id: tag
+        run: |
+          echo "::set-output name=release_tag::nightly-${GITHUB_SHA}"
+
+      - name: release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.tag.outputs.release_tag }}
+          prerelease: true
+          files: |
+            helios_linux_armv7.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/heliosup/heliosup
+++ b/heliosup/heliosup
@@ -36,7 +36,9 @@ if [ "${ARCHITECTURE}" = "x86_64" ]; then
     ARCHITECTURE="amd64" # Intel.
   fi
 elif [ "${ARCHITECTURE}" = "arm64" ] ||[ "${ARCHITECTURE}" = "aarch64" ] ; then
-  ARCHITECTURE="arm64" # Arm.
+  ARCHITECTURE="arm64" # 64-bit Arm.
+elif [ "${ARCHITECTURE}" = "armv7l" ]; then
+  ARCHITECTURE="armv7l" # 32-bit Arm.
 else
   ARCHITECTURE="amd64" # Amd.
 fi


### PR DESCRIPTION
This PR adds a new build target for the release workflow targeting `armv7l`. This is the standard architecture for all non-64 bit Raspberry Pis, and other microcomputers.

This build was tested against a Raspberry Pi running Raspberry Pi OS (fka Raspbian) Bullseye. 

Note that very old Raspberry Pis may be running Raspbian Buster (the older version of the OS), and targeting them is possible when the version of `GLIBC` the builder VM is running is `2.28` (tested by building locally with `cross-rs` and run on Raspbian Buster). This would require a self-hosted runner for Github Actions, as the oldest version of Ubuntu that GA supports out of the box is 20.02, which is being used here.

If your Raspberry Pi is using Buster (check using `cat /etc/os-release`), consider upgrading to Bullseye with the [Imager](https://www.raspberrypi.com/software/) or in-place like [this](https://www.makeuseof.com/tag/raspberry-pi-update-raspbian-os).

This PR also includes modifications to `heliosup` to properly target `armv7l`.
