### PR TITLE
fix: use valid nightly release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: generate tag name
         id: tag
         run: |
-          echo "::set-output name=release_tag::${GITHUB_SHA}"
+          echo "::set-output name=release_tag::nightly-${GITHUB_SHA}"
 
       - name: release
         uses: softprops/action-gh-release@v1
@@ -70,7 +70,7 @@ jobs:
       - name: generate tag name
         id: tag
         run: |
-          echo "::set-output name=release_tag::${GITHUB_SHA}"
+          echo "::set-output name=release_tag::nightly-${GITHUB_SHA}"
 
       - name: release
         uses: softprops/action-gh-release@v1
@@ -115,7 +115,7 @@ jobs:
       - name: generate tag name
         id: tag
         run: |
-          echo "::set-output name=release_tag::${GITHUB_SHA}"
+          echo "::set-output name=release_tag::nightly-${GITHUB_SHA}"
 
       - name: release
         uses: softprops/action-gh-release@v1
@@ -154,7 +154,7 @@ jobs:
       - name: generate tag name
         id: tag
         run: |
-          echo "::set-output name=release_tag::${GITHUB_SHA}"
+          echo "::set-output name=release_tag::nightly-${GITHUB_SHA}"
 
       - name: release
         uses: softprops/action-gh-release@v1
@@ -202,7 +202,7 @@ jobs:
       - name: generate tag name
         id: tag
         run: |
-          echo "::set-output name=release_tag::${GITHUB_SHA}"
+          echo "::set-output name=release_tag::nightly-${GITHUB_SHA}"
 
       - name: release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Github doesn't like it when a tag is a valid commit hash, so we prepend `nightly` to the front of the tag name.