### PR TITLE
Fix Typos and Improve Clarity in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Helios is a trustless, efficient, and portable multichain light client written i
 
 Helios converts an untrusted centralized RPC endpoint into a safe unmanipulable local RPC for its users. It syncs in seconds, requires no storage, and is lightweight enough to run on mobile devices.
 
-Helios has a small binary size and compiles into WebAssembly. This makes it a perfect target to embed directly inside wallets and dapps.
+Helios has a small binary size and compiles into WebAssembly. This makes it a perfect target to embed directly inside wallets and dapps.README.md
 
 ## Installing
 
@@ -144,7 +144,7 @@ cp .env.example .env
 To run all tests, use the following command:
 
 ```sh
-cargo test-all
+cargo test --all
 ```
 
 To run tests for an individual package, use this command, replacing <package-name> with the package you want to test:
@@ -159,7 +159,7 @@ All contributions to Helios are welcome. Before opening a PR, please submit an i
 
 ## Telegram
 
-If you are having trouble with Helios or are considering contributing, feel free to join our telegram [here](https://t.me/+IntDY_gZJSRkNTJj).
+If you are having trouble with Helios or are considering contributing, feel free to join our Telegram [here](https://t.me/+IntDY_gZJSRkNTJj).
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Helios is a trustless, efficient, and portable multichain light client written i
 
 Helios converts an untrusted centralized RPC endpoint into a safe unmanipulable local RPC for its users. It syncs in seconds, requires no storage, and is lightweight enough to run on mobile devices.
 
-Helios has a small binary size and compiles into WebAssembly. This makes it a perfect target to embed directly inside wallets and dapps.README.md
+Helios has a small binary size and compiles into WebAssembly. This makes it a perfect target to embed directly inside wallets and dapps.
 
 ## Installing
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -2,12 +2,12 @@
 
 Helios performance is measured using [criterion](https://github.com/bheisler/criterion.rs) for comprehensive statistics-driven benchmarking.
 
-Benchmarks are defined in the [benches](./) subdirectory and can be run using the cargo `bench` subcommand (eg `cargo bench`). To run a specific benchmark, you can use `cargo bench --bench <name>`, where `<name>` is one of the benchmarks defined in the [Cargo.toml](./Cargo.toml) file under a `[[bench]]` section.
+Benchmarks are defined in the [benches](./) subdirectory and can be run using the cargo `bench` subcommand (e.g. `cargo bench`). To run a specific benchmark, you can use `cargo bench --bench <name>`, where `<name>` is one of the benchmarks defined in the [Cargo.toml](./Cargo.toml) file under a `[[bench]]` section.
 
 
 #### Flamegraphs
 
-[Flamegraph](https://github.com/brendangregg/FlameGraph) is a powerful rust crate for generating profile visualizations, that is graphing the time a program spends in each function. Functions called during execution are displayed as horizontal rectangles with the width proportional to the time spent in that function. As the call stack grows (think nested function invocations), the rectangles are stacked vertically. This provides a powerful visualization for quickly understanding which parts of a codebase take up disproportionate amounts of time.
+[Flamegraph](https://github.com/brendangregg/FlameGraph) is a powerful rust crate for generating profile visualizations, which graphs the time a program spends in each function. Functions called during execution are displayed as horizontal rectangles with the width proportional to the time spent in that function. As the call stack grows (think nested function invocations), the rectangles are stacked vertically. This provides a powerful visualization for quickly understanding which parts of a codebase take up disproportionate amounts of time.
 
 Check out Brendan Gregg's [Flame Graphs](http://www.brendangregg.com/flamegraphs.html) blog post if you're interested in learning more about flamegraphs and performance visualizations in general.
 


### PR DESCRIPTION
Changes Made:
Command Correction:

Updated cargo test-all to cargo test --all to reflect the correct syntax for running tests.
Capitalization Fix:

Changed "telegram" to "Telegram" for proper noun capitalization.
Language Improvement:

Replaced "eg" with "e.g." for grammatical correctness and consistency.
Revised "that is graphing the time a program spends in each function" to "which graphs the time a program spends in each function" for clarity and conciseness.
Reason for Changes:
To fix typographical and grammatical issues.
To enhance readability and ensure the documentation adheres to standard conventions.
To ensure correctness of commands and language usage.
Testing and Verification:
Verified all corrections in the documentation for accuracy.
Ensured that the updated cargo test --all command executes correctly.