### PR TITLE
fix: make file_db benchmark runable

### DIFF
--- a/benches/file_db.rs
+++ b/benches/file_db.rs
@@ -17,7 +17,8 @@ criterion_main!(file_db);
 /// Benchmark saving/writing a checkpoint to the file db.
 pub fn save_checkpoint(c: &mut Criterion) {
     c.bench_function("save_checkpoint", |b| {
-        let checkpoint: alloy::primitives::FixedBytes<32>  = b256!("c7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce");
+        let checkpoint: alloy::primitives::FixedBytes<32> =
+            b256!("c7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce");
         b.iter(|| {
             let data_dir = Some(tempdir().unwrap().into_path());
             let config = Config {
@@ -40,7 +41,8 @@ pub fn load_checkpoint(c: &mut Criterion) {
             ..Default::default()
         };
         let db = FileDB::new(&config).unwrap();
-        let written_checkpoint = b256!("c7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce");
+        let written_checkpoint =
+            b256!("c7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce");
         db.save_checkpoint(written_checkpoint.clone()).unwrap();
 
         // Then read from the db

--- a/benches/file_db.rs
+++ b/benches/file_db.rs
@@ -1,3 +1,4 @@
+use alloy::primitives::b256;
 use config::Config;
 use consensus::database::{Database, FileDB};
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -16,7 +17,7 @@ criterion_main!(file_db);
 /// Benchmark saving/writing a checkpoint to the file db.
 pub fn save_checkpoint(c: &mut Criterion) {
     c.bench_function("save_checkpoint", |b| {
-        let checkpoint: &[u8] = &[1, 2, 3];
+        let checkpoint: alloy::primitives::FixedBytes<32>  = b256!("c7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce");
         b.iter(|| {
             let data_dir = Some(tempdir().unwrap().into_path());
             let config = Config {
@@ -39,8 +40,8 @@ pub fn load_checkpoint(c: &mut Criterion) {
             ..Default::default()
         };
         let db = FileDB::new(&config).unwrap();
-        let written_checkpoint = vec![1; 32];
-        db.save_checkpoint(&written_checkpoint.clone()).unwrap();
+        let written_checkpoint = b256!("c7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce");
+        db.save_checkpoint(written_checkpoint.clone()).unwrap();
 
         // Then read from the db
         b.iter(|| {

--- a/benches/get_balance.rs
+++ b/benches/get_balance.rs
@@ -1,5 +1,5 @@
-use criterion::{criterion_group, criterion_main, Criterion};
 use alloy::primitives::Address;
+use criterion::{criterion_group, criterion_main, Criterion};
 use helios::types::BlockTag;
 use std::str::FromStr;
 

--- a/benches/get_balance.rs
+++ b/benches/get_balance.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use ethers::prelude::*;
+use alloy::primitives::Address;
 use helios::types::BlockTag;
 use std::str::FromStr;
 
@@ -32,7 +32,7 @@ pub fn bench_mainnet_get_balance(c: &mut Criterion) {
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {
             let inner = std::sync::Arc::clone(&client);
-            inner.get_balance(&addr, block).await.unwrap()
+            inner.get_balance(addr, block).await.unwrap()
         })
     });
 }
@@ -64,7 +64,7 @@ pub fn bench_goerli_get_balance(c: &mut Criterion) {
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {
             let inner = std::sync::Arc::clone(&client);
-            inner.get_balance(&addr, block).await.unwrap()
+            inner.get_balance(addr, block).await.unwrap()
         })
     });
 }

--- a/benches/get_code.rs
+++ b/benches/get_code.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use ethers::prelude::*;
+use alloy::primitives::Address;
 use helios::types::BlockTag;
 use std::str::FromStr;
 
@@ -32,7 +32,7 @@ pub fn bench_mainnet_get_code(c: &mut Criterion) {
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {
             let inner = std::sync::Arc::clone(&client);
-            inner.get_code(&addr, block).await.unwrap()
+            inner.get_code(addr, block).await.unwrap()
         })
     });
 }
@@ -57,7 +57,7 @@ pub fn bench_goerli_get_code(c: &mut Criterion) {
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {
             let inner = std::sync::Arc::clone(&client);
-            inner.get_code(&addr, block).await.unwrap()
+            inner.get_code(addr, block).await.unwrap()
         })
     });
 }

--- a/benches/get_code.rs
+++ b/benches/get_code.rs
@@ -1,5 +1,5 @@
-use criterion::{criterion_group, criterion_main, Criterion};
 use alloy::primitives::Address;
+use criterion::{criterion_group, criterion_main, Criterion};
 use helios::types::BlockTag;
 use std::str::FromStr;
 

--- a/benches/harness.rs
+++ b/benches/harness.rs
@@ -1,8 +1,12 @@
 #![allow(dead_code)]
-use alloy::primitives::{Address, B256,U256};
-use std::{path::PathBuf, str::FromStr};
 use ::client::Client;
-use helios::{client::{self, FileDB}, config::networks, types::BlockTag};
+use alloy::primitives::{Address, B256, U256};
+use helios::{
+    client::{self, FileDB},
+    config::networks,
+    types::BlockTag,
+};
+use std::{path::PathBuf, str::FromStr};
 
 /// Fetches the latest mainnet checkpoint from the fallback service.
 ///
@@ -39,7 +43,9 @@ pub async fn inner_construct_mainnet_client() -> eyre::Result<Client<FileDB>> {
     Ok(client)
 }
 
-pub async fn construct_mainnet_client_with_checkpoint(checkpoint: B256) -> eyre::Result<Client<FileDB>> {
+pub async fn construct_mainnet_client_with_checkpoint(
+    checkpoint: B256,
+) -> eyre::Result<Client<FileDB>> {
     let benchmark_rpc_url = std::env::var("MAINNET_EXECUTION_RPC")?;
     let mut client = client::ClientBuilder::new()
         .network(networks::Network::MAINNET)

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use ethers::types::Address;
+use alloy::primitives::Address;
 use helios::types::BlockTag;
 
 mod harness;
@@ -19,13 +19,12 @@ criterion_group! {
 pub fn bench_full_sync(c: &mut Criterion) {
     // Externally, let's fetch the latest checkpoint from our fallback service so as not to benchmark the checkpoint fetch.
     let checkpoint = harness::await_future(harness::fetch_mainnet_checkpoint()).unwrap();
-    let checkpoint = hex::encode(checkpoint);
 
     // On client construction, it will sync to the latest checkpoint using our fetched checkpoint.
     c.bench_function("full_sync", |b| {
         b.to_async(harness::construct_runtime()).iter(|| async {
             let _client = std::sync::Arc::new(
-                harness::construct_mainnet_client_with_checkpoint(&checkpoint)
+                harness::construct_mainnet_client_with_checkpoint(checkpoint)
                     .await
                     .unwrap(),
             );
@@ -38,13 +37,12 @@ pub fn bench_full_sync(c: &mut Criterion) {
 pub fn bench_full_sync_with_call(c: &mut Criterion) {
     // Externally, let's fetch the latest checkpoint from our fallback service so as not to benchmark the checkpoint fetch.
     let checkpoint = harness::await_future(harness::fetch_mainnet_checkpoint()).unwrap();
-    let checkpoint = hex::encode(checkpoint);
 
     // On client construction, it will sync to the latest checkpoint using our fetched checkpoint.
     c.bench_function("full_sync_call", |b| {
         b.to_async(harness::construct_runtime()).iter(|| async {
             let client = std::sync::Arc::new(
-                harness::construct_mainnet_client_with_checkpoint(&checkpoint)
+                harness::construct_mainnet_client_with_checkpoint(checkpoint)
                     .await
                     .unwrap(),
             );
@@ -52,7 +50,7 @@ pub fn bench_full_sync_with_call(c: &mut Criterion) {
                 .parse::<Address>()
                 .unwrap();
             let block = BlockTag::Latest;
-            client.get_balance(&addr, block).await.unwrap()
+            client.get_balance(addr, block).await.unwrap()
         })
     });
 }

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -1,5 +1,5 @@
-use criterion::{criterion_group, criterion_main, Criterion};
 use alloy::primitives::Address;
+use criterion::{criterion_group, criterion_main, Criterion};
 use helios::types::BlockTag;
 
 mod harness;


### PR DESCRIPTION
**Description**

- Due to the migration from `ether-rs` to `Alloy `and changes in some basic API parameter types, the benchmark part was unable to run properly. 
- **This PR fixes the tests for file_db.** 
- The other benchmark tests involve changes related to the testnet, which would require more extensive modifications. Since the file_db test does not involve network requests, it is submitted as a separate PR

**Local test result**
![image](https://github.com/user-attachments/assets/c586fd9a-54a7-4ec3-b4b8-56722d4579f2)
