### PR TITLE
feat: Add WASM compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,20 @@ jobs:
         with:
           command: clippy
           args: --all -- -D warnings
+  wasm-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Check wasm compatibility for common and consensus-core
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target wasm32-unknown-unknown -p common -p consensus-core --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,7 @@ dependencies = [
  "ethereum_ssz 0.6.0",
  "ethereum_ssz_derive 0.6.0",
  "eyre",
+ "getrandom 0.2.15",
  "serde",
  "sha2 0.9.9",
  "ssz_types",

--- a/consensus-core/Cargo.toml
+++ b/consensus-core/Cargo.toml
@@ -4,7 +4,13 @@ name = "consensus-core"
 edition = "2021"
 
 [dependencies]
-alloy = { version = "0.2.1", features = ["consensus", "rpc-types", "ssz", "rlp", "k256"] }
+alloy = { version = "0.2.1", features = [
+    "consensus",
+    "rpc-types",
+    "ssz",
+    "rlp",
+    "k256",
+] }
 bls12_381.workspace = true
 ssz_types.workspace = true
 ethereum_ssz_derive.workspace = true
@@ -19,3 +25,6 @@ superstruct.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 zduny-wasm-timer.workspace = true
+# Building consensus-core for wasm requires getrandom with the js feature.
+# Source: https://github.com/alloy-rs/core?tab=readme-ov-file#wasm-support
+getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
External users of Helios require `consensus-core` to be compiled to targets such as `wasm32-unknown-unknown` for use in chain binaries (e.g. WASM binaries for Substrate chains). 

Add support for WASM to `consensus-core` and add a CI job which confirms WASM compatibility.


## Misc
I've tested that a `wasm32-unknown-unknown` binary can be built when importing this crate here: https://github.com/succinctlabs/sp1-helios/pull/5