### PR TITLE
fix: populate missing tx fields

### DIFF
--- a/consensus/src/types/utils.rs
+++ b/consensus/src/types/utils.rs
@@ -109,19 +109,18 @@ impl From<ExecutionPayload> for Block {
                 tx.from = tx.recover_from().unwrap();
                 tx.transaction_index = Some(i.into());
 
-                match (tx.max_fee_per_gas, tx.max_priority_fee_per_gas) {
-                    (Some(max_fee), Some(max_priority_fee)) => {
-                        let base_fee = ethers::types::U256::from_little_endian(
-                            &value.base_fee_per_gas().to_bytes_le(),
-                        );
+                if let (Some(max_fee), Some(max_priority_fee)) =
+                    (tx.max_fee_per_gas, tx.max_priority_fee_per_gas)
+                {
+                    let base_fee = ethers::types::U256::from_little_endian(
+                        &value.base_fee_per_gas().to_bytes_le(),
+                    );
 
-                        tx.gas_price = if max_fee >= max_priority_fee + base_fee {
-                            Some(base_fee + max_priority_fee)
-                        } else {
-                            Some(max_fee)
-                        };
-                    }
-                    _ => (),
+                    tx.gas_price = if max_fee >= max_priority_fee + base_fee {
+                        Some(base_fee + max_priority_fee)
+                    } else {
+                        Some(max_fee)
+                    };
                 }
 
                 tx

--- a/helios-ts/index.html
+++ b/helios-ts/index.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <script src="./dist/lib.js"></script>
-    <script src="https://cdn.ethers.io/lib/ethers-5.2.umd.min.js"></script>
+    <script src="https://cdn.ethers.io/lib/ethers-5.7.umd.min.js"></script>
     <script>
       const config = {
         executionRpc:"http://localhost:9001/proxy", 

--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -41,7 +41,6 @@ export class HeliosProvider {
       };
       case "eth_getTransactionByHash": {
         let tx = await this.#client.get_transaction_by_hash(req.params[0]);
-        console.log(mapToObj(tx));
         return mapToObj(tx);
       };
       case "eth_getTransactionCount": {

--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -41,6 +41,7 @@ export class HeliosProvider {
       };
       case "eth_getTransactionByHash": {
         let tx = await this.#client.get_transaction_by_hash(req.params[0]);
+        console.log(mapToObj(tx));
         return mapToObj(tx);
       };
       case "eth_getTransactionCount": {
@@ -110,7 +111,10 @@ function mapToObj(map: Map<any, any> | undefined): Object | undefined {
   if(!map) return undefined;
 
   return Array.from(map).reduce((obj: any, [key, value]) => {
-    obj[key] = value;
+    if (value !== undefined) {
+      obj[key] = value;
+    }
+
     return obj;
   }, {});
 }


### PR DESCRIPTION
Some transactions fields aren't being populated correctly. It turn out just rlp decoding the transaction is not sufficient. This bug was introduced during previous refactoring so is only present in 0.5.0. We should cut a new release to fix since this is a fairly major bug.