### PR TITLE
fix: replace the unavailable goerli testnet part with sepolia and holesky

### DIFF
--- a/config/src/checkpoints.rs
+++ b/config/src/checkpoints.rs
@@ -96,6 +96,7 @@ impl CheckpointFallback {
                 networks::Network::MAINNET,
                 networks::Network::GOERLI,
                 networks::Network::SEPOLIA,
+                networks::Network::HOLESKY,
             ],
         }
     }

--- a/config/tests/checkpoints.rs
+++ b/config/tests/checkpoints.rs
@@ -10,7 +10,6 @@ async fn test_checkpoint_fallback() {
     assert_eq!(cf.services.get(&networks::Network::SEPOLIA), None);
     assert_eq!(cf.services.get(&networks::Network::HOLESKY), None);
 
-
     assert_eq!(
         cf.networks,
         [
@@ -34,7 +33,6 @@ async fn test_construct_checkpoints() {
     assert!(cf.services[&networks::Network::GOERLI].len() > 1);
     assert!(cf.services[&networks::Network::SEPOLIA].len() > 1);
     assert!(cf.services[&networks::Network::HOLESKY].len() > 1);
-
 }
 
 #[tokio::test]
@@ -49,9 +47,9 @@ async fn test_fetch_latest_checkpoints() {
         .unwrap();
     assert!(checkpoint != H256::zero());
     let checkpoint = cf
-    .fetch_latest_checkpoint(&networks::Network::HOLESKY)
-    .await
-    .unwrap();
+        .fetch_latest_checkpoint(&networks::Network::HOLESKY)
+        .await
+        .unwrap();
     assert!(checkpoint != H256::zero());
     let checkpoint = cf
         .fetch_latest_checkpoint(&networks::Network::MAINNET)

--- a/config/tests/checkpoints.rs
+++ b/config/tests/checkpoints.rs
@@ -7,13 +7,17 @@ async fn test_checkpoint_fallback() {
 
     assert_eq!(cf.services.get(&networks::Network::MAINNET), None);
     assert_eq!(cf.services.get(&networks::Network::GOERLI), None);
+    assert_eq!(cf.services.get(&networks::Network::SEPOLIA), None);
+    assert_eq!(cf.services.get(&networks::Network::HOLESKY), None);
+
 
     assert_eq!(
         cf.networks,
         [
             networks::Network::MAINNET,
             networks::Network::GOERLI,
-            networks::Network::SEPOLIA
+            networks::Network::SEPOLIA,
+            networks::Network::HOLESKY,
         ]
         .to_vec()
     );
@@ -28,6 +32,9 @@ async fn test_construct_checkpoints() {
 
     assert!(cf.services[&networks::Network::MAINNET].len() > 1);
     assert!(cf.services[&networks::Network::GOERLI].len() > 1);
+    assert!(cf.services[&networks::Network::SEPOLIA].len() > 1);
+    assert!(cf.services[&networks::Network::HOLESKY].len() > 1);
+
 }
 
 #[tokio::test]
@@ -37,9 +44,14 @@ async fn test_fetch_latest_checkpoints() {
         .await
         .unwrap();
     let checkpoint = cf
-        .fetch_latest_checkpoint(&networks::Network::GOERLI)
+        .fetch_latest_checkpoint(&networks::Network::SEPOLIA)
         .await
         .unwrap();
+    assert!(checkpoint != H256::zero());
+    let checkpoint = cf
+    .fetch_latest_checkpoint(&networks::Network::HOLESKY)
+    .await
+    .unwrap();
     assert!(checkpoint != H256::zero());
     let checkpoint = cf
         .fetch_latest_checkpoint(&networks::Network::MAINNET)
@@ -58,6 +70,10 @@ async fn test_get_all_fallback_endpoints() {
     assert!(!urls.is_empty());
     let urls = cf.get_all_fallback_endpoints(&networks::Network::GOERLI);
     assert!(!urls.is_empty());
+    let urls = cf.get_all_fallback_endpoints(&networks::Network::SEPOLIA);
+    assert!(!urls.is_empty());
+    let urls = cf.get_all_fallback_endpoints(&networks::Network::HOLESKY);
+    assert!(!urls.is_empty());
 }
 
 #[tokio::test]
@@ -69,5 +85,9 @@ async fn test_get_healthy_fallback_endpoints() {
     let urls = cf.get_healthy_fallback_endpoints(&networks::Network::MAINNET);
     assert!(!urls.is_empty());
     let urls = cf.get_healthy_fallback_endpoints(&networks::Network::GOERLI);
+    assert!(!urls.is_empty());
+    let urls = cf.get_healthy_fallback_endpoints(&networks::Network::SEPOLIA);
+    assert!(!urls.is_empty());
+    let urls = cf.get_healthy_fallback_endpoints(&networks::Network::HOLESKY);
     assert!(!urls.is_empty());
 }

--- a/examples/checkpoints.rs
+++ b/examples/checkpoints.rs
@@ -14,12 +14,19 @@ async fn main() -> Result<()> {
         .await
         .unwrap();
 
-    // Fetch the latest goerli checkpoint
-    let goerli_checkpoint = cf
-        .fetch_latest_checkpoint(&networks::Network::GOERLI)
+    // Fetch the latest sepolia checkpoint
+    let sepolia_checkpoint = cf
+        .fetch_latest_checkpoint(&networks::Network::SEPOLIA)
         .await
         .unwrap();
-    println!("Fetched latest goerli checkpoint: {goerli_checkpoint}");
+    println!("Fetched latest goerli checkpoint: {sepolia_checkpoint}");
+
+    // Fetch the latest holesky checkpoint
+    let holesky_checkpoint = cf
+        .fetch_latest_checkpoint(&networks::Network::SEPOLIA)
+        .await
+        .unwrap();
+    println!("Fetched latest goerli checkpoint: {holesky_checkpoint}");
 
     // Fetch the latest mainnet checkpoint
     let mainnet_checkpoint = cf


### PR DESCRIPTION
The closure of the Goerli testnet prevents some related tests and examples from passing.
Replacing them with sepolia and holesky