### PR TITLE
Avoid unnecessary clone in NimbusRPC's `get_updates`

### DIFF
--- a/consensus/src/rpc/nimbus_rpc.rs
+++ b/consensus/src/rpc/nimbus_rpc.rs
@@ -58,7 +58,7 @@ impl ConsensusRpc for NimbusRpc {
             .await
             .map_err(|e| RpcError::new("updates", e))?;
 
-        Ok(res.iter().map(|d| d.data.clone()).collect())
+        Ok(res.into_iter().map(|d| d.data).collect())
     }
 
     async fn get_finality_update(&self) -> Result<FinalityUpdate> {


### PR DESCRIPTION
https://github.com/a16z/helios/blob/6bc43bd81b325c3f637714d79401b4420a437839/consensus/src/rpc/nimbus_rpc.rs#L52-L61
Since we have the ownership of the response, we can simply consume it instead of cloning.