### PR TITLE
fix(example/call): read local env variables via dotenv

### DIFF
--- a/examples/call.rs
+++ b/examples/call.rs
@@ -1,11 +1,11 @@
 #![allow(deprecated)]
 
+use dotenv::dotenv;
 use ethers::prelude::*;
 use std::path::PathBuf;
 use tracing::info;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::FmtSubscriber;
-use dotenv::dotenv;
 
 use helios::{
     client::{Client, ClientBuilder, FileDB},

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use tracing::info;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::FmtSubscriber;
+use dotenv::dotenv;
 
 use helios::{
     client::{Client, ClientBuilder, FileDB},
@@ -26,6 +27,7 @@ async fn main() -> eyre::Result<()> {
     tracing::subscriber::set_global_default(subscriber).expect("subsriber set failed");
 
     // Load the rpc url using the `MAINNET_EXECUTION_RPC` environment variable
+    dotenv().ok();
     let eth_rpc_url = std::env::var("MAINNET_EXECUTION_RPC")?;
     let consensus_rpc = "https://www.lightclientdata.org";
     info!("Consensus RPC URL: {}", consensus_rpc);


### PR DESCRIPTION
add `dotenv().ok();` in order to read env variables from .env located in the current project folder.