### PR TITLE
Typo Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! The entire size of Helios's binary is 13Mb and compiles into WebAssembly. This makes it a perfect target to embed directly inside wallets and dapps.
 //!
-//! Examples on how you can use helios can be found in the [`examples` directory of the repository](https://github.com/a16z/helios/tree/master/examples) and in the `tests/` directories of each crate.
+//! Examples of using Helios can be found in the [`examples` directory of the repository](https://github.com/a16z/helios/tree/master/examples) and in the `tests/` directories of each crate.
 //!
 
 pub mod core {


### PR DESCRIPTION
### Description:
I noticed a small but important correction in the documentation. The phrase **"Examples on how you can use helios"** sounded a bit awkward and could be phrased more clearly. I’ve updated it to **"Examples of using Helios"**.

### Why it matters:
The original wording could cause slight confusion or awkwardness for readers. By adjusting the phrasing, the sentence now reads more naturally and aligns better with common English expression, improving readability and clarity for users.

