### PR TITLE
refactor: change rpc from string to url in cli entrypoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,6 +3051,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -3136,6 +3137,7 @@ dependencies = [
  "tree_hash",
  "triehash-ethereum",
  "typenum",
+ "url",
  "wasm-bindgen-futures",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.5.4", features = ["derive", "env"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 dirs = "5.0.1"
 ctrlc = "3.2.3"
+url = "2.5.0"
 
 helios-core = { path = "../core" }
 helios-ethereum = { path = "../ethereum" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -25,6 +25,7 @@ use helios_opstack::{config::Config as OpStackConfig, OpStackClient, OpStackClie
 use tracing::{error, info};
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::FmtSubscriber;
+use url::Url;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -129,10 +130,10 @@ struct EthereumArgs {
     rpc_port: Option<u16>,
     #[clap(short = 'w', long, env)]
     checkpoint: Option<B256>,
-    #[clap(short, long, env)]
-    execution_rpc: Option<String>,
-    #[clap(short, long, env)]
-    consensus_rpc: Option<String>,
+    #[clap(short, long, env, value_parser = parse_url)]
+    execution_rpc: Option<Url>,
+    #[clap(short, long, env, value_parser = parse_url)]
+    consensus_rpc: Option<Url>,
     #[clap(short, long, env)]
     data_dir: Option<String>,
     #[clap(short = 'f', long, env)]
@@ -187,10 +188,10 @@ struct OpStackArgs {
     rpc_bind_ip: Option<IpAddr>,
     #[clap(short = 'p', long, env, default_value = "8545")]
     rpc_port: Option<u16>,
-    #[clap(short, long, env)]
-    execution_rpc: Option<String>,
-    #[clap(short, long, env)]
-    consensus_rpc: Option<String>,
+    #[clap(short, long, env, value_parser = parse_url)]
+    execution_rpc: Option<Url>,
+    #[clap(short, long, env, value_parser = parse_url)]
+    consensus_rpc: Option<Url>,
     #[clap(
         short = 'w',
         long = "ethereum-checkpoint",
@@ -226,11 +227,11 @@ impl OpStackArgs {
         let mut user_dict = HashMap::new();
 
         if let Some(rpc) = &self.execution_rpc {
-            user_dict.insert("execution_rpc", Value::from(rpc.clone()));
+            user_dict.insert("execution_rpc", Value::from(rpc.to_string()));
         }
 
         if let Some(rpc) = &self.consensus_rpc {
-            user_dict.insert("consensus_rpc", Value::from(rpc.clone()));
+            user_dict.insert("consensus_rpc", Value::from(rpc.to_string()));
         }
 
         if self.rpc_bind_ip.is_some() && self.rpc_port.is_some() {
@@ -264,4 +265,8 @@ fn true_or_none(b: bool) -> Option<bool> {
     } else {
         None
     }
+}
+
+fn parse_url(s: &str) -> Result<Url, url::ParseError> {
+    Url::parse(s)
 }

--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -13,6 +13,7 @@ triehash-ethereum.workspace = true
 figment = { version = "0.10.7", features = ["toml", "env"] }
 serde_yaml = "0.9.14"
 strum = { version = "0.26.2", features = ["derive"] }
+url = "2.5.0"
 
 # async/futures
 tokio.workspace = true

--- a/ethereum/src/config/cli.rs
+++ b/ethereum/src/config/cli.rs
@@ -1,5 +1,6 @@
 use std::net::IpAddr;
 use std::{collections::HashMap, path::PathBuf};
+use url::Url;
 
 use alloy::primitives::B256;
 use figment::{providers::Serialized, value::Value};
@@ -8,8 +9,8 @@ use serde::{Deserialize, Serialize};
 /// Cli Config
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct CliConfig {
-    pub execution_rpc: Option<String>,
-    pub consensus_rpc: Option<String>,
+    pub execution_rpc: Option<Url>,
+    pub consensus_rpc: Option<Url>,
     pub checkpoint: Option<B256>,
     pub rpc_bind_ip: Option<IpAddr>,
     pub rpc_port: Option<u16>,
@@ -24,11 +25,11 @@ impl CliConfig {
         let mut user_dict = HashMap::new();
 
         if let Some(rpc) = &self.execution_rpc {
-            user_dict.insert("execution_rpc", Value::from(rpc.clone()));
+            user_dict.insert("execution_rpc", Value::from(rpc.to_string()));
         }
 
         if let Some(rpc) = &self.consensus_rpc {
-            user_dict.insert("consensus_rpc", Value::from(rpc.clone()));
+            user_dict.insert("consensus_rpc", Value::from(rpc.to_string()));
         }
 
         if let Some(checkpoint) = &self.checkpoint {


### PR DESCRIPTION
partially towards #474 

replaces string type to url in cli. There are other places this type change can be implemented, will raise similar small PRs towards #474 