### PR TITLE
chore: serialize lc store

### DIFF
--- a/consensus-core/src/types/mod.rs
+++ b/consensus-core/src/types/mod.rs
@@ -19,7 +19,7 @@ pub type LogsBloom = ByteVector<typenum::U256>;
 pub type KZGCommitment = ByteVector<typenum::U48>;
 pub type Transaction = ByteList<typenum::U1073741824>;
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct LightClientStore {
     pub finalized_header: Header,
     pub current_sync_committee: SyncCommittee,


### PR DESCRIPTION
This `Serialize` bound was removed in https://github.com/a16z/helios/pull/356, but is necessary to convert the `LightClientStore` into bytes, which is used in https://github.com/succinctlabs/sp1-helios/.