### PR TITLE
fixes #233: eth_getTransactionByHash & eth_getTransactionByBlockHashAndIndex in helios-ts provider

### DIFF
--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -104,6 +104,12 @@ export class HeliosProvider {
       case "eth_getTransactionReceipt": {
         return this.#client.get_transaction_receipt(req.params[0]);
       }
+      case "eth_getTransactionByHash": {
+        return this.#client.get_transaction_by_hash(req.params[0]);
+      }
+      case "eth_getTransactionByBlockHashAndIndex": {
+        return this.#client.get_transaction_by_block_hash_and_index(req.params[0], req.params[1]);
+      }
       case "eth_getLogs": {
         return this.#client.get_logs(req.params[0]);
       }

--- a/helios-ts/src/ethereum.rs
+++ b/helios-ts/src/ethereum.rs
@@ -143,6 +143,21 @@ impl EthereumClient {
     }
 
     #[wasm_bindgen]
+    pub async fn get_transaction_by_block_hash_and_index(
+        &self,
+        hash: JsValue,
+        index: JsValue,
+    ) -> Result<JsValue, JsError> {
+        let hash: B256 = serde_wasm_bindgen::from_value(hash)?;
+        let index: u64 = serde_wasm_bindgen::from_value(index)?;
+        let tx = self
+            .inner
+            .get_transaction_by_block_hash_and_index(hash, index)
+            .await;
+        Ok(serde_wasm_bindgen::to_value(&tx)?)
+    }
+
+    #[wasm_bindgen]
     pub async fn get_transaction_count(
         &self,
         addr: JsValue,

--- a/helios-ts/src/opstack.rs
+++ b/helios-ts/src/opstack.rs
@@ -86,6 +86,21 @@ impl OpStackClient {
     }
 
     #[wasm_bindgen]
+    pub async fn get_transaction_by_block_hash_and_index(
+        &self,
+        hash: JsValue,
+        index: JsValue,
+    ) -> Result<JsValue, JsError> {
+        let hash: B256 = serde_wasm_bindgen::from_value(hash)?;
+        let index: u64 = serde_wasm_bindgen::from_value(index)?;
+        let tx = self
+            .inner
+            .get_transaction_by_block_hash_and_index(hash, index)
+            .await;
+        Ok(serde_wasm_bindgen::to_value(&tx)?)
+    }
+
+    #[wasm_bindgen]
     pub async fn get_transaction_count(
         &self,
         addr: JsValue,

--- a/rpc.md
+++ b/rpc.md
@@ -19,6 +19,8 @@ Helios provides a variety of RPC methods for interacting with the Ethereum netwo
 | `eth_getBlockByHash` | `get_block_by_hash` | Returns the information of a block by hash. | `get_block_by_hash(&self, hash: &str, full_tx: bool)` |
 | `eth_sendRawTransaction` | `send_raw_transaction` | Submits a raw transaction to the network. | `client.send_raw_transaction(&self, bytes: &str)` |
 | `eth_getTransactionReceipt` | `get_transaction_receipt` | Returns the receipt of a transaction by transaction hash. | `client.get_transaction_receipt(&self, hash: &str)` |
+| `eth_getTransactionByHash` | `get_transaction_by_hash` | Returns the information about a transaction requested by transaction hash. | `client.get_transaction_by_hash(&self, hash: &str)`
+| `eth_getTransactionByBlockHashAndIndex` | `get_transaction_by_block_hash_and_index` | Returns information about a transaction by block hash and transaction index position. | `client.get_transaction_by_block_hash_and_index(&self, hash: &str, index: u64)`
 | `eth_getLogs` | `get_logs` | Returns an array of logs matching the filter. | `client.get_logs(&self, filter: Filter)` |
 | `eth_getStorageAt` | `get_storage_at` | Returns the value from a storage position at a given address. | `client.get_storage_at(&self, address: &str, slot: H256, block: BlockTag)` |
 | `eth_getBlockTransactionCountByHash` | `get_block_transaction_count_by_hash` | Returns the number of transactions in a block from a block matching the transaction hash. | `client.get_block_transaction_count_by_hash(&self, hash: &str)` |


### PR DESCRIPTION
Closes #233.

Changes:
- Expose `eth_getTransactionByHash` and `eth_getTransactionByBlockHashAndIndex` in the helios-ts provider.
- Add info on `eth_getTransactionByHash` and `eth_getTransactionByBlockHashAndIndex` in rpc.md