### PR TITLE
Add `SEPOLIA` to `CheckpointFallback` networks

### DIFF
--- a/config/src/checkpoints.rs
+++ b/config/src/checkpoints.rs
@@ -92,7 +92,11 @@ impl CheckpointFallback {
     pub fn new() -> Self {
         Self {
             services: Default::default(),
-            networks: [networks::Network::MAINNET, networks::Network::GOERLI].to_vec(),
+            networks: vec![
+                networks::Network::MAINNET,
+                networks::Network::GOERLI,
+                networks::Network::SEPOLIA,
+            ],
         }
     }
 

--- a/config/src/networks.rs
+++ b/config/src/networks.rs
@@ -64,6 +64,8 @@ impl Network {
         match id {
             1 => Ok(Network::MAINNET),
             5 => Ok(Network::GOERLI),
+            11155111 => Ok(Network::SEPOLIA),
+            17000 => Ok(Network::HOLESKY),
             _ => Err(eyre::eyre!("chain id not known")),
         }
     }


### PR DESCRIPTION
Without `SEPOLIA` in the list of networks, the call `CheckpointFallback::get_healthy_fallback_services` fails for `networks::Network::SEPOLIA`.