### PR TITLE
feat(rpc): Add filter rpc endpoints

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -310,6 +310,26 @@ impl Client {
         self.node.get_logs(filter).await
     }
 
+    pub async fn get_filter_changes(&self, filter_id: &U256) -> Result<bool> {
+        self.node.uninstall_filter(filter_id).await
+    }
+
+    pub async fn uninstall_filter(&self, filter_id: &U256) -> Result<bool> {
+        self.node.uninstall_filter(filter_id).await
+    }
+
+    pub async fn get_new_filter(&self, filter: &Filter) -> Result<U256> {
+        self.node.get_new_filter(filter).await
+    }
+
+    pub async fn get_new_block_filter(&self) -> Result<U256> {
+        self.node.get_new_block_filter().await
+    }
+
+    pub async fn get_new_pending_transaction_filter(&self) -> Result<U256> {
+        self.node.get_new_pending_transaction_filter().await
+    }
+
     pub async fn get_gas_price(&self) -> Result<U256> {
         self.node.get_gas_price().await
     }

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -163,6 +163,26 @@ impl Node {
         self.execution.get_logs(filter).await
     }
 
+    pub async fn get_filter_changes(&self, filter_id: &U256) -> Result<Vec<Log>> {
+        self.execution.get_filter_changes(filter_id).await
+    }
+
+    pub async fn uninstall_filter(&self, filter_id: &U256) -> Result<bool> {
+        self.execution.uninstall_filter(filter_id).await
+    }
+
+    pub async fn get_new_filter(&self, filter: &Filter) -> Result<U256> {
+        self.execution.get_new_filter(filter).await
+    }
+
+    pub async fn get_new_block_filter(&self) -> Result<U256> {
+        self.execution.get_new_block_filter().await
+    }
+
+    pub async fn get_new_pending_transaction_filter(&self) -> Result<U256> {
+        self.execution.get_new_pending_transaction_filter().await
+    }
+
     // assumes tip of 1 gwei to prevent having to prove out every tx in the block
     pub async fn get_gas_price(&self) -> Result<U256> {
         self.check_head_age().await?;

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -105,6 +105,16 @@ trait EthRpc {
     ) -> Result<Option<Transaction>, Error>;
     #[method(name = "getLogs")]
     async fn get_logs(&self, filter: Filter) -> Result<Vec<Log>, Error>;
+    #[method(name = "getFilterChanges")]
+    async fn get_filter_changes(&self, filter_id: U256) -> Result<Vec<Log>, Error>;
+    #[method(name = "uninstallFilter")]
+    async fn uninstall_filter(&self, filter_id: U256) -> Result<bool, Error>;
+    #[method(name = "getNewFilter")]
+    async fn get_new_filter(&self, filter: Filter) -> Result<U256, Error>;
+    #[method(name = "getNewBlockFilter")]
+    async fn get_new_block_filter(&self) -> Result<U256, Error>;
+    #[method(name = "getNewPendingTransactionFilter")]
+    async fn get_new_pending_transaction_filter(&self) -> Result<U256, Error>;
     #[method(name = "getStorageAt")]
     async fn get_storage_at(
         &self,
@@ -261,6 +271,26 @@ impl EthRpcServer for RpcInner {
 
     async fn get_logs(&self, filter: Filter) -> Result<Vec<Log>, Error> {
         convert_err(self.node.get_logs(&filter).await)
+    }
+
+    async fn get_filter_changes(&self, filter_id: U256) -> Result<Vec<Log>, Error> {
+        convert_err(self.node.get_filter_changes(&filter_id).await)
+    }
+
+    async fn uninstall_filter(&self, filter_id: U256) -> Result<bool, Error> {
+        convert_err(self.node.uninstall_filter(&filter_id).await)
+    }
+
+    async fn get_new_filter(&self, filter: Filter) -> Result<U256, Error> {
+        convert_err(self.node.get_new_filter(&filter).await)
+    }
+
+    async fn get_new_block_filter(&self) -> Result<U256, Error> {
+        convert_err(self.node.get_new_block_filter().await)
+    }
+
+    async fn get_new_pending_transaction_filter(&self) -> Result<U256, Error> {
+        convert_err(self.node.get_new_pending_transaction_filter().await)
     }
 
     async fn get_storage_at(

--- a/execution/src/execution.rs
+++ b/execution/src/execution.rs
@@ -241,10 +241,7 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         Ok(logs)
     }
 
-       pub async fn get_filter_changes(
-        &self, 
-        filter_id: &U256,
-    ) -> Result<Vec<Log>> {
+    pub async fn get_filter_changes(&self, filter_id: &U256) -> Result<Vec<Log>> {
         let logs = self.rpc.get_filter_changes(filter_id).await?;
         if logs.len() > MAX_SUPPORTED_LOGS_NUMBER {
             return Err(
@@ -259,10 +256,7 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         self.rpc.uninstall_filter(filter_id).await
     }
 
-    pub async fn get_new_filter(
-        &self, 
-        filter: &Filter,
-    ) -> Result<U256> {
+    pub async fn get_new_filter(&self, filter: &Filter) -> Result<U256> {
         let filter = filter.clone();
 
         // avoid submitting a filter for logs for a block helios hasn't seen yet
@@ -288,7 +282,7 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         self.rpc.get_new_pending_transaction_filter().await
     }
 
-    async fn verify_logs(&self, logs: &[Log]) -> Result<()>{
+    async fn verify_logs(&self, logs: &[Log]) -> Result<()> {
         for (_pos, log) in logs.iter().enumerate() {
             // For every log
             // Get the hash of the tx that generated it
@@ -322,7 +316,6 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
         Ok(())
     }
 }
-
 
 fn encode_receipt(receipt: &TransactionReceipt) -> Vec<u8> {
     let mut stream = RlpStream::new();

--- a/execution/src/execution.rs
+++ b/execution/src/execution.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use common::errors::BlockNotFoundError;
 use ethers::abi::AbiEncode;
 use ethers::prelude::Address;
-use ethers::types::{Filter, Log, Transaction, TransactionReceipt, H256};
+use ethers::types::{Filter, Log, Transaction, TransactionReceipt, H256, U256};
 use ethers::utils::keccak256;
 use ethers::utils::rlp::{encode, Encodable, RlpStream};
 use eyre::Result;
@@ -268,6 +268,83 @@ impl<R: ExecutionRpc> ExecutionClient<R> {
             }
         }
         Ok(logs)
+    }
+
+       pub async fn get_filter_changes(
+        &self, 
+        filter_id: &U256,
+    ) -> Result<Vec<Log>> {
+        let logs = self.rpc.get_filter_changes(&filter_id).await?;
+        if logs.len() > MAX_SUPPORTED_LOGS_NUMBER {
+            return Err(
+                ExecutionError::TooManyLogsToProve(logs.len(), MAX_SUPPORTED_LOGS_NUMBER).into(),
+            );
+        }
+
+        for (_pos, log) in logs.iter().enumerate() {
+            // For every log
+            // Get the hash of the tx that generated it
+            let tx_hash = log
+                .transaction_hash
+                .ok_or(eyre::eyre!("tx hash not found in log"))?;
+            // Get its proven receipt
+            let receipt = self
+                .get_transaction_receipt(&tx_hash)
+                .await?
+                .ok_or(ExecutionError::NoReceiptForTransaction(tx_hash.to_string()))?;
+
+            // Check if the receipt contains the desired log
+            // Encoding logs for comparison
+            let receipt_logs_encoded = receipt
+                .logs
+                .iter()
+                .map(|log| log.rlp_bytes())
+                .collect::<Vec<_>>();
+
+            let log_encoded = log.rlp_bytes();
+
+            if !receipt_logs_encoded.contains(&log_encoded) {
+                return Err(ExecutionError::MissingLog(
+                    tx_hash.to_string(),
+                    log.log_index.unwrap(),
+                )
+                .into());
+            }
+        }
+        Ok(logs)
+    }
+
+    pub async fn uninstall_filter(&self, filter_id: &U256) -> Result<bool> {
+        self.rpc.uninstall_filter(filter_id).await
+    }
+
+    pub async fn get_new_filter(
+        &self, 
+        filter: &Filter,
+    ) -> Result<U256> {
+        let filter = filter.clone();
+
+        // avoid submitting a filter for logs for a block helios hasn't seen yet
+        let filter = if filter.get_to_block().is_none() && filter.get_block_hash().is_none() {
+            let block = self.state.latest_block_number().await.unwrap();
+            let filter = filter.to_block(block);
+            if filter.get_from_block().is_none() {
+                filter.from_block(block)
+            } else {
+                filter
+            }
+        } else {
+            filter
+        };
+        self.rpc.get_new_filter(&filter).await
+    }
+
+    pub async fn get_new_block_filter(&self) -> Result<U256> {
+        self.rpc.get_new_block_filter().await
+    }
+
+    pub async fn get_new_pending_transaction_filter(&self) -> Result<U256> {
+        self.rpc.get_new_pending_transaction_filter().await
     }
 }
 

--- a/execution/src/rpc/http_rpc.rs
+++ b/execution/src/rpc/http_rpc.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use common::types::BlockTag;
 use ethers::prelude::{Address, Http};
-use ethers::providers::{HttpRateLimitRetryPolicy, Middleware, Provider, RetryClient};
+use ethers::providers::{HttpRateLimitRetryPolicy, Middleware, Provider, RetryClient, FilterKind};
 use ethers::types::transaction::eip2718::TypedTransaction;
 use ethers::types::transaction::eip2930::AccessList;
 use ethers::types::{
@@ -132,6 +132,26 @@ impl ExecutionRpc for HttpRpc {
             .get_logs(filter)
             .await
             .map_err(|e| RpcError::new("get_logs", e))?)
+    }
+
+    async fn get_filter_changes(&self, filter_id: &U256) -> Result<Vec<Log>> {
+        Ok(self.provider.get_filter_changes(filter_id).await.map_err(|e| RpcError::new("get_filter_changes", e))?)
+    }
+
+    async fn uninstall_filter(&self, filter_id: &U256) -> Result<bool> {
+        Ok(self.provider.uninstall_filter(filter_id).await.map_err(|e| RpcError::new("uninstall_filter", e))?)
+    }
+
+    async fn get_new_filter(&self, filter: &Filter) -> Result<U256> {
+        Ok(self.provider.new_filter(FilterKind::Logs(filter)).await.map_err(|e| RpcError::new("get_new_filter", e))?)
+    }
+
+    async fn get_new_block_filter(&self) -> Result<U256> {
+        Ok(self.provider.new_filter(FilterKind::NewBlocks).await.map_err(|e| RpcError::new("get_new_block_filter", e))?)
+    }
+
+    async fn get_new_pending_transaction_filter(&self) -> Result<U256> {
+        Ok(self.provider.new_filter(FilterKind::PendingTransactions).await.map_err(|e| RpcError::new("get_new_pending_transactions", e))?)
     }
 
     async fn chain_id(&self) -> Result<u64> {

--- a/execution/src/rpc/http_rpc.rs
+++ b/execution/src/rpc/http_rpc.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use common::types::BlockTag;
 use ethers::prelude::{Address, Http};
-use ethers::providers::{HttpRateLimitRetryPolicy, Middleware, Provider, RetryClient, FilterKind};
+use ethers::providers::{FilterKind, HttpRateLimitRetryPolicy, Middleware, Provider, RetryClient};
 use ethers::types::transaction::eip2718::TypedTransaction;
 use ethers::types::transaction::eip2930::AccessList;
 use ethers::types::{
@@ -135,23 +135,43 @@ impl ExecutionRpc for HttpRpc {
     }
 
     async fn get_filter_changes(&self, filter_id: &U256) -> Result<Vec<Log>> {
-        Ok(self.provider.get_filter_changes(filter_id).await.map_err(|e| RpcError::new("get_filter_changes", e))?)
+        Ok(self
+            .provider
+            .get_filter_changes(filter_id)
+            .await
+            .map_err(|e| RpcError::new("get_filter_changes", e))?)
     }
 
     async fn uninstall_filter(&self, filter_id: &U256) -> Result<bool> {
-        Ok(self.provider.uninstall_filter(filter_id).await.map_err(|e| RpcError::new("uninstall_filter", e))?)
+        Ok(self
+            .provider
+            .uninstall_filter(filter_id)
+            .await
+            .map_err(|e| RpcError::new("uninstall_filter", e))?)
     }
 
     async fn get_new_filter(&self, filter: &Filter) -> Result<U256> {
-        Ok(self.provider.new_filter(FilterKind::Logs(filter)).await.map_err(|e| RpcError::new("get_new_filter", e))?)
+        Ok(self
+            .provider
+            .new_filter(FilterKind::Logs(filter))
+            .await
+            .map_err(|e| RpcError::new("get_new_filter", e))?)
     }
 
     async fn get_new_block_filter(&self) -> Result<U256> {
-        Ok(self.provider.new_filter(FilterKind::NewBlocks).await.map_err(|e| RpcError::new("get_new_block_filter", e))?)
+        Ok(self
+            .provider
+            .new_filter(FilterKind::NewBlocks)
+            .await
+            .map_err(|e| RpcError::new("get_new_block_filter", e))?)
     }
 
     async fn get_new_pending_transaction_filter(&self) -> Result<U256> {
-        Ok(self.provider.new_filter(FilterKind::PendingTransactions).await.map_err(|e| RpcError::new("get_new_pending_transactions", e))?)
+        Ok(self
+            .provider
+            .new_filter(FilterKind::PendingTransactions)
+            .await
+            .map_err(|e| RpcError::new("get_new_pending_transactions", e))?)
     }
 
     async fn chain_id(&self) -> Result<u64> {

--- a/execution/src/rpc/mock_rpc.rs
+++ b/execution/src/rpc/mock_rpc.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use common::{types::BlockTag, utils::hex_str_to_bytes};
 use ethers::types::{
     transaction::eip2930::AccessList, Address, EIP1186ProofResponse, FeeHistory, Filter, Log,
-    Transaction, TransactionReceipt, H256,
+    Transaction, TransactionReceipt, H256, U256,
 };
 use eyre::{eyre, Result};
 
@@ -61,6 +61,27 @@ impl ExecutionRpc for MockRpc {
     async fn get_logs(&self, _filter: &Filter) -> Result<Vec<Log>> {
         let logs = read_to_string(self.path.join("logs.json"))?;
         Ok(serde_json::from_str(&logs)?)
+    }
+
+    async fn get_filter_changes(&self, _filter_id: &U256) -> Result<Vec<Log>> {
+        let logs = read_to_string(self.path.join("logs.json"))?;
+        Ok(serde_json::from_str(&logs)?)
+    }
+
+    async fn uninstall_filter(&self, _filter_id: &U256) -> Result<bool> {
+        Err(eyre!("not implemented"))
+    }
+
+    async fn get_new_filter(&self, _filter: &Filter) -> Result<U256> {
+        Err(eyre!("not implemented"))
+    }
+
+    async fn get_new_block_filter(&self) -> Result<U256> {
+        Err(eyre!("not implemented"))
+    }
+
+    async fn get_new_pending_transaction_filter(&self) -> Result<U256> {
+        Err(eyre!("not implemented"))
     }
 
     async fn chain_id(&self) -> Result<u64> {

--- a/execution/src/rpc/mod.rs
+++ b/execution/src/rpc/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use common::types::BlockTag;
 use ethers::types::{
     transaction::eip2930::AccessList, Address, EIP1186ProofResponse, FeeHistory, Filter, Log,
-    Transaction, TransactionReceipt, H256,
+    Transaction, TransactionReceipt, H256, U256,
 };
 use eyre::Result;
 
@@ -31,6 +31,11 @@ pub trait ExecutionRpc: Send + Clone + Sync + 'static {
     async fn get_transaction_receipt(&self, tx_hash: &H256) -> Result<Option<TransactionReceipt>>;
     async fn get_transaction(&self, tx_hash: &H256) -> Result<Option<Transaction>>;
     async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>>;
+    async fn get_filter_changes(&self, filter_id: &U256) -> Result<Vec<Log>>;
+    async fn uninstall_filter(&self, filter_id: &U256) -> Result<bool>;
+    async fn get_new_filter(&self, filter: &Filter) -> Result<U256>;
+    async fn get_new_block_filter(&self) -> Result<U256>;
+    async fn get_new_pending_transaction_filter(&self) -> Result<U256>;
     async fn chain_id(&self) -> Result<u64>;
     async fn get_fee_history(
         &self,

--- a/execution/tests/execution.rs
+++ b/execution/tests/execution.rs
@@ -158,6 +158,11 @@ async fn test_get_receipt() {
 }
 
 #[tokio::test]
+async fn test_get_filter_logs() {
+    todo!();
+}
+
+#[tokio::test]
 async fn test_get_receipt_bad_proof() {
     let tx = Transaction::decode(&Rlp::new(&hex::decode("02f8b20583623355849502f900849502f91082ea6094326c977e6efc84e512bb9c30f76e30c160ed06fb80b844a9059cbb0000000000000000000000007daccf9b3c1ae2fa5c55f1c978aeef700bc83be0000000000000000000000000000000000000000000000001158e460913d00000c080a0e1445466b058b6f883c0222f1b1f3e2ad9bee7b5f688813d86e3fa8f93aa868ca0786d6e7f3aefa8fe73857c65c32e4884d8ba38d0ecfb947fbffb82e8ee80c167").unwrap())).unwrap();
 

--- a/execution/tests/execution.rs
+++ b/execution/tests/execution.rs
@@ -158,11 +158,6 @@ async fn test_get_receipt() {
 }
 
 #[tokio::test]
-async fn test_get_filter_logs() {
-    todo!();
-}
-
-#[tokio::test]
 async fn test_get_receipt_bad_proof() {
     let tx = Transaction::decode(&Rlp::new(&hex::decode("02f8b20583623355849502f900849502f91082ea6094326c977e6efc84e512bb9c30f76e30c160ed06fb80b844a9059cbb0000000000000000000000007daccf9b3c1ae2fa5c55f1c978aeef700bc83be0000000000000000000000000000000000000000000000001158e460913d00000c080a0e1445466b058b6f883c0222f1b1f3e2ad9bee7b5f688813d86e3fa8f93aa868ca0786d6e7f3aefa8fe73857c65c32e4884d8ba38d0ecfb947fbffb82e8ee80c167").unwrap())).unwrap();
 


### PR DESCRIPTION
Contributes to #200 . Adds

- `eth_getFilterChanges`
- `eth_uninstallFilter`
- `eth_getNewFilter`
- `eth_getNewBlockFilter`
- `eth_getNewPendingTransactionFilter`

@ncitron wanted your thoughts on adding tests. Some of these are just wrappers around ethers::providers.