### PR TITLE
fix: use wasm compatible rpc retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,20 +317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.10",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,7 +799,6 @@ dependencies = [
 name = "config"
 version = "0.5.1"
 dependencies = [
- "backoff",
  "common",
  "dirs",
  "ethers",
@@ -822,6 +807,7 @@ dependencies = [
  "futures",
  "hex",
  "reqwest",
+ "retri",
  "serde",
  "serde_yaml",
  "strum 0.24.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "openssl",
  "parking_lot 0.11.2",
  "reqwest",
+ "retri",
  "serde",
  "serde_json",
  "ssz_rs",
@@ -4080,6 +4081,14 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.22.6",
  "winreg",
+]
+
+[[package]]
+name = "retri"
+version = "0.1.0"
+source = "git+https://github.com/ncitron/retri?rev=ca724f0e0a033e29fbd0d898f98c407705201a9a#ca724f0e0a033e29fbd0d898f98c407705201a9a"
+dependencies = [
+ "zduny-wasm-timer",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,6 @@ name = "consensus"
 version = "0.5.1"
 dependencies = [
  "async-trait",
- "backoff",
  "bytes",
  "chrono",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ superstruct = "0.7.0"
 openssl = { version = "0.10", features = ["vendored"] }
 hyper = "0.14.23"
 zduny-wasm-timer = "0.2.8"
-backoff = { version = "0.4.0", features = ["tokio"] }
 retri = { git = "https://github.com/ncitron/retri", rev = "ca724f0e0a033e29fbd0d898f98c407705201a9a" }
 
 ######################################

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 hyper = "0.14.23"
 zduny-wasm-timer = "0.2.8"
 backoff = { version = "0.4.0", features = ["tokio"] }
+retri = { git = "https://github.com/ncitron/retri", rev = "ca724f0e0a033e29fbd0d898f98c407705201a9a" }
 
 ######################################
 # Top Level Dependencies

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -12,7 +12,7 @@ thiserror.workspace = true
 tracing.workspace = true
 reqwest.workspace = true
 futures.workspace = true
-backoff.workspace = true
+retri.workspace = true
 
 figment = { version = "0.10.7", features = ["toml", "env"] }
 serde_yaml = "0.9.14"

--- a/config/src/checkpoints.rs
+++ b/config/src/checkpoints.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use ethers::types::H256;
 use eyre::Result;
-use retri::{BackoffSettings, retry};
+use retri::{retry, BackoffSettings};
 use serde::{Deserialize, Serialize};
 
 use crate::networks;

--- a/config/src/checkpoints.rs
+++ b/config/src/checkpoints.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
-use backoff::future::retry_notify;
-use backoff::ExponentialBackoff;
 use ethers::types::H256;
+use eyre::Result;
+use retri::{BackoffSettings, retry};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 
 use crate::networks;
 
@@ -76,11 +75,10 @@ pub struct CheckpointFallback {
     pub networks: Vec<networks::Network>,
 }
 
-async fn get(req: &str) -> Result<reqwest::Response, reqwest::Error> {
-    retry_notify(
-        ExponentialBackoff::default(),
-        || async { Ok(reqwest::get(req).await?) },
-        |e, dur| warn!(target: "helios::checkpoint", "rpc error occurred at {:?}: {}", dur, e),
+async fn get(req: &str) -> Result<reqwest::Response> {
+    retry(
+        || async { Ok::<_, eyre::Report>(reqwest::get(req).await?) },
+        BackoffSettings::default(),
     )
     .await
 }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -30,6 +30,7 @@ chrono.workspace = true
 thiserror.workspace = true
 superstruct.workspace = true
 zduny-wasm-timer.workspace = true
+retri.workspace = true
 
 common = { path = "../common" }
 config = { path = "../config" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -30,7 +30,6 @@ chrono.workspace = true
 thiserror.workspace = true
 superstruct.workspace = true
 zduny-wasm-timer.workspace = true
-backoff.workspace = true
 
 common = { path = "../common" }
 config = { path = "../config" }


### PR DESCRIPTION
Most retry libraries don't have good enough wasm support to handle executing in a webworker. I wrote a new retry crate called [retri](https://github.com/ncitron/retri) that uses [zduny-wasm-timer](https://github.com/zduny/wasm-timer) internally which has supports both non wasm, browser wasm, and webworker wasm environments.