### PR TITLE
Fix incorrect testing command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cp .env.example .env
 To run all tests, use the following command:
 
 ```sh
-cargo test-all
+cargo test --all
 ```
 
 To run tests for an individual package, use this command, replacing <package-name> with the package you want to test:


### PR DESCRIPTION
### Description  
This change corrects a minor but important typo in the documentation under the **Testing** section. The command for running all tests was written as:  

<img width="188" alt="Снимок экрана 2024-12-09 в 15 00 56" src="https://github.com/user-attachments/assets/b5e34e20-65f1-466a-8d4e-18c033a472bf">

However, this is not a valid Cargo command. The correct syntax is:  

```sh
cargo test --all
```  

This fix ensures that users following the documentation can successfully run all tests without confusion or errors. The previous version of the command could lead to failed execution, potentially frustrating contributors or users attempting to validate the project. 