### PR TITLE
docs: fix allthatnode ethereum mainnet rpc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Ethereum Execution API provider JSON RPC endpoints used must support the `eth_ge
 For example, the following cURL request should return a response `{"jsonrpc":"2.0","id":1,"result":{...}}` to demonstrate that the All That Node public JSON RPC endpoints on the Ethereum Goerli network and Mainnet support the `eth_getProof` endpoint.
 
 ```sh
-curl https://ethereum-sepolia.g.allthatnode.com \
+curl https://ethereum-goerli-rpc.allthatnode.com \
 -X POST \
 -H "Content-Type: application/json" \
 -d '{"jsonrpc":"2.0","method":"eth_getProof","params":["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"],"latest"],"id":1}'

--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ Ethereum Execution API provider JSON RPC endpoints used must support the `eth_ge
 For example, the following cURL request should return a response `{"jsonrpc":"2.0","id":1,"result":{...}}` to demonstrate that the All That Node public JSON RPC endpoints on the Ethereum Goerli network and Mainnet support the `eth_getProof` endpoint.
 
 ```sh
-curl https://ethereum-goerli-rpc.allthatnode.com \
+curl https://ethereum-sepolia.g.allthatnode.com \
 -X POST \
 -H "Content-Type: application/json" \
 -d '{"jsonrpc":"2.0","method":"eth_getProof","params":["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"],"latest"],"id":1}'
 ```
 
 ```sh
-curl https://ethereum-mainnet-rpc.allthatnode.com \
+curl https://ethereum-mainnet.g.allthatnode.com \
 -X POST \
 -H "Content-Type: application/json" \
 -d '{"jsonrpc":"2.0","method":"eth_getProof","params":["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"],"latest"],"id":1}'
@@ -196,7 +196,7 @@ This latest checkpoint may be provided as an [Additional CLI Option](#additional
 helios \
     --network mainnet \
     --consensus-rpc https://www.lightclientdata.org \
-    --execution-rpc https://ethereum-mainnet-rpc.allthatnode.com \
+    --execution-rpc https://ethereum-mainnet.g.allthatnode.com \
     --checkpoint 0xe1912ca8ca3b45dac497cae7825bab055b0f60285533721b046e8fefb5b076f2
 ```
 


### PR DESCRIPTION
The All that Node Ethereum RPC URLs are changed. So I created a pull request.
I have a question. Does the helios keep support `goerli` network in this project? 
Because the All That Node deprecated the goerli testnet.