### PR TITLE
Replace `wasm-timer` with `zduny-wasm-timer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "client",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "common",
  "config",
@@ -723,7 +723,7 @@ dependencies = [
  "tokio",
  "tracing",
  "wasm-bindgen-futures",
- "wasm-timer",
+ "zduny-wasm-timer",
 ]
 
 [[package]]
@@ -799,7 +799,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "common"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "backoff",
  "common",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "consensus"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -857,7 +857,7 @@ dependencies = [
  "tokio",
  "tracing",
  "wasm-bindgen-futures",
- "wasm-timer",
+ "zduny-wasm-timer",
 ]
 
 [[package]]
@@ -1738,7 +1738,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "execution"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2274,7 +2274,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "helios"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "client",
  "common",
@@ -5661,21 +5661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5902,6 +5887,21 @@ dependencies = [
  "dlib",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "zduny-wasm-timer"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f22d6a02cbc84ea1993b0b341833a55a0866a3378c3a76e0ca664bc2574e370"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.12.1",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ thiserror = "1.0.37"
 superstruct = "0.7.0"
 openssl = { version = "0.10", features = ["vendored"] }
 hyper = "0.14.23"
-wasm-timer = "0.2.5"
+zduny-wasm-timer = "0.2.8"
 backoff = { version = "0.4.0", features = ["tokio"] }
 
 ######################################

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,7 +13,7 @@ futures.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-wasm-timer.workspace = true
+zduny-wasm-timer.workspace = true
 
 common = { path = "../common" }
 consensus = { path = "../consensus" }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -13,7 +13,7 @@ use common::types::{Block, BlockTag};
 use config::Config;
 use execution::types::CallOpts;
 use tracing::{info, warn};
-use wasm_timer::Delay;
+use zduny_wasm_timer::Delay;
 
 use crate::node::Node;
 

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -5,7 +5,7 @@ use ethers::types::{
     Filter, Log, SyncProgress, SyncingStatus, Transaction, TransactionReceipt, H256,
 };
 use eyre::{eyre, Result};
-use wasm_timer::{SystemTime, UNIX_EPOCH};
+use zduny_wasm_timer::{SystemTime, UNIX_EPOCH};
 
 use common::types::{Block, BlockTag};
 use config::Config;

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -29,7 +29,7 @@ tracing.workspace = true
 chrono.workspace = true
 thiserror.workspace = true
 superstruct.workspace = true
-wasm-timer.workspace = true
+zduny-wasm-timer.workspace = true
 backoff.workspace = true
 
 common = { path = "../common" }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -11,7 +11,7 @@ use milagro_bls::PublicKey;
 use ssz_rs::prelude::*;
 use tokio::sync::mpsc::Sender;
 use tracing::{debug, error, info, warn};
-use wasm_timer::{SystemTime, UNIX_EPOCH};
+use zduny_wasm_timer::{SystemTime, UNIX_EPOCH};
 
 use tokio::sync::mpsc::channel;
 use tokio::sync::mpsc::Receiver;
@@ -112,7 +112,7 @@ impl<R: ConsensusRpc, DB: Database> ConsensusClient<R, DB> {
             _ = inner.send_blocks().await;
 
             loop {
-                wasm_timer::Delay::new(inner.duration_until_next_update().to_std().unwrap())
+                zduny_wasm_timer::Delay::new(inner.duration_until_next_update().to_std().unwrap())
                     .await
                     .unwrap();
 


### PR DESCRIPTION
This fixes the following error that happens when running `helios-ts` in a Web Worker environment:

![telegram-cloud-photo-size-1-5023824917329718351-y](https://github.com/a16z/helios/assets/168856/f30fd573-2336-4688-a5c0-73761f7f244c)

More information on the origin of the error:
https://github.com/tomaka/wasm-timer/issues/12

And this is the commit of zduny's fork that fixed it:
https://github.com/zduny/wasm-timer/commit/31beb5c336a52e0438594fcfea45c164fb450350