### PR TITLE
Exposing rpc_bind_ip on ClientBuilder

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -69,6 +69,12 @@ impl ClientBuilder {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    pub fn rpc_bind_ip(mut self, ip: IpAddr) -> Self {
+        self.rpc_bind_ip = Some(ip);
+        self
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn rpc_port(mut self, port: u16) -> Self {
         self.rpc_port = Some(port);
         self


### PR DESCRIPTION
Hello,

while updating [HeliosKit](https://github.com/rkreutz/HeliosKit) I've noticed that `rpc_bind_ip` is not accessible from `ClientBuilder`, only way to inject it into the builder would be to serialise the config with the binding IP which might be cumbersome, exposing it directly through the builder makes it easier to override.