### PR TITLE
wip: `no-std` support for `consensus-core` and `common`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
-      - name: Check wasm compatibility
+      - name: Check wasm compatibility for common and consensus-core
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target wasm32-unknown-unknown --no-default-features
+          args: --target wasm32-unknown-unknown -p common -p consensus-core --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,21 @@ jobs:
         with:
           command: clippy
           args: --all -- -D warnings
+
+  wasm-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Check wasm compatibility
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target wasm32-unknown-unknown --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,6 +2594,7 @@ name = "helios"
 version = "0.6.0"
 dependencies = [
  "alloy",
+ "anyhow",
  "client",
  "common",
  "config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,7 +1278,7 @@ dependencies = [
  "jsonrpsee",
  "parking_lot",
  "serde",
- "thiserror",
+ "thiserror-no-std",
  "tokio",
  "tracing",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,14 +1303,8 @@ version = "0.6.0"
 dependencies = [
  "alloy",
  "anyhow",
- "hex",
  "serde",
- "serde_json",
- "superstruct",
- "thiserror",
  "thiserror-no-std",
- "tracing",
- "zduny-wasm-timer",
 ]
 
 [[package]]
@@ -1319,7 +1313,6 @@ version = "0.6.0"
 dependencies = [
  "alloy",
  "anyhow",
- "common",
  "consensus-core",
  "dirs",
  "figment",
@@ -1330,9 +1323,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "strum",
- "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1355,8 +1346,6 @@ dependencies = [
  "retri",
  "serde",
  "serde_json",
- "superstruct",
- "thiserror",
  "tokio",
  "tracing",
  "tree_hash",
@@ -2066,7 +2055,6 @@ dependencies = [
  "openssl",
  "reqwest",
  "revm",
- "serde",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2627,11 +2615,8 @@ dependencies = [
  "config",
  "consensus",
  "console_error_panic_hook",
- "execution",
  "hex",
- "serde",
  "serde-wasm-bindgen",
- "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ name = "cli"
 version = "0.6.0"
 dependencies = [
  "alloy",
+ "anyhow",
  "clap",
  "client",
  "common",
@@ -1255,7 +1256,6 @@ dependencies = [
  "consensus",
  "ctrlc",
  "dirs",
- "eyre",
  "futures",
  "tokio",
  "tracing",
@@ -1267,11 +1267,11 @@ name = "client"
 version = "0.6.0"
 dependencies = [
  "alloy",
+ "anyhow",
  "common",
  "config",
  "consensus",
  "execution",
- "eyre",
  "futures",
  "gloo-timers 0.3.0",
  "hex",
@@ -1302,12 +1302,13 @@ name = "common"
 version = "0.6.0"
 dependencies = [
  "alloy",
- "eyre",
+ "anyhow",
  "hex",
  "serde",
  "serde_json",
  "superstruct",
  "thiserror",
+ "thiserror-no-std",
  "tracing",
  "zduny-wasm-timer",
 ]
@@ -1317,10 +1318,10 @@ name = "config"
 version = "0.6.0"
 dependencies = [
  "alloy",
+ "anyhow",
  "common",
  "consensus-core",
  "dirs",
- "eyre",
  "figment",
  "futures",
  "hex",
@@ -1339,12 +1340,12 @@ name = "consensus"
 version = "0.6.0"
 dependencies = [
  "alloy",
+ "anyhow",
  "async-trait",
  "chrono",
  "common",
  "config",
  "consensus-core",
- "eyre",
  "futures",
  "getrandom 0.2.15",
  "hex",
@@ -1367,16 +1368,17 @@ dependencies = [
 name = "consensus-core"
 version = "0.6.0"
 dependencies = [
- "alloy",
+ "alloy-primitives",
+ "anyhow",
  "bls12_381",
  "ethereum_ssz 0.6.0",
  "ethereum_ssz_derive 0.6.0",
- "eyre",
+ "getrandom 0.2.15",
  "serde",
  "sha2 0.9.9",
  "ssz_types",
  "superstruct",
- "thiserror",
+ "thiserror-no-std",
  "tracing",
  "tree_hash",
  "tree_hash_derive",
@@ -2055,10 +2057,10 @@ name = "execution"
 version = "0.6.0"
 dependencies = [
  "alloy",
+ "anyhow",
  "async-trait",
  "common",
  "consensus",
- "eyre",
  "futures",
  "hex",
  "openssl",
@@ -2071,16 +2073,6 @@ dependencies = [
  "tracing",
  "triehash-ethereum",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -2611,7 +2603,6 @@ dependencies = [
  "dirs",
  "dotenv",
  "execution",
- "eyre",
  "hex",
  "plotters",
  "pretty_assertions",
@@ -2629,13 +2620,13 @@ name = "helios-ts"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "anyhow",
  "client",
  "common",
  "config",
  "consensus",
  "console_error_panic_hook",
  "execution",
- "eyre",
  "hex",
  "serde",
  "serde-wasm-bindgen",
@@ -2983,12 +2974,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -5248,6 +5233,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "thiserror-impl-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
+dependencies = [
+ "thiserror-impl-no-std",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ dotenv = "0.15.0"
 serde = { version = "1.0.154", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+anyhow = { version = "1.0", default-features = false }
 alloy = { version = "0.2.1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 dirs = "5.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ tree_hash = "0.7.0"
 sha2 = "0.9"
 bls12_381 = { version = "0.8.0", features = ["experimental"] }
 
+anyhow = { version = "1.0", default-features = false }
+
 # execution
 alloy = { version = "0.2.1", features = [
     "rpc-types",
@@ -43,14 +45,14 @@ alloy = { version = "0.2.1", features = [
     "sol-types",
     "network",
     "ssz",
-]}
+] }
 revm = { version = "12.1.0", default-features = false, features = [
     "std",
     "serde",
     "optional_block_gas_limit",
     "optional_eip3607",
     "optional_no_base_fee",
-]}
+] }
 triehash-ethereum = { git = "https://github.com/openethereum/parity-ethereum", rev = "55c90d4016505317034e3e98f699af07f5404b63" }
 
 # async/futures
@@ -60,16 +62,16 @@ tokio = { version = "1", features = ["rt", "sync", "macros"] }
 
 # io
 reqwest = { version = "0.12.4", features = ["json"] }
-serde = { version = "1.0.143", features = ["derive"] }
+serde = { version = "1.0.143", features = ["derive"], default-features = false }
 serde_json = "1.0.85"
 
 # misc
-eyre = "0.6.8"
 hex = "0.4.3"
 toml = "0.5.9"
 tracing = "0.1.37"
 chrono = "0.4.23"
-thiserror = "1.0.37"
+thiserror = { version = "1.0.37", default-features = false }
+thiserror-no-std = "2.0.2"
 superstruct = "0.7.0"
 openssl = { version = "0.10", features = ["vendored"] }
 zduny-wasm-timer = "0.2.8"
@@ -96,7 +98,6 @@ serde = { version = "1.0.154", features = ["derive"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 alloy = { version = "0.2.1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
-eyre = "0.6.8"
 dirs = "5.0.1"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing = "0.1.37"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ use std::{path::PathBuf, str::FromStr, env};
 
 use helios::{client::ClientBuilder, config::networks::Network, types::BlockTag, prelude::*};
 use alloy::primitives::{utils, Address};
-use eyre::Result;
+use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -136,7 +136,7 @@ Below we demonstrate fetching checkpoints from the community-maintained list of 
 > This is a community-maintained list and thus no security guarantees are provided. Attacks on your light client can occur if malicious checkpoints are set in the list. Please use the explicit `checkpoint` flag, environment variable, or config setting with an updated, and verified checkpoint.
 
 ```rust
-use eyre::Result;
+use anyhow::Result;
 use helios::config::{checkpoints, networks};
 
 #[tokio::main]

--- a/benches/harness.rs
+++ b/benches/harness.rs
@@ -14,7 +14,7 @@ use std::{path::PathBuf, str::FromStr};
 /// The `build` method will fetch a list of [CheckpointFallbackService](config::CheckpointFallbackService)s from a community-mainained list by ethPandaOps.
 /// This list is NOT guaranteed to be secure, but is provided in good faith.
 /// The raw list can be found here: https://github.com/ethpandaops/checkpoint-sync-health-checks/blob/master/_data/endpoints.yaml
-pub async fn fetch_mainnet_checkpoint() -> eyre::Result<B256> {
+pub async fn fetch_mainnet_checkpoint() -> anyhow::Result<B256> {
     let cf = config::CheckpointFallback::new().build().await.unwrap();
     cf.fetch_latest_checkpoint(&networks::Network::MAINNET)
         .await
@@ -26,11 +26,11 @@ pub async fn fetch_mainnet_checkpoint() -> eyre::Result<B256> {
 /// The client is parameterized with a [FileDB](client::FileDB).
 /// It will also use the environment variable `MAINNET_EXECUTION_RPC` to connect to a mainnet node.
 /// The client will use `https://www.lightclientdata.org` as the consensus RPC.
-pub fn construct_mainnet_client(rt: &tokio::runtime::Runtime) -> eyre::Result<Client<FileDB>> {
+pub fn construct_mainnet_client(rt: &tokio::runtime::Runtime) -> anyhow::Result<Client<FileDB>> {
     rt.block_on(inner_construct_mainnet_client())
 }
 
-pub async fn inner_construct_mainnet_client() -> eyre::Result<Client<FileDB>> {
+pub async fn inner_construct_mainnet_client() -> anyhow::Result<Client<FileDB>> {
     let benchmark_rpc_url = std::env::var("MAINNET_EXECUTION_RPC")?;
     let mut client = client::ClientBuilder::new()
         .network(networks::Network::MAINNET)
@@ -45,7 +45,7 @@ pub async fn inner_construct_mainnet_client() -> eyre::Result<Client<FileDB>> {
 
 pub async fn construct_mainnet_client_with_checkpoint(
     checkpoint: B256,
-) -> eyre::Result<Client<FileDB>> {
+) -> anyhow::Result<Client<FileDB>> {
     let benchmark_rpc_url = std::env::var("MAINNET_EXECUTION_RPC")?;
     let mut client = client::ClientBuilder::new()
         .network(networks::Network::MAINNET)
@@ -75,7 +75,7 @@ pub fn construct_runtime() -> tokio::runtime::Runtime {
 /// The client is parameterized with a [FileDB](client::FileDB).
 /// It will also use the environment variable `GOERLI_EXECUTION_RPC` to connect to a mainnet node.
 /// The client will use `http://testing.prater.beacon-api.nimbus.team` as the consensus RPC.
-pub fn construct_goerli_client(rt: &tokio::runtime::Runtime) -> eyre::Result<Client<FileDB>> {
+pub fn construct_goerli_client(rt: &tokio::runtime::Runtime) -> anyhow::Result<Client<FileDB>> {
     rt.block_on(async {
         let benchmark_rpc_url = std::env::var("GOERLI_EXECUTION_RPC")?;
         let mut client = client::ClientBuilder::new()
@@ -94,7 +94,7 @@ pub fn get_balance(
     rt: &tokio::runtime::Runtime,
     client: Client<FileDB>,
     address: &str,
-) -> eyre::Result<U256> {
+) -> anyhow::Result<U256> {
     rt.block_on(async {
         let block = BlockTag::Latest;
         let address = Address::from_str(address)?;

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 tokio.workspace = true
-eyre.workspace = true
+anyhow.workspace = true
 tracing.workspace = true
 futures.workspace = true
 alloy.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,9 +7,9 @@ use std::{
 };
 
 use alloy::primitives::B256;
+use anyhow::Result;
 use clap::Parser;
 use dirs::home_dir;
-use anyhow::Result;
 use futures::executor::block_on;
 use tracing::{error, info};
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 use alloy::primitives::B256;
 use clap::Parser;
 use dirs::home_dir;
-use eyre::Result;
+use anyhow::Result;
 use futures::executor::block_on;
 use tracing::{error, info};
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,7 +10,7 @@ serde.workspace = true
 hex.workspace = true
 futures.workspace = true
 tracing.workspace = true
-thiserror.workspace = true
+thiserror-no-std.workspace = true
 tokio.workspace = true
 zduny-wasm-timer.workspace = true
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 alloy.workspace = true
-eyre.workspace = true
+anyhow.workspace = true
 serde.workspace = true
 hex.workspace = true
 futures.workspace = true

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -7,7 +7,7 @@ use alloy::primitives::{Address, Bytes, B256, U256};
 use alloy::rpc::types::{
     Filter, Log, SyncStatus, Transaction, TransactionReceipt, TransactionRequest,
 };
-use eyre::{eyre, Result};
+use anyhow::{anyhow, Result};
 use tracing::{info, warn};
 use zduny_wasm_timer::Delay;
 
@@ -112,7 +112,7 @@ impl ClientBuilder {
             let config = self
                 .config
                 .as_ref()
-                .ok_or(eyre!("missing network config"))?;
+                .ok_or(anyhow!("missing network config"))?;
             config.to_base_config()
         };
 

--- a/client/src/errors.rs
+++ b/client/src/errors.rs
@@ -1,5 +1,4 @@
-use anyhow::Report;
-use thiserror::Error;
+use thiserror_no_std::Error;
 
 use common::errors::BlockNotFoundError;
 use execution::errors::EvmError;
@@ -11,28 +10,28 @@ pub enum NodeError {
     ExecutionEvmError(#[from] EvmError),
 
     #[error("execution error: {0}")]
-    ExecutionError(Report),
+    ExecutionError(anyhow::Error),
 
     #[error("out of sync: {0} seconds behind")]
     OutOfSync(u64),
 
     #[error("consensus payload error: {0}")]
-    ConsensusPayloadError(Report),
+    ConsensusPayloadError(anyhow::Error),
 
     #[error("execution payload error: {0}")]
-    ExecutionPayloadError(Report),
+    ExecutionPayloadError(anyhow::Error),
 
     #[error("consensus client creation error: {0}")]
-    ConsensusClientCreationError(Report),
+    ConsensusClientCreationError(anyhow::Error),
 
     #[error("execution client creation error: {0}")]
-    ExecutionClientCreationError(Report),
+    ExecutionClientCreationError(anyhow::Error),
 
     #[error("consensus advance error: {0}")]
-    ConsensusAdvanceError(Report),
+    ConsensusAdvanceError(anyhow::Error),
 
     #[error("consensus sync error: {0}")]
-    ConsensusSyncError(Report),
+    ConsensusSyncError(anyhow::Error),
 
     #[error(transparent)]
     BlockNotFoundError(#[from] BlockNotFoundError),
@@ -60,5 +59,11 @@ impl NodeError {
             },
             _ => jsonrpsee::core::Error::Custom(self.to_string()),
         }
+    }
+}
+
+impl From<NodeError> for anyhow::Error {
+    fn from(error: NodeError) -> Self {
+        anyhow::Error::msg(error.to_string())
     }
 }

--- a/client/src/errors.rs
+++ b/client/src/errors.rs
@@ -1,4 +1,4 @@
-use eyre::Report;
+use anyhow::Report;
 use thiserror::Error;
 
 use common::errors::BlockNotFoundError;

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -4,7 +4,7 @@ use alloy::primitives::{Address, Bytes, B256, U256};
 use alloy::rpc::types::{
     Filter, Log, SyncInfo, SyncStatus, Transaction, TransactionReceipt, TransactionRequest,
 };
-use eyre::{eyre, Result};
+use anyhow::{anyhow, Result};
 use zduny_wasm_timer::{SystemTime, UNIX_EPOCH};
 
 use common::types::{Block, BlockTag};
@@ -119,7 +119,7 @@ impl<DB: Database> Node<DB> {
         let value = account.slots.get(&slot);
         match value {
             Some(value) => Ok(*value),
-            None => Err(eyre!("slot not found")),
+            None => Err(anyhow!("slot not found")),
         }
     }
 

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -5,7 +5,7 @@ use alloy::primitives::{Address, Bytes, B256, U256, U64};
 use alloy::rpc::types::{
     Filter, Log, SyncStatus, Transaction, TransactionReceipt, TransactionRequest,
 };
-use eyre::Result;
+use anyhow::Result;
 use jsonrpsee::{
     core::{async_trait, server::Methods, Error},
     proc_macros::rpc,

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,11 +5,12 @@ edition = "2021"
 
 [dependencies]
 alloy = { version = "0.2.1", features = ["rpc-types"] }
-eyre.workspace = true
+anyhow.workspace = true
 serde.workspace = true
 hex.workspace = true
 serde_json.workspace = true
 superstruct.workspace = true
 thiserror.workspace = true
+thiserror-no-std.workspace = true
 tracing.workspace = true
 zduny-wasm-timer.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,10 +7,4 @@ edition = "2021"
 alloy = { version = "0.2.1", features = ["rpc-types"] }
 anyhow.workspace = true
 serde.workspace = true
-hex.workspace = true
-serde_json.workspace = true
-superstruct.workspace = true
-thiserror.workspace = true
 thiserror-no-std.workspace = true
-tracing.workspace = true
-zduny-wasm-timer.workspace = true

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -1,5 +1,6 @@
+use alloc::string::{String, ToString};
 use alloy::primitives::B256;
-use thiserror::Error;
+use thiserror_no_std::Error;
 
 use crate::types::BlockTag;
 
@@ -40,5 +41,15 @@ impl<E: ToString> RpcError<E> {
             method: method.to_string(),
             error: err,
         }
+    }
+}
+
+impl<E: ToString> From<RpcError<E>> for anyhow::Error {
+    fn from(error: RpcError<E>) -> Self {
+        anyhow::anyhow!(
+            "RPC error in method '{}': {}",
+            error.method,
+            error.error.to_string()
+        )
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,2 +1,6 @@
+#![no_std]
+
+extern crate alloc;
+
 pub mod errors;
 pub mod types;

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,4 +1,7 @@
-use std::fmt::Display;
+use core::fmt::Display;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 use alloy::primitives::{Address, Bytes, B256, U256, U64};
 use alloy::rpc::types::Transaction;
@@ -54,7 +57,7 @@ impl Transactions {
 }
 
 impl Serialize for Transactions {
-    fn serialize<S>(&self, s: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, s: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -87,7 +90,7 @@ pub enum BlockTag {
 }
 
 impl Display for BlockTag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let formatted = match self {
             Self::Latest => "latest".to_string(),
             Self::Finalized => "finalized".to_string(),

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -8,8 +8,6 @@ alloy.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 hex.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
 reqwest.workspace = true
 futures.workspace = true
 retri.workspace = true
@@ -18,7 +16,6 @@ figment = { version = "0.10.7", features = ["toml", "env"] }
 serde_yaml = "0.9.14"
 strum = { version = "0.26.2", features = ["derive"] }
 
-common = { path = "../common" }
 consensus-core = { path = "../consensus-core" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 alloy.workspace = true
-eyre.workspace = true
+anyhow.workspace = true
 serde.workspace = true
 hex.workspace = true
 thiserror.workspace = true

--- a/config/src/networks.rs
+++ b/config/src/networks.rs
@@ -4,9 +4,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use alloy::primitives::{b256, fixed_bytes};
+use anyhow::Result;
 #[cfg(not(target_arch = "wasm32"))]
 use dirs::home_dir;
-use eyre::Result;
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 
@@ -26,7 +26,7 @@ pub enum Network {
 }
 
 impl FromStr for Network {
-    type Err = eyre::Report;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self> {
         match s {
@@ -34,7 +34,7 @@ impl FromStr for Network {
             "goerli" => Ok(Self::GOERLI),
             "sepolia" => Ok(Self::SEPOLIA),
             "holesky" => Ok(Self::HOLESKY),
-            _ => Err(eyre::eyre!("network not recognized")),
+            _ => Err(anyhow::anyhow!("network not recognized")),
         }
     }
 }
@@ -68,7 +68,7 @@ impl Network {
             5 => Ok(Network::GOERLI),
             11155111 => Ok(Network::SEPOLIA),
             17000 => Ok(Network::HOLESKY),
-            _ => Err(eyre::eyre!("chain id not known")),
+            _ => Err(anyhow::anyhow!("chain id not known")),
         }
     }
 }

--- a/consensus-core/Cargo.toml
+++ b/consensus-core/Cargo.toml
@@ -19,4 +19,6 @@ superstruct.workspace = true
 thiserror-no-std.workspace = true
 tracing.workspace = true
 zduny-wasm-timer.workspace = true
+# Building consensus-core for wasm requires getrandom with the js feature.
+# Source: https://github.com/alloy-rs/core?tab=readme-ov-file#wasm-support
 getrandom = { version = "0.2", features = ["js"] }

--- a/consensus-core/Cargo.toml
+++ b/consensus-core/Cargo.toml
@@ -4,7 +4,7 @@ name = "consensus-core"
 edition = "2021"
 
 [dependencies]
-alloy = { version = "0.2.1", features = ["consensus", "rpc-types", "ssz", "rlp", "k256"] }
+alloy-primitives = { version = "0.7.7", default-features = false }
 bls12_381.workspace = true
 ssz_types.workspace = true
 ethereum_ssz_derive.workspace = true
@@ -13,9 +13,10 @@ tree_hash_derive.workspace = true
 tree_hash.workspace = true
 typenum.workspace = true
 sha2.workspace = true
-eyre.workspace = true
+anyhow.workspace = true
 serde.workspace = true
 superstruct.workspace = true
-thiserror.workspace = true
+thiserror-no-std.workspace = true
 tracing.workspace = true
 zduny-wasm-timer.workspace = true
+getrandom = { version = "0.2", features = ["js"] }

--- a/consensus-core/src/consensus_core.rs
+++ b/consensus-core/src/consensus_core.rs
@@ -1,7 +1,7 @@
-use std::cmp;
+use core::cmp;
 
-use alloy::primitives::B256;
-use eyre::Result;
+use alloy_primitives::B256;
+use anyhow::Result;
 use ssz_types::BitVector;
 use tracing::{info, warn};
 use tree_hash::TreeHash;
@@ -283,7 +283,7 @@ fn verify_generic_update(
 
 pub fn expected_current_slot(now: SystemTime, genesis_time: u64) -> u64 {
     let now = now.duration_since(UNIX_EPOCH).unwrap();
-    let since_genesis = now - std::time::Duration::from_secs(genesis_time);
+    let since_genesis = now - core::time::Duration::from_secs(genesis_time);
 
     since_genesis.as_secs() / 12
 }

--- a/consensus-core/src/errors.rs
+++ b/consensus-core/src/errors.rs
@@ -1,5 +1,12 @@
-use alloy::primitives::B256;
-use thiserror::Error;
+use alloc::string::ToString;
+use alloy_primitives::B256;
+use thiserror_no_std::Error;
+
+impl From<ConsensusError> for anyhow::Error {
+    fn from(error: ConsensusError) -> Self {
+        anyhow::Error::msg(error.to_string())
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum ConsensusError {

--- a/consensus-core/src/lib.rs
+++ b/consensus-core/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 pub mod errors;
 pub mod types;
 

--- a/consensus-core/src/proof.rs
+++ b/consensus-core/src/proof.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::B256;
+use alloy_primitives::B256;
 use sha2::{Digest, Sha256};
 use tree_hash::TreeHash;
 

--- a/consensus-core/src/types/bls.rs
+++ b/consensus-core/src/types/bls.rs
@@ -5,7 +5,7 @@ use bls12_381::{
     multi_miller_loop, G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective, Gt, Scalar,
 };
 use serde::{Deserialize, Serialize};
-use ssz_derive::{Decode, Encode};
+use ssz_derive::Encode;
 use tree_hash_derive::TreeHash;
 
 use super::bytes::ByteVector;

--- a/consensus-core/src/types/bls.rs
+++ b/consensus-core/src/types/bls.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use bls12_381::{
     hash_to_curve::{ExpandMsgXmd, HashToCurve},
     multi_miller_loop, G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective, Gt, Scalar,

--- a/consensus-core/src/types/bytes.rs
+++ b/consensus-core/src/types/bytes.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
-use ssz_derive::{Decode, Encode};
+use ssz_derive::Encode;
 use ssz_types::{
     serde_utils::{hex_fixed_vec, hex_var_list},
     FixedVector, VariableList,

--- a/consensus-core/src/types/bytes.rs
+++ b/consensus-core/src/types/bytes.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
@@ -6,20 +7,20 @@ use ssz_types::{
 };
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, Clone, Default, Encode, Decode, TreeHash)]
+#[derive(Debug, Clone, Default, Encode, TreeHash)]
 #[ssz(struct_behaviour = "transparent")]
 pub struct ByteVector<N: typenum::Unsigned> {
     pub inner: FixedVector<u8, N>,
 }
 
-#[derive(Debug, Clone, Default, Encode, Decode, TreeHash)]
+#[derive(Debug, Clone, Default, Encode, TreeHash)]
 #[ssz(struct_behaviour = "transparent")]
 pub struct ByteList<N: typenum::Unsigned> {
     pub inner: VariableList<u8, N>,
 }
 
 impl<'de, N: typenum::Unsigned> serde::Deserialize<'de> for ByteVector<N> {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -38,7 +39,7 @@ impl<N: typenum::Unsigned> Serialize for ByteVector<N> {
 }
 
 impl<'de, N: typenum::Unsigned> Deserialize<'de> for ByteList<N> {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {

--- a/consensus-core/src/types/mod.rs
+++ b/consensus-core/src/types/mod.rs
@@ -1,5 +1,6 @@
-use alloy::primitives::{Address, FixedBytes, B256, U256};
-use eyre::Result;
+use alloc::vec::Vec;
+use alloy_primitives::{Address, FixedBytes, B256, U256};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use ssz_derive::Encode;
 use ssz_types::{serde_utils::quoted_u64_var_list, BitList, BitVector, FixedVector, VariableList};

--- a/consensus-core/src/types/serde_utils.rs
+++ b/consensus-core/src/types/serde_utils.rs
@@ -1,4 +1,5 @@
 pub mod u64 {
+    use alloc::string::{String, ToString};
     use serde::{de::Error, Deserializer, Serializer};
 
     pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
@@ -18,7 +19,8 @@ pub mod u64 {
 }
 
 pub mod u256 {
-    use alloy::primitives::U256;
+    use alloc::string::String;
+    use alloy_primitives::U256;
     use serde::{de::Error, Deserializer};
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<U256, D::Error>

--- a/consensus-core/src/utils.rs
+++ b/consensus-core/src/utils.rs
@@ -1,5 +1,6 @@
-use alloy::primitives::B256;
-use eyre::Result;
+use alloc::vec::Vec;
+use alloy_primitives::B256;
+use anyhow::Result;
 use ssz_types::{BitVector, FixedVector};
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -19,7 +19,7 @@ serde_json.workspace = true
 
 #misc
 alloy.workspace = true
-eyre.workspace = true
+anyhow.workspace = true
 hex.workspace = true
 tracing.workspace = true
 chrono.workspace = true

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -23,8 +23,6 @@ anyhow.workspace = true
 hex.workspace = true
 tracing.workspace = true
 chrono.workspace = true
-thiserror.workspace = true
-superstruct.workspace = true
 zduny-wasm-timer.workspace = true
 retri.workspace = true
 

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -6,9 +6,9 @@ use alloy::consensus::{Transaction as TxTrait, TxEnvelope};
 use alloy::primitives::{b256, B256, U256, U64};
 use alloy::rlp::Decodable;
 use alloy::rpc::types::{Parity, Signature, Transaction};
+use anyhow::anyhow;
+use anyhow::Result;
 use chrono::Duration;
-use eyre::eyre;
-use eyre::Result;
 use futures::future::join_all;
 use tracing::{debug, error, info, warn};
 use tree_hash::TreeHash;
@@ -361,7 +361,7 @@ impl<R: ConsensusRpc> Inner<R> {
             .rpc
             .get_bootstrap(checkpoint)
             .await
-            .map_err(|err| eyre!("could not fetch bootstrap: {}", err))?;
+            .map_err(|err| anyhow!("could not fetch bootstrap: {}", err))?;
 
         let is_valid = self.is_valid_checkpoint(bootstrap.header.slot);
 

--- a/consensus/src/database.rs
+++ b/consensus/src/database.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use alloy::primitives::B256;
+use anyhow::Result;
 use config::Config;
-use eyre::Result;
 
 pub trait Database: Clone + Sync + Send + 'static {
     fn new(config: &Config) -> Result<Self>
@@ -35,7 +35,7 @@ impl Database for FileDB {
             });
         }
 
-        eyre::bail!("data dir not in config")
+        anyhow::bail!("data dir not in config")
     }
 
     fn save_checkpoint(&self, checkpoint: B256) -> Result<()> {

--- a/consensus/src/rpc/mock_rpc.rs
+++ b/consensus/src/rpc/mock_rpc.rs
@@ -2,7 +2,7 @@ use std::{fs::read_to_string, path::PathBuf};
 
 use alloy::primitives::B256;
 use async_trait::async_trait;
-use eyre::Result;
+use anyhow::Result;
 
 use consensus_core::types::{BeaconBlock, Bootstrap, FinalityUpdate, OptimisticUpdate, Update};
 
@@ -53,7 +53,7 @@ impl ConsensusRpc for MockRpc {
     }
 
     async fn chain_id(&self) -> Result<u64> {
-        eyre::bail!("not implemented")
+        anyhow::bail!("not implemented")
     }
 }
 

--- a/consensus/src/rpc/mock_rpc.rs
+++ b/consensus/src/rpc/mock_rpc.rs
@@ -1,8 +1,8 @@
 use std::{fs::read_to_string, path::PathBuf};
 
 use alloy::primitives::B256;
-use async_trait::async_trait;
 use anyhow::Result;
+use async_trait::async_trait;
 
 use consensus_core::types::{BeaconBlock, Bootstrap, FinalityUpdate, OptimisticUpdate, Update};
 

--- a/consensus/src/rpc/mod.rs
+++ b/consensus/src/rpc/mod.rs
@@ -3,7 +3,7 @@ pub mod nimbus_rpc;
 
 use alloy::primitives::B256;
 use async_trait::async_trait;
-use eyre::Result;
+use anyhow::Result;
 
 use consensus_core::types::{BeaconBlock, Bootstrap, FinalityUpdate, OptimisticUpdate, Update};
 

--- a/consensus/src/rpc/mod.rs
+++ b/consensus/src/rpc/mod.rs
@@ -2,8 +2,8 @@ pub mod mock_rpc;
 pub mod nimbus_rpc;
 
 use alloy::primitives::B256;
-use async_trait::async_trait;
 use anyhow::Result;
+use async_trait::async_trait;
 
 use consensus_core::types::{BeaconBlock, Bootstrap, FinalityUpdate, OptimisticUpdate, Update};
 

--- a/consensus/src/rpc/nimbus_rpc.rs
+++ b/consensus/src/rpc/nimbus_rpc.rs
@@ -1,8 +1,8 @@
 use std::cmp;
 
 use alloy::primitives::B256;
+use anyhow::Result;
 use async_trait::async_trait;
-use eyre::Result;
 use retri::{retry, BackoffSettings};
 use serde::de::DeserializeOwned;
 
@@ -18,7 +18,7 @@ pub struct NimbusRpc {
 
 async fn get<R: DeserializeOwned>(req: &str) -> Result<R> {
     let bytes = retry(
-        || async { Ok::<_, eyre::Report>(reqwest::get(req).await?.bytes().await?) },
+        || async { Ok::<_, anyhow::Error>(reqwest::get(req).await?.bytes().await?) },
         BackoffSettings::default(),
     )
     .await?;

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, str::FromStr};
 
 use alloy::primitives::{utils::format_ether, Address};
-use eyre::Result;
+use anyhow::Result;
 use tracing::info;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::FmtSubscriber;

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -16,7 +16,7 @@ use helios::{
 };
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> anyhow::Result<()> {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env()

--- a/examples/checkpoints.rs
+++ b/examples/checkpoints.rs
@@ -1,4 +1,4 @@
-use eyre::Result;
+use anyhow::Result;
 
 // From helios::config
 use config::{checkpoints, networks};

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use alloy::primitives::b256;
-use eyre::Result;
+use anyhow::Result;
 
 use helios::prelude::*;
 

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -1,5 +1,5 @@
-use dirs::home_dir;
 use anyhow::Result;
+use dirs::home_dir;
 
 use config::CliConfig;
 use helios::prelude::*;

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -1,5 +1,5 @@
 use dirs::home_dir;
-use eyre::Result;
+use anyhow::Result;
 
 use config::CliConfig;
 use helios::prelude::*;

--- a/execution/Cargo.toml
+++ b/execution/Cargo.toml
@@ -20,7 +20,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 # misc
-eyre.workspace = true
+anyhow.workspace = true
 hex.workspace = true
 tracing.workspace = true
 thiserror.workspace = true

--- a/execution/Cargo.toml
+++ b/execution/Cargo.toml
@@ -16,7 +16,6 @@ tokio.workspace = true
 
 # io
 reqwest.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 
 # misc

--- a/execution/src/errors.rs
+++ b/execution/src/errors.rs
@@ -1,6 +1,5 @@
 use alloy::primitives::{Address, Bytes, B256, U256};
 use alloy::sol_types::decode_revert_reason;
-use eyre::Report;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -45,7 +44,7 @@ pub enum EvmError {
     Generic(String),
 
     #[error("rpc error: {0:?}")]
-    RpcError(Report),
+    RpcError(anyhow::Error),
 }
 
 impl EvmError {

--- a/execution/src/evm.rs
+++ b/execution/src/evm.rs
@@ -1,7 +1,7 @@
 use std::{borrow::BorrowMut, collections::HashMap, sync::Arc};
 
 use alloy::{network::TransactionBuilder, rpc::types::TransactionRequest};
-use eyre::{Report, Result};
+use anyhow::Result;
 use futures::future::join_all;
 use revm::{
     primitives::{
@@ -216,7 +216,7 @@ impl<R: ExecutionRpc> EvmState<R> {
             Ok(account.clone())
         } else {
             self.access = Some(StateAccess::Basic(address));
-            eyre::bail!("state missing");
+            anyhow::bail!("state missing");
         }
     }
 
@@ -226,7 +226,7 @@ impl<R: ExecutionRpc> EvmState<R> {
             Ok(*slot)
         } else {
             self.access = Some(StateAccess::Storage(address, slot));
-            eyre::bail!("state missing");
+            anyhow::bail!("state missing");
         }
     }
 
@@ -235,7 +235,7 @@ impl<R: ExecutionRpc> EvmState<R> {
             Ok(*hash)
         } else {
             self.access = Some(StateAccess::BlockHash(block));
-            eyre::bail!("state missing");
+            anyhow::bail!("state missing");
         }
     }
 
@@ -323,9 +323,9 @@ impl<R: ExecutionRpc> EvmState<R> {
 }
 
 impl<R: ExecutionRpc> Database for ProofDB<R> {
-    type Error = Report;
+    type Error = anyhow::Error;
 
-    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Report> {
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, anyhow::Error> {
         if is_precompile(&address) {
             return Ok(Some(AccountInfo::default()));
         }
@@ -339,18 +339,18 @@ impl<R: ExecutionRpc> Database for ProofDB<R> {
         Ok(Some(self.state.get_basic(address)?))
     }
 
-    fn block_hash(&mut self, number: u64) -> Result<B256, Report> {
+    fn block_hash(&mut self, number: u64) -> Result<B256, anyhow::Error> {
         trace!(target: "helios::evm", "fetch block hash for block={:?}", number);
         self.state.get_block_hash(number)
     }
 
-    fn storage(&mut self, address: Address, slot: U256) -> Result<U256, Report> {
+    fn storage(&mut self, address: Address, slot: U256) -> Result<U256, anyhow::Error> {
         trace!(target: "helios::evm", "fetch evm state for address={:?}, slot={}", address, slot);
         self.state.get_storage(address, slot)
     }
 
-    fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Report> {
-        Err(eyre::eyre!("should never be called"))
+    fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, anyhow::Error> {
+        Err(anyhow::anyhow!("should never be called"))
     }
 }
 

--- a/execution/src/rpc/http_rpc.rs
+++ b/execution/src/rpc/http_rpc.rs
@@ -7,8 +7,8 @@ use alloy::rpc::types::{
 };
 use alloy::transports::http::Http;
 use alloy::transports::layers::{RetryBackoffLayer, RetryBackoffService};
-use async_trait::async_trait;
 use anyhow::Result;
+use async_trait::async_trait;
 use reqwest::Client;
 use revm::primitives::AccessList;
 

--- a/execution/src/rpc/http_rpc.rs
+++ b/execution/src/rpc/http_rpc.rs
@@ -8,7 +8,7 @@ use alloy::rpc::types::{
 use alloy::transports::http::Http;
 use alloy::transports::layers::{RetryBackoffLayer, RetryBackoffService};
 use async_trait::async_trait;
-use eyre::Result;
+use anyhow::Result;
 use reqwest::Client;
 use revm::primitives::AccessList;
 

--- a/execution/src/rpc/mock_rpc.rs
+++ b/execution/src/rpc/mock_rpc.rs
@@ -5,8 +5,8 @@ use alloy::rpc::types::{
     AccessList, EIP1186AccountProofResponse, FeeHistory, Filter, Log, Transaction,
     TransactionReceipt, TransactionRequest,
 };
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use eyre::{eyre, Result};
 
 use super::ExecutionRpc;
 use common::types::BlockTag;
@@ -39,7 +39,7 @@ impl ExecutionRpc for MockRpc {
         _opts: &TransactionRequest,
         _block: BlockTag,
     ) -> Result<AccessList> {
-        Err(eyre!("not implemented"))
+        Err(anyhow!("not implemented"))
     }
 
     async fn get_code(&self, _address: Address, _block: u64) -> Result<Vec<u8>> {
@@ -48,7 +48,7 @@ impl ExecutionRpc for MockRpc {
     }
 
     async fn send_raw_transaction(&self, _bytes: &[u8]) -> Result<B256> {
-        Err(eyre!("not implemented"))
+        Err(anyhow!("not implemented"))
     }
 
     async fn get_transaction_receipt(&self, _tx_hash: B256) -> Result<Option<TransactionReceipt>> {
@@ -72,23 +72,23 @@ impl ExecutionRpc for MockRpc {
     }
 
     async fn uninstall_filter(&self, _filter_id: U256) -> Result<bool> {
-        Err(eyre!("not implemented"))
+        Err(anyhow!("not implemented"))
     }
 
     async fn get_new_filter(&self, _filter: &Filter) -> Result<U256> {
-        Err(eyre!("not implemented"))
+        Err(anyhow!("not implemented"))
     }
 
     async fn get_new_block_filter(&self) -> Result<U256> {
-        Err(eyre!("not implemented"))
+        Err(anyhow!("not implemented"))
     }
 
     async fn get_new_pending_transaction_filter(&self) -> Result<U256> {
-        Err(eyre!("not implemented"))
+        Err(anyhow!("not implemented"))
     }
 
     async fn chain_id(&self) -> Result<u64> {
-        Err(eyre!("not implemented"))
+        Err(anyhow!("not implemented"))
     }
 
     async fn get_fee_history(

--- a/execution/src/rpc/mod.rs
+++ b/execution/src/rpc/mod.rs
@@ -5,7 +5,7 @@ use alloy::rpc::types::{
     AccessList, EIP1186AccountProofResponse, FeeHistory, Filter, Log, Transaction,
     TransactionReceipt, TransactionRequest,
 };
-use eyre::Result;
+use anyhow::Result;
 
 use common::types::BlockTag;
 

--- a/helios-ts/Cargo.toml
+++ b/helios-ts/Cargo.toml
@@ -19,12 +19,9 @@ anyhow.workspace = true
 alloy.workspace = true
 
 hex = "0.4.3"
-serde = { version = "1.0.143", features = ["derive"] }
-serde_json = "1.0.85"
 
 client = { path = "../client" }
 consensus = { path = "../consensus" }
-execution = { path = "../execution" }
 config = { path = "../config" }
 common = { path = "../common" }
 

--- a/helios-ts/Cargo.toml
+++ b/helios-ts/Cargo.toml
@@ -15,7 +15,7 @@ wasm-bindgen-test = "0.3.0"
 serde-wasm-bindgen = "0.6.5"
 console_error_panic_hook = "0.1.7"
 
-eyre.workspace = true
+anyhow.workspace = true
 alloy.workspace = true
 
 hex = "0.4.3"

--- a/helios-ts/src/lib.rs
+++ b/helios-ts/src/lib.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use alloy::hex::FromHex;
 use alloy::primitives::{Address, B256};
 use alloy::rpc::types::{Filter, TransactionRequest};
-use eyre::Result;
+use anyhow::Result;
 use wasm_bindgen::prelude::*;
 
 use common::types::BlockTag;

--- a/helios-ts/src/storage.rs
+++ b/helios-ts/src/storage.rs
@@ -2,7 +2,7 @@ extern crate console_error_panic_hook;
 extern crate web_sys;
 
 use alloy::{hex::FromHex, primitives::B256};
-use eyre::Result;
+use anyhow::Result;
 use wasm_bindgen::prelude::*;
 
 use config::Config;
@@ -19,7 +19,7 @@ impl Database for LocalStorageDB {
             return Ok(Self {});
         }
 
-        eyre::bail!("local_storage not available")
+        anyhow::bail!("local_storage not available")
     }
 
     fn load_checkpoint(&self) -> Result<B256> {
@@ -29,12 +29,12 @@ impl Database for LocalStorageDB {
             if let Ok(Some(checkpoint)) = checkpoint {
                 let checkpoint = checkpoint.strip_prefix("0x").unwrap_or(&checkpoint);
                 return B256::from_hex(checkpoint)
-                    .map_err(|_| eyre::eyre!("Failed to decode checkpoint"));
+                    .map_err(|_| anyhow::anyhow!("Failed to decode checkpoint"));
             }
-            eyre::bail!("checkpoint not found")
+            anyhow::bail!("checkpoint not found")
         }
 
-        eyre::bail!("local_storage not available")
+        anyhow::bail!("local_storage not available")
     }
 
     fn save_checkpoint(&self, checkpoint: B256) -> Result<()> {
@@ -46,6 +46,6 @@ impl Database for LocalStorageDB {
             return Ok(());
         }
 
-        eyre::bail!("local_storage not available")
+        anyhow::bail!("local_storage not available")
     }
 }


### PR DESCRIPTION
## Overview
External users of Helios require `common` and `consensus-core` to be compiled to `no-std` targets such as `wasm32-unknown-unknown` for use in chain binaries (e.g. WASM binaries for Substrate chains). Add support for this target to both `consensus-core` and `common` by changing the error crate, adding a `no-std` flag, and adding a CI job which confirms the compatibility of these crates.

## Details
- Add `no-std` flag to both `common` and `consensus-core`.
- Add CI test to confirm that `common` and `consensus-core` compile on the `wasm32-unknown-unknown` target.
- Change error library to `anyhow` which has `no-std` support.
- Use `alloy-primitives` instead of `alloy` for `no-std` support.
- Note: Needed to remove the `ssz-derive` `Decode` trait, because it required some `std` crates. This can be re-added more carefully in the future.
- `eyre::Report` and `anyhow::Result` are equivalent.