### PR TITLE
fix: missing parentheses in helios-ts/lib.ts

### DIFF
--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -110,7 +110,7 @@ export class HeliosProvider {
       case "eth_getTransactionByBlockHashAndIndex": {
         return this.#client.get_transaction_by_block_hash_and_index(req.params[0], req.params[1]);
       }
-      case "eth_getBlockReceipts":
+      case "eth_getBlockReceipts": {
         return this.#client.get_block_receipts(req.params[0]);
       }
       case "eth_getLogs": {

--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -31,10 +31,7 @@ export class HeliosProvider {
       const executionRpc = config.executionRpc;
       const network = config.network;
 
-      this.#client = new OpStackClient(
-        executionRpc,
-        network,
-      );
+      this.#client = new OpStackClient(executionRpc, network);
     } else {
       throw "invalid kind: must be ethereum or opstack";
     }
@@ -108,7 +105,10 @@ export class HeliosProvider {
         return this.#client.get_transaction_by_hash(req.params[0]);
       }
       case "eth_getTransactionByBlockHashAndIndex": {
-        return this.#client.get_transaction_by_block_hash_and_index(req.params[0], req.params[1]);
+        return this.#client.get_transaction_by_block_hash_and_index(
+          req.params[0],
+          req.params[1]
+        );
       }
       case "eth_getBlockReceipts": {
         return this.#client.get_block_receipts(req.params[0]);


### PR DESCRIPTION
This fixes a typo (missing `{`) introduced in https://github.com/a16z/helios/pull/425.