### PR TITLE
chore: update alloy version to 9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -81,9 +82,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4a4aaae80afd4be443a6aecd92a6b255dcdd000f97996928efb33d8a71e100"
+checksum = "4305e0397a7eb57f4840a048583b7ab904eabd250264568fc65a7e38a76c9e40"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -111,36 +112,54 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4932d790c723181807738cf1ac68198ab581cd699545b155601332541ee47bd"
 dependencies = [
- "alloy-primitives 0.8.9",
+ "alloy-primitives",
  "num_enum",
  "strum",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c309895995eaa4bfcc345f5515a39c7df9447798645cc8bf462b6c5bf1dc96"
+checksum = "d802a6d579d924a2926d181bce43231aaab4699a7c206197e88fbc6b9dda846f"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "alloy-trie",
+ "auto_impl",
  "c-kzg",
+ "derive_more",
+ "k256",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1bcb3e4810bff7e2a62ac0d741c70a7b5560e57b76eb0f0d33e1070735c60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4e0ef72b0876ae3068b2ed7dfae9ae1779ce13cfaec2ee1f08f5bd0348dc57"
+checksum = "8e56bc4dc06ab205dc4106348c44b92e0d979148f8db751994c11caabf5ebbef"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-types-eth",
@@ -148,30 +167,30 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
- "thiserror",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "alloy-core"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529fc6310dc1126c8de51c376cbc59c79c7f662bd742be7dc67055d5421a81b4"
+checksum = "c618bd382f0bc2ac26a7e4bfae01c9b015ca8f21b37ca40059ae35a7e62b3dc6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413902aa18a97569e60f679c23f46a18db1656d87ab4d4e49d0e1e52042f66df"
+checksum = "41056bde53ae10ffbbf11618efbe1e0290859e5eab0fe9ef82ebdb62f12a866f"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
@@ -182,19 +201,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "0.2.1"
+name = "alloy-eip2930"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9431c99a3b3fe606ede4b3d4043bdfbcb780c45b8d8d226c3804e2b75cfbe68"
+checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c986539255fb839d1533c128e190e557e52ff652c9ef62939e233a81dd93f7e"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "k256",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "k256",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938bc1cf2ec42579e187834efc254e76dd3fa19f526b57872713e6b95f411305"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702 0.5.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
- "derive_more 0.99.18",
- "ethereum_ssz 0.5.4",
- "ethereum_ssz_derive 0.5.4",
- "k256",
+ "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "once_cell",
  "serde",
  "sha2 0.10.8",
@@ -202,22 +259,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79614dfe86144328da11098edcc7bc1a3f25ad8d3134a9eb9e857e06f0d9840d"
+checksum = "b648eac186485ead3da160985b929e610a45eb39903f750da9b35f58a91eef52"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-eips",
+ "alloy-primitives",
  "alloy-serde",
+ "alloy-trie",
  "serde",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc05b04ac331a9f07e3a4036ef7926e49a8bf84a99a1ccfc7e2ab55a5fcbb372"
+checksum = "c357da577dfb56998d01f574d81ad7a1958d248740a7981b205d69d65a7da404"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -225,29 +284,31 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e2865c4c3bb4cdad3f0d9ec1ab5c0c657ba69a375651bd35e32fb6c180ccc2"
+checksum = "a1a38b4b49667a84ecad7cdaf431b8bd3f14ca496e5a021df1c26d5c4595dca6"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.9",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-network"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e701fc87ef9a3139154b0b4ccb935b565d27ffd9de020fe541bf2dec5ae4ede"
+checksum = "4fb5dc326960e88eec6b5e9add221a071f15cb8fa93b9e88ee9c76cd0e4e1009"
 dependencies = [
  "alloy-consensus",
+ "alloy-consensus-any",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
@@ -255,65 +316,57 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d5a0f9170b10988b6774498a022845e13eda94318440d17709d50687f67f9"
+checksum = "1535c89ae0648f2c15c0bf9b8b92670f6b3b8515b645425c8b46462563c0eae4"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
+checksum = "6259a506ab13e1d658796c31e6e39d2e2ee89243bcc505ddc613b35732e0a430"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.18",
- "ethereum_ssz 0.5.4",
+ "derive_more",
+ "foldhash",
+ "hashbrown 0.15.0",
  "hex-literal",
+ "indexmap",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "rand 0.8.5",
  "ruint",
+ "rustc-hash 2.1.0",
  "serde",
- "tiny-keccak 2.0.2",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71738eb20c42c5fb149571e76536a0f309d142f3957c28791662b96baf77a3d"
-dependencies = [
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 1.0.0",
- "hex-literal",
- "itoa",
- "paste",
- "ruint",
+ "sha3",
  "tiny-keccak 2.0.2",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9c0ab10b93de601a6396fc7ff2ea10d3b28c46f079338fa562107ebf9857c8"
+checksum = "a9a9d6ef38d75e4b0dce6737463099698f9b839d1c3f7c8883bfdfce8954374b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -321,7 +374,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
@@ -336,23 +389,27 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru",
+ "parking_lot 0.12.3",
  "pin-project",
  "reqwest",
+ "schnellru",
  "serde",
  "serde_json",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
+ "wasmtimer 0.4.1",
 ]
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5da2c55cbaf229bad3c5f8b00b5ab66c74ef093e5f3a753d874cfecf7d2281"
+checksum = "1be3b30bab565198a1bda090915dd165ca9211154eb0b37d046a22829418dcc0"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-transport",
  "bimap",
  "futures",
@@ -360,15 +417,15 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
+checksum = "f542548a609dca89fcd72b3b9f355928cf844d4363c5eed9c5273a3dd225e097"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec 0.7.6",
@@ -377,23 +434,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b09cae092c27b6f1bde952653a22708691802e57bfef4a2973b80bea21efd3f"
+checksum = "5a833d97bf8a5f0f878daf2c8451fff7de7f9de38baa5a45d936ec718d81255a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38e3ffdb285df5d9f60cb988d336d9b8e3505acb78750c3bc60336a7af41d3"
+checksum = "f5ed1e9957edfc8d155e2610e2ff3e10b059b89a6103de9f01579f40d8926d47"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -406,17 +463,19 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tracing",
  "url",
+ "wasmtimer 0.4.1",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c31a3750b8f5a350d17354e46a52b0f2f19ec5f2006d816935af599dedc521"
+checksum = "206749723862bd27d5468270e30fc987c5b4376240aefee728d7e64282c9d146"
 dependencies = [
+ "alloy-primitives",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -425,139 +484,149 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-beacon"
-version = "0.2.1"
+name = "alloy-rpc-types-any"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a24bcff4f9691d7a4971b43e5da46aa7b4ce22ed7789796612dc1eed220983"
+checksum = "5e6ff23d7bde6ddeea4c1ca98e7a5a728326d543bd7133735c04ea83ebde41d0"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-beacon"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e59d76349c11aa7fac9aadeceb65cf31d3f3430b407159b172b39d36ccb0671a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-rpc-types-engine",
- "ethereum_ssz 0.5.4",
- "ethereum_ssz_derive 0.5.4",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff63f51b2fb2f547df5218527fd0653afb1947bf7fead5b3ce58c75d170b30f7"
+checksum = "ee96e9793d3ec528ead6e8580f24e9acc71f5c2bc35feefba24465044bb77d76"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
  "alloy-serde",
- "ethereum_ssz 0.5.4",
- "ethereum_ssz_derive 0.5.4",
- "jsonwebtoken",
- "rand 0.8.5",
+ "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
- "thiserror",
+ "strum",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e18424d962d7700a882fe423714bd5b9dde74c7a7589d4255ea64068773aef"
+checksum = "319a0ca31863bd6fb9aafeaa16425d0a2f1228da44bc24fd2f997ba50afe7e18"
 dependencies = [
  "alloy-consensus",
+ "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33feda6a53e6079895aed1d08dcb98a1377b000d80d16370fbbdb8155d547ef"
+checksum = "81537867986734e5867a9131145bdc56301f5b37ef9c9fb4654d7f7691a4015d"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-signer"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740a25b92e849ed7b0fa013951fe2f64be9af1ad5abe805037b44fb7770c5c47"
+checksum = "0fdcbfe7079c877b3cb6ec43017e94f66432480f1c1779f736c064e6a8d422cc"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "async-trait",
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0707d4f63e4356a110b30ef3add8732ab6d181dd7be4607bf79b8777105cee"
+checksum = "3f5175bd063463e25f1ffc6daaa223db15baf4b18e3d83d0d31fb95756aab6cc"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-signer",
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
+checksum = "d9d64f851d95619233f74b310f12bcf16e0cbc27ee3762b6115c14a84809280a"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
+checksum = "6bf7ed1574b699f48bf17caab4e6e54c6d12bc3c006ab33d58b1e227c1c3559f"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.6.0",
- "proc-macro-error",
+ "indexmap",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
  "syn-solidity",
  "tiny-keccak 2.0.2",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
+checksum = "8c02997ccef5f34f9c099277d4145f183b422938ed5322dc57a089fe9b9ad9ee"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -566,15 +635,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.84",
+ "syn 2.0.91",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbcba3ca07cf7975f15d871b721fb18031eec8bce51103907f6dcce00b255d98"
+checksum = "ce13ff37285b0870d0a0746992a4ae48efaf34b766ae4c2640fa15e5305f8e73"
 dependencies = [
  "serde",
  "winnow",
@@ -582,12 +651,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
+checksum = "1174cafd6c6d810711b4e00383037bdb458efc4fe3dbafafa16567e0320c54d8"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -595,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0590afbdacf2f8cca49d025a2466f3b6584a016a8b28f532f29f8da1007bae"
+checksum = "6121c7a8791d7984bd3e1a487aae55c62358b0bd94330126db41d795d942e24e"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -605,33 +674,34 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tracing",
  "url",
+ "wasmtimer 0.4.1",
 ]
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2437d145d80ea1aecde8574d2058cceb8b3c9cba05f6aea8e67907c660d46698"
+checksum = "15487cd2d7f2bfd8546e851d80db470603c2a1de82f7c39403078356b20d9a21"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804494366e20468776db4e18f9eb5db7db0fe14f1271eb6dbf155d867233405c"
+checksum = "a74511d4703f571c2b4da85458b5634855d97e10a94407c05d97b2052ed5450b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -648,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.2.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af855163e7df008799941aa6dd324a43ef2bf264b08ba4b22d44aad6ced65300"
+checksum = "f812a1f1ae7955964727d3040bf240955ca324d80383b9dd0ab21a6de3007386"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -662,6 +732,22 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "ws_stream_wasm",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e428104b2445a4f929030891b3dbf8c94433a8349ba6480946bf6af7975c2f6"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arrayvec 0.7.6",
+ "derive_more",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -881,6 +967,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -894,7 +983,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.65",
  "time",
 ]
 
@@ -985,7 +1074,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -996,7 +1085,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1056,7 +1145,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1497,7 +1586,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1539,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1555,12 +1644,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -1799,7 +1882,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1847,7 +1930,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1869,16 +1952,17 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1952,7 +2036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -1964,19 +2047,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.84",
 ]
 
 [[package]]
@@ -1996,7 +2066,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
  "unicode-xid",
 ]
 
@@ -2087,7 +2157,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2253,7 +2323,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2280,22 +2350,9 @@ checksum = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
 dependencies = [
  "crunchy",
  "fixed-hash 0.5.2",
- "impl-rlp 0.2.1",
+ "impl-rlp",
  "impl-serde 0.2.3",
  "tiny-keccak 1.5.0",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash 0.8.0",
- "impl-rlp 0.3.0",
- "impl-serde 0.4.0",
- "tiny-keccak 2.0.2",
 ]
 
 [[package]]
@@ -2304,26 +2361,12 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
 dependencies = [
- "ethbloom 0.8.1",
+ "ethbloom",
  "fixed-hash 0.5.2",
- "impl-rlp 0.2.1",
+ "impl-rlp",
  "impl-serde 0.2.3",
  "primitive-types 0.6.2",
  "uint 0.8.5",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash 0.8.0",
- "impl-rlp 0.3.0",
- "impl-serde 0.4.0",
- "primitive-types 0.12.2",
- "uint 0.9.5",
 ]
 
 [[package]]
@@ -2337,11 +2380,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum_serde_utils"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c228a90f44b159ccc0c16da6c56da42d0a521b0388cca87e89919d1af1889b2"
+checksum = "70cbccfccf81d67bff0ab36e591fa536c8a935b078a7b0e58c1d00d418332fc9"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "hex",
  "serde",
  "serde_derive",
@@ -2350,48 +2393,29 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.5.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3627f83d8b87b432a5fad9934b4565260722a141a2c40f371f8080adec9425"
+checksum = "036c84bd29bff35e29bbee3c8fc0e2fb95db12b6f2f3cae82a827fbc97256f3a"
 dependencies = [
- "ethereum-types 0.14.1",
- "itertools 0.10.5",
- "smallvec",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654bbebe60af1f6554e0e1216b8e336bc1a5ec483b7774d904e25e6e65a655c6"
-dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
+ "ethereum_serde_utils",
  "itertools 0.13.0",
+ "serde",
+ "serde_derive",
  "smallvec",
+ "typenum",
 ]
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.5.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eccd5378ec34a07edd3d9b48088cbc63309d0367d14ba10b0cdb1d1791080ea"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21b5706b8763f5cbae4fbc407dacb8ce574ff619b98ff9d9c15adda2384681b"
+checksum = "9dc8e67e1f770f5aa4c2c2069aaaf9daee7ac21bed357a71b911b37a58966cfb"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2592,7 +2616,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2700,7 +2724,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2855,7 +2879,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.65",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2919,7 +2943,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.6.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2938,7 +2962,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.6.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2963,9 +2987,9 @@ checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -2975,7 +2999,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -2987,6 +3010,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -3060,8 +3084,8 @@ dependencies = [
  "alloy",
  "alloy-rlp",
  "bls12_381",
- "ethereum_ssz 0.6.0",
- "ethereum_ssz_derive 0.6.0",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "eyre",
  "getrandom 0.2.15",
  "serde",
@@ -3070,13 +3094,13 @@ dependencies = [
  "snap",
  "ssz_types",
  "superstruct",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
  "tracing",
  "tree_hash",
  "tree_hash_derive",
  "typenum",
- "wasmtimer",
+ "wasmtimer 0.2.0",
  "zduny-wasm-timer",
 ]
 
@@ -3097,12 +3121,12 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
  "tracing",
  "triehash-ethereum",
  "wasm-bindgen-futures",
- "wasmtimer",
+ "wasmtimer 0.2.0",
 ]
 
 [[package]]
@@ -3130,7 +3154,7 @@ dependencies = [
  "serde_yaml",
  "strum",
  "superstruct",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
  "tracing",
  "tree_hash",
@@ -3148,8 +3172,8 @@ dependencies = [
  "axum",
  "clap",
  "discv5",
- "ethereum_ssz 0.6.0",
- "ethereum_ssz_derive 0.6.0",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "eyre",
  "figment",
  "futures",
@@ -3191,6 +3215,7 @@ dependencies = [
  "helios-ethereum",
  "helios-opstack",
  "hex",
+ "op-alloy-rpc-types",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -3585,15 +3610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp 0.5.2",
-]
-
-[[package]]
 name = "impl-serde"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,15 +3623,6 @@ name = "impl-serde"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
 ]
@@ -3636,17 +3643,6 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
 
 [[package]]
 name = "indexmap"
@@ -3803,7 +3799,7 @@ dependencies = [
  "pin-project",
  "rustls-native-certs",
  "soketto",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
@@ -3828,11 +3824,11 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot 0.12.3",
  "rand 0.8.5",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "soketto",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3852,7 +3848,7 @@ dependencies = [
  "jsonrpsee-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
  "tower 0.4.13",
  "tracing",
@@ -3901,7 +3897,7 @@ dependencies = [
  "beef",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.65",
  "tracing",
 ]
 
@@ -3926,21 +3922,6 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "9.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
-dependencies = [
- "base64 0.21.7",
- "js-sys",
- "pem 3.0.4",
- "ring 0.17.8",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]
@@ -3981,25 +3962,10 @@ name = "keccak-hasher"
 version = "0.1.1"
 source = "git+https://github.com/openethereum/parity-ethereum?rev=55c90d4016505317034e3e98f699af07f5404b63#55c90d4016505317034e3e98f699af07f5404b63"
 dependencies = [
- "ethereum-types 0.8.0",
+ "ethereum-types",
  "hash-db",
  "plain_hasher",
  "tiny-keccak 1.5.0",
-]
-
-[[package]]
-name = "kzg-rs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9920cd4460ce3cbca19c62f3bb9a9611562478a4dc9d2c556f4a7d049c5b6b"
-dependencies = [
- "bls12_381",
- "glob",
- "hex",
- "once_cell",
- "serde",
- "serde_derive",
- "serde_yaml",
 ]
 
 [[package]]
@@ -4109,7 +4075,7 @@ dependencies = [
  "rand 0.8.5",
  "rw-stream-sink",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.65",
  "unsigned-varint",
  "void",
 ]
@@ -4154,7 +4120,7 @@ dependencies = [
  "regex",
  "sha2 0.10.8",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.65",
  "unsigned-varint",
  "void",
  "wasm-timer",
@@ -4176,7 +4142,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.65",
  "zeroize",
 ]
 
@@ -4250,7 +4216,7 @@ dependencies = [
  "sha2 0.10.8",
  "snow",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.65",
  "x25519-dalek",
  "zeroize",
 ]
@@ -4290,7 +4256,7 @@ dependencies = [
  "quinn-proto",
  "rand 0.8.5",
  "rustls 0.20.9",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
 ]
 
@@ -4355,7 +4321,7 @@ dependencies = [
  "rcgen",
  "ring 0.16.20",
  "rustls 0.20.9",
- "thiserror",
+ "thiserror 1.0.65",
  "webpki",
  "x509-parser",
  "yasna",
@@ -4669,7 +4635,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "paste",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -4683,7 +4649,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
 ]
 
@@ -4856,7 +4822,20 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a62e678a89501192cc5ebf47dcbc656b608ae5e1c61c9251fe35230f119fe3"
+dependencies = [
+ "alloy-rlp",
+ "const-hex",
+ "proptest",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -4891,40 +4870,48 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.1.5"
-source = "git+https://github.com/alloy-rs/op-alloy?tag=v0.1.5#ce7f25c524f1eb8346ded160abd37eccfbdee2ac"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0adb232ec805af3aa35606c19329aa7dc44c4457ae318ed0b8fc7f799dd7dbfe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 0.99.18",
+ "derive_more",
  "serde",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "op-alloy-network"
-version = "0.1.5"
-source = "git+https://github.com/alloy-rs/op-alloy?tag=v0.1.5#ce7f25c524f1eb8346ded160abd37eccfbdee2ac"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19872a58b7acceeffb8e88ea048bee1690e7cde53068bd652976435d61fcd1de"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
+ "alloy-signer",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.1.5"
-source = "git+https://github.com/alloy-rs/op-alloy?tag=v0.1.5#ce7f25c524f1eb8346ded160abd37eccfbdee2ac"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68d1a51fe3ee143f102b82f54fa237f21d12635da363276901e6d3ef6c65b7b"
 dependencies = [
- "alloy-network",
- "alloy-primitives 0.7.7",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "derive_more",
  "op-alloy-consensus",
  "serde",
  "serde_json",
@@ -4959,7 +4946,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5148,7 +5135,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5158,16 +5145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
-dependencies = [
- "base64 0.22.1",
- "serde",
 ]
 
 [[package]]
@@ -5183,7 +5160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.65",
  "ucd-trie",
 ]
 
@@ -5214,7 +5191,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5384,7 +5361,7 @@ checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 dependencies = [
  "fixed-hash 0.5.2",
  "impl-codec 0.4.2",
- "impl-rlp 0.2.1",
+ "impl-rlp",
  "impl-serde 0.3.2",
  "uint 0.8.5",
 ]
@@ -5397,8 +5374,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash 0.8.0",
  "impl-codec 0.6.0",
- "impl-rlp 0.3.0",
- "impl-serde 0.4.0",
  "uint 0.9.5",
 ]
 
@@ -5408,7 +5383,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.65",
  "toml 0.5.11",
 ]
 
@@ -5446,10 +5421,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.89"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -5462,7 +5459,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
  "version_check",
  "yansi",
 ]
@@ -5487,7 +5484,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5534,7 +5531,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror",
+ "thiserror 1.0.65",
  "unsigned-varint",
 ]
 
@@ -5547,10 +5544,10 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring 0.16.20",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.20.9",
  "slab",
- "thiserror",
+ "thiserror 1.0.65",
  "tinyvec",
  "tracing",
  "webpki",
@@ -5599,6 +5596,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -5683,7 +5681,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
- "pem 1.1.1",
+ "pem",
  "ring 0.16.20",
  "time",
  "yasna",
@@ -5721,7 +5719,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -5832,9 +5830,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "12.1.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cfb48bce8ca2113e157bdbddbd5eeb09daac1c903d79ec17085897c38c7c91"
+checksum = "15689a3c6a8d14b647b4666f2e236ef47b5a5133cdfd423f545947986fff7013"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -5847,9 +5845,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "8.1.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b0daddea06fc6da5346acc39b32a357bbe3579e9e3d94117d9ae125cd596fc"
+checksum = "74e3f11d0fed049a4a10f79820c59113a79b38aed4ebec786a79d5c667bfeb51"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -5857,9 +5855,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "9.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef55228211251d7b6c7707c3ee13bb70dea4d2fd81ec4034521e4fe31010b2ea"
+checksum = "e381060af24b750069a2b2d2c54bba273d84e8f5f9e8026fc9262298e26cc336"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -5875,12 +5873,13 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "7.1.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
+checksum = "3702f132bb484f4f0d0ca4f6fbde3c82cfd745041abbedd6eda67730e1868ef0"
 dependencies = [
- "alloy-eips",
- "alloy-primitives 0.7.7",
+ "alloy-eip2930",
+ "alloy-eip7702 0.4.2",
+ "alloy-primitives",
  "auto_impl",
  "bitflags 2.6.0",
  "bitvec 1.0.1",
@@ -5888,9 +5887,7 @@ dependencies = [
  "cfg-if",
  "dyn-clone",
  "enumn",
- "hashbrown 0.14.5",
  "hex",
- "kzg-rs",
  "serde",
 ]
 
@@ -5973,7 +5970,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-proto",
  "nix 0.24.3",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
 ]
 
@@ -5987,7 +5984,6 @@ dependencies = [
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",
- "ethereum_ssz 0.5.4",
  "fastrlp",
  "num-bigint",
  "num-traits",
@@ -6019,6 +6015,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc-hex"
@@ -6215,6 +6217,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "schnellru"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6356,7 +6369,7 @@ checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6365,7 +6378,7 @@ version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -6412,8 +6425,6 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
- "indexmap 1.9.3",
- "indexmap 2.6.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6430,7 +6441,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6439,7 +6450,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -6555,18 +6566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "simple_asn1"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror",
- "time",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6580,6 +6579,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"
@@ -6664,13 +6666,12 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e202ef3c07d9abc7b110a81206064e462758074242e8d176e3cb07415f01a3ad"
+checksum = "22bc24c8a61256950632fb6b68ea09f6b5c988070924c6292eb5933635202e00"
 dependencies = [
- "derivative",
  "ethereum_serde_utils",
- "ethereum_ssz 0.6.0",
+ "ethereum_ssz",
  "itertools 0.13.0",
  "serde",
  "serde_derive",
@@ -6716,7 +6717,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6765,9 +6766,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.84"
+version = "2.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2c4efbc0b0670e3d41f388e3cb936ff364bf681703b4c92ae26ca509966111"
+checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6776,14 +6777,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.7"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
+checksum = "219389c1ebe89f8333df8bdfb871f6631c552ff399c23cac02480b6088aad8f0"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6880,7 +6881,16 @@ version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.65",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+dependencies = [
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -6891,7 +6901,18 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7013,7 +7034,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7061,9 +7082,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
@@ -7126,7 +7147,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7196,7 +7217,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7256,30 +7277,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "tree_hash"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f113108f55d589941862727b5a74f75276a54c157060983611d99f7f7fa6368"
+checksum = "3cc60ae4c4236ee721305d0f0b5aa3e8ef5b66f3fa61d17072430bc246d6694a"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives",
  "ethereum_hashing",
+ "ethereum_ssz",
  "smallvec",
+ "typenum",
 ]
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b623b16740c2ff75b04a705e726f436abab04eecb60a27b39eea55ec5e81e543"
+checksum = "5c8ee219344a44410237d7b849d150a445a621d0cae92d6fbab10d84d4428870"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7297,7 +7320,7 @@ name = "triehash-ethereum"
 version = "0.2.0"
 source = "git+https://github.com/openethereum/parity-ethereum?rev=55c90d4016505317034e3e98f699af07f5404b63#55c90d4016505317034e3e98f699af07f5404b63"
 dependencies = [
- "ethereum-types 0.8.0",
+ "ethereum-types",
  "keccak-hasher",
  "triehash",
 ]
@@ -7321,7 +7344,7 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "socket2 0.4.10",
- "thiserror",
+ "thiserror 1.0.65",
  "tinyvec",
  "tokio",
  "tracing",
@@ -7342,7 +7365,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
  "tracing",
  "trust-dns-proto",
@@ -7362,9 +7385,9 @@ checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
  "byteorder",
  "bytes",
@@ -7376,7 +7399,7 @@ dependencies = [
  "rustls 0.23.15",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 1.0.65",
  "utf-8",
 ]
 
@@ -7606,7 +7629,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
  "wasm-bindgen-shared",
 ]
 
@@ -7640,7 +7663,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7674,7 +7697,7 @@ checksum = "4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7697,6 +7720,20 @@ name = "wasmtimer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f656cd8858a5164932d8a90f936700860976ec21eb00e0fe2aa8cab13f6b4cf"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.12.3",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
 dependencies = [
  "futures",
  "js-sys",
@@ -8034,7 +8071,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
- "thiserror",
+ "thiserror 1.0.65",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -8074,7 +8111,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.65",
  "time",
 ]
 
@@ -8137,7 +8174,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8157,5 +8194,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.84",
+ "syn 2.0.91",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ default-members = ["cli"]
 
 [workspace.dependencies]
 # consensus
-ssz_types = "0.7.0"
-ethereum_ssz_derive = "0.6.0"
-ethereum_ssz = "0.6.0"
-tree_hash_derive = "0.7.0"
-tree_hash = "0.7.0"
+ssz_types = "0.10"
+ethereum_ssz_derive = "0.8"
+ethereum_ssz = "0.8"
+tree_hash_derive = "0.9.0"
+tree_hash = "0.9.0"
 sha2 = "0.9"
 bls12_381 = { version = "0.8.0", features = ["experimental"] }
 
 # execution
-alloy = { version = "0.2.1", features = [
+alloy = { version = "0.9.1", features = [
     "rpc-types",
     "consensus",
     "rlp",
@@ -44,7 +44,8 @@ alloy = { version = "0.2.1", features = [
     "json-rpc",
     "signers",
 ]}
-revm = { version = "12.1.0", default-features = false, features = [
+op-alloy-rpc-types = "0.9.0"
+revm = { version = "18.0.0", default-features = false, features = [
     "std",
     "serde",
     "optional_block_gas_limit",
@@ -92,7 +93,7 @@ dotenv = "0.15.0"
 serde = { version = "1.0.154", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-alloy = { version = "0.2.1", features = ["full"] }
+alloy = { version = "0.9.1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 eyre = "0.6.8"
 dirs = "5.0.1"

--- a/core/src/execution/mod.rs
+++ b/core/src/execution/mod.rs
@@ -84,7 +84,7 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> ExecutionClient<N, R> {
         let mut slot_map = HashMap::new();
 
         for storage_proof in proof.storage_proof {
-            let key = storage_proof.key.0;
+            let key = storage_proof.key.as_b256();
             let key_hash = keccak256(key);
             let value = encode(storage_proof.value);
 

--- a/core/src/execution/rpc/http_rpc.rs
+++ b/core/src/execution/rpc/http_rpc.rs
@@ -127,9 +127,10 @@ impl<N: NetworkSpec> ExecutionRpc<N> for HttpRpc<N> {
             BlockTag::Number(num) => BlockNumberOrTag::Number(num),
         };
 
+        let block_id = BlockId::from(block);
         let receipts = self
             .provider
-            .get_block_receipts(block)
+            .get_block_receipts(block_id)
             .await
             .map_err(|e| RpcError::new("get_block_receipts", e))?;
 

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -58,8 +58,8 @@ impl<T: TransactionResponse> Block<T> {
             blob_gas_used: self.blob_gas_used.map(|v| v.to()),
             excess_blob_gas: self.excess_blob_gas.map(|v| v.to()),
             parent_beacon_block_root: self.parent_beacon_block_root,
-            requests_root: None,
             extra_data: self.extra_data.clone(),
+            requests_hash: None,
         };
 
         header.hash_slow() == self.hash

--- a/ethereum/consensus-core/Cargo.toml
+++ b/ethereum/consensus-core/Cargo.toml
@@ -4,14 +4,14 @@ name = "helios-consensus-core"
 edition = "2021"
 
 [dependencies]
-alloy = { version = "0.2.1", features = [
+alloy = { version = "0.9.1", features = [
     "consensus",
     "rpc-types",
     "ssz",
     "rlp",
     "k256",
 ] }
-alloy-rlp = "0.3.0"
+alloy-rlp = "0.3.10"
 bls12_381.workspace = true
 ssz_types.workspace = true
 ethereum_ssz_derive.workspace = true

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use alloy::consensus::{Transaction as TxTrait, TxEnvelope};
 use alloy::primitives::{b256, fixed_bytes, B256, U256, U64};
 use alloy::rlp::{encode, Decodable};
-use alloy::rpc::types::{Parity, Signature, Transaction};
+use alloy::rpc::types::Transaction;
 use chrono::Duration;
 use eyre::eyre;
 use eyre::Result;
@@ -590,89 +590,16 @@ fn payload_to_block<S: ConsensusSpec>(value: ExecutionPayload<S>) -> Block<Trans
             let mut tx_bytes_slice = tx_bytes.as_slice();
             let tx_envelope = TxEnvelope::decode(&mut tx_bytes_slice).unwrap();
 
-            let mut tx = Transaction {
-                hash: *tx_envelope.tx_hash(),
-                nonce: tx_envelope.nonce(),
+            let base_fee = Some(value.base_fee_per_gas().to());
+
+            Transaction {
                 block_hash: Some(*value.block_hash()),
                 block_number: Some(*value.block_number()),
                 transaction_index: Some(i as u64),
-                to: tx_envelope.to().to().cloned(),
-                value: tx_envelope.value(),
-                gas_price: tx_envelope.gas_price(),
-                gas: tx_envelope.gas_limit(),
-                input: tx_envelope.input().to_vec().into(),
-                chain_id: tx_envelope.chain_id(),
-                transaction_type: Some(tx_envelope.tx_type().into()),
-                ..Default::default()
-            };
-
-            match tx_envelope {
-                TxEnvelope::Legacy(inner) => {
-                    tx.from = inner.recover_signer().unwrap();
-                    tx.signature = Some(Signature {
-                        r: inner.signature().r(),
-                        s: inner.signature().s(),
-                        v: U256::from(inner.signature().v().to_u64()),
-                        y_parity: None,
-                    });
-                }
-                TxEnvelope::Eip2930(inner) => {
-                    tx.from = inner.recover_signer().unwrap();
-                    tx.signature = Some(Signature {
-                        r: inner.signature().r(),
-                        s: inner.signature().s(),
-                        v: U256::from(inner.signature().v().to_u64()),
-                        y_parity: Some(Parity(inner.signature().v().to_u64() == 1)),
-                    });
-                    tx.access_list = Some(inner.tx().access_list.clone());
-                }
-                TxEnvelope::Eip1559(inner) => {
-                    tx.from = inner.recover_signer().unwrap();
-                    tx.signature = Some(Signature {
-                        r: inner.signature().r(),
-                        s: inner.signature().s(),
-                        v: U256::from(inner.signature().v().to_u64()),
-                        y_parity: Some(Parity(inner.signature().v().to_u64() == 1)),
-                    });
-
-                    let tx_inner = inner.tx();
-                    tx.access_list = Some(tx_inner.access_list.clone());
-                    tx.max_fee_per_gas = Some(tx_inner.max_fee_per_gas);
-                    tx.max_priority_fee_per_gas = Some(tx_inner.max_priority_fee_per_gas);
-
-                    tx.gas_price = Some(gas_price(
-                        tx_inner.max_fee_per_gas,
-                        tx_inner.max_priority_fee_per_gas,
-                        value.base_fee_per_gas().to(),
-                    ));
-                }
-                TxEnvelope::Eip4844(inner) => {
-                    tx.from = inner.recover_signer().unwrap();
-                    tx.signature = Some(Signature {
-                        r: inner.signature().r(),
-                        s: inner.signature().s(),
-                        v: U256::from(inner.signature().v().to_u64()),
-                        y_parity: Some(Parity(inner.signature().v().to_u64() == 1)),
-                    });
-
-                    let tx_inner = inner.tx().tx();
-                    tx.access_list = Some(tx_inner.access_list.clone());
-                    tx.max_fee_per_gas = Some(tx_inner.max_fee_per_gas);
-                    tx.max_priority_fee_per_gas = Some(tx_inner.max_priority_fee_per_gas);
-                    tx.max_fee_per_blob_gas = Some(tx_inner.max_fee_per_blob_gas);
-                    tx.gas_price = Some(tx_inner.max_fee_per_gas);
-                    tx.blob_versioned_hashes = Some(tx_inner.blob_versioned_hashes.clone());
-
-                    tx.gas_price = Some(gas_price(
-                        tx_inner.max_fee_per_gas,
-                        tx_inner.max_priority_fee_per_gas,
-                        value.base_fee_per_gas().to(),
-                    ));
-                }
-                _ => todo!(),
+                from: tx_envelope.recover_signer().unwrap().clone(),
+                effective_gas_price: Some(tx_envelope.effective_gas_price(base_fee)),
+                inner: tx_envelope,
             }
-
-            tx
         })
         .collect::<Vec<Transaction>>();
 
@@ -709,10 +636,6 @@ fn payload_to_block<S: ConsensusSpec>(value: ExecutionPayload<S>) -> Block<Trans
         withdrawals_root: B256::from_slice(withdrawals_root.as_bytes()),
         parent_beacon_block_root: Some(*value.parent_hash()),
     }
-}
-
-fn gas_price(max_fee: u128, max_prio_fee: u128, base_fee: u128) -> u128 {
-    u128::min(max_fee, max_prio_fee + base_fee)
 }
 
 #[cfg(test)]

--- a/helios-ts/Cargo.toml
+++ b/helios-ts/Cargo.toml
@@ -17,6 +17,7 @@ console_error_panic_hook = "0.1.7"
 
 eyre.workspace = true
 alloy.workspace = true
+op-alloy-rpc-types.workspace = true
 
 hex = "0.4.3"
 serde = { version = "1.0.143", features = ["derive"] }

--- a/helios-ts/src/opstack.rs
+++ b/helios-ts/src/opstack.rs
@@ -4,8 +4,10 @@ extern crate web_sys;
 use std::str::FromStr;
 
 use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::{Filter, TransactionRequest};
+use alloy::rpc::types::Filter;
 use wasm_bindgen::prelude::*;
+
+use op_alloy_rpc_types::OpTransactionRequest;
 
 use helios_core::types::BlockTag;
 use helios_opstack::config::{Config, Network, NetworkConfig};
@@ -175,7 +177,7 @@ impl OpStackClient {
 
     #[wasm_bindgen]
     pub async fn call(&self, opts: JsValue, block: JsValue) -> Result<String, JsError> {
-        let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
+        let opts: OpTransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockTag = serde_wasm_bindgen::from_value(block)?;
         let res = map_err(self.inner.call(&opts, block).await)?;
         Ok(format!("0x{}", hex::encode(res)))
@@ -183,7 +185,7 @@ impl OpStackClient {
 
     #[wasm_bindgen]
     pub async fn estimate_gas(&self, opts: JsValue) -> Result<u32, JsError> {
-        let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
+        let opts: OpTransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         Ok(map_err(self.inner.estimate_gas(&opts).await)? as u32)
     }
 

--- a/opstack/Cargo.toml
+++ b/opstack/Cargo.toml
@@ -28,9 +28,9 @@ ethereum_ssz.workspace = true
 ssz_types.workspace = true
 triehash-ethereum.workspace = true
 alloy-rlp = "0.3.0"
-op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", tag = "v0.1.5" }
-op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", tag = "v0.1.5" }
-op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", tag = "v0.1.5" }
+op-alloy-network = "0.9.0"
+op-alloy-consensus = "0.9.0"
+op-alloy-rpc-types.workspace = true
 snap = "1"
 
 # config

--- a/opstack/src/spec.rs
+++ b/opstack/src/spec.rs
@@ -1,18 +1,18 @@
 use alloy::{
-    consensus::{
-        BlobTransactionSidecar, Receipt, ReceiptWithBloom, TxReceipt, TxType, TypedTransaction,
-    },
-    network::Network,
+    consensus::{Receipt, ReceiptWithBloom, Transaction as TxTrait, TxReceipt, TxType},
     primitives::{Address, Bytes, ChainId, TxKind, U256},
     rpc::types::{AccessList, Log, TransactionRequest},
 };
+
 use helios_core::{network_spec::NetworkSpec, types::Block};
 use op_alloy_consensus::{
-    OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxType,
+    OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxEnvelope, OpTxType,
+    OpTypedTransaction,
 };
 use op_alloy_network::{
-    BuildResult, Ethereum, NetworkWallet, TransactionBuilder, TransactionBuilderError,
+    BuildResult, Ethereum, Network, NetworkWallet, TransactionBuilder, TransactionBuilderError,
 };
+use op_alloy_rpc_types::{OpTransactionRequest, Transaction};
 use revm::primitives::{BlobExcessGasAndPrice, BlockEnv, TxEnv};
 
 #[derive(Clone, Copy, Debug)]
@@ -33,9 +33,9 @@ impl NetworkSpec for OpStack {
             OpReceiptEnvelope::Legacy(inner)
             | OpReceiptEnvelope::Eip2930(inner)
             | OpReceiptEnvelope::Eip1559(inner)
-            | OpReceiptEnvelope::Eip4844(inner) => {
+            | OpReceiptEnvelope::Eip7702(inner) => {
                 let r = Receipt {
-                    status: *inner.status_or_post_state(),
+                    status: inner.status_or_post_state(),
                     cumulative_gas_used: inner.cumulative_gas_used(),
                     logs,
                 };
@@ -83,30 +83,36 @@ impl NetworkSpec for OpStack {
 
     fn tx_env(tx: &Self::TransactionRequest) -> TxEnv {
         let mut tx_env = TxEnv::default();
-        tx_env.caller = tx.from.unwrap_or_default();
-        tx_env.gas_limit = <TransactionRequest as TransactionBuilder<Self>>::gas_limit(tx)
+        tx_env.caller =
+            <OpTransactionRequest as TransactionBuilder<Self>>::from(tx).unwrap_or_default();
+        tx_env.gas_limit = <OpTransactionRequest as TransactionBuilder<Self>>::gas_limit(tx)
             .map(|v| v as u64)
             .unwrap_or(u64::MAX);
-        tx_env.gas_price = <TransactionRequest as TransactionBuilder<Self>>::gas_price(tx)
+        tx_env.gas_price = <OpTransactionRequest as TransactionBuilder<Self>>::gas_price(tx)
             .map(U256::from)
             .unwrap_or_default();
-        tx_env.transact_to = tx.to.unwrap_or_default();
-        tx_env.value = tx.value.unwrap_or_default();
-        tx_env.data = <TransactionRequest as TransactionBuilder<Self>>::input(tx)
+        tx_env.transact_to =
+            <OpTransactionRequest as TransactionBuilder<Self>>::kind(tx).unwrap_or_default();
+        tx_env.value =
+            <OpTransactionRequest as TransactionBuilder<Self>>::value(tx).unwrap_or_default();
+        tx_env.data = <OpTransactionRequest as TransactionBuilder<Self>>::input(tx)
             .unwrap_or_default()
             .clone();
-        tx_env.nonce = <TransactionRequest as TransactionBuilder<Self>>::nonce(tx);
-        tx_env.chain_id = <TransactionRequest as TransactionBuilder<Self>>::chain_id(tx);
-        tx_env.access_list = <TransactionRequest as TransactionBuilder<Self>>::access_list(tx)
+        tx_env.nonce = <OpTransactionRequest as TransactionBuilder<Self>>::nonce(tx);
+        tx_env.chain_id = <OpTransactionRequest as TransactionBuilder<Self>>::chain_id(tx);
+        tx_env.access_list = <OpTransactionRequest as TransactionBuilder<Self>>::access_list(tx)
             .map(|v| v.to_vec())
             .unwrap_or_default();
         tx_env.gas_priority_fee =
-            <TransactionRequest as TransactionBuilder<Self>>::max_priority_fee_per_gas(tx)
+            <OpTransactionRequest as TransactionBuilder<Self>>::max_priority_fee_per_gas(tx)
                 .map(U256::from);
         tx_env.max_fee_per_blob_gas =
-            <TransactionRequest as TransactionBuilder<Self>>::max_fee_per_gas(tx).map(U256::from);
+            <OpTransactionRequest as TransactionBuilder<Self>>::max_fee_per_gas(tx).map(U256::from);
         tx_env.blob_hashes = tx
-            .blob_versioned_hashes
+            .clone()
+            .build_typed_tx()
+            .unwrap()
+            .blob_versioned_hashes()
             .as_ref()
             .map(|v| v.to_vec())
             .unwrap_or_default();
@@ -133,123 +139,125 @@ impl NetworkSpec for OpStack {
 
 impl Network for OpStack {
     type TxType = op_alloy_consensus::OpTxType;
-    type TxEnvelope = alloy::consensus::TxEnvelope;
-    type UnsignedTx = alloy::consensus::TypedTransaction;
+    type TxEnvelope = OpTxEnvelope;
+    type UnsignedTx = OpTypedTransaction;
     type ReceiptEnvelope = op_alloy_consensus::OpReceiptEnvelope;
     type Header = alloy::consensus::Header;
-    type TransactionRequest = TransactionRequest;
-    type TransactionResponse = alloy::rpc::types::Transaction;
+    type TransactionRequest = OpTransactionRequest;
+    type TransactionResponse = Transaction;
     type ReceiptResponse = op_alloy_rpc_types::OpTransactionReceipt;
     type HeaderResponse = alloy::rpc::types::Header;
+    type BlockResponse = alloy::rpc::types::Block<Self::TransactionResponse, Self::HeaderResponse>;
 }
 
-impl TransactionBuilder<OpStack> for TransactionRequest {
+impl TransactionBuilder<OpStack> for OpTransactionRequest {
     fn chain_id(&self) -> Option<ChainId> {
-        self.chain_id
+        <TransactionRequest as TransactionBuilder<Ethereum>>::chain_id(self.as_ref())
     }
 
     fn set_chain_id(&mut self, chain_id: ChainId) {
-        self.chain_id = Some(chain_id);
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_chain_id(self.as_mut(), chain_id);
     }
 
     fn nonce(&self) -> Option<u64> {
-        self.nonce
+        <TransactionRequest as TransactionBuilder<Ethereum>>::nonce(self.as_ref())
     }
 
     fn set_nonce(&mut self, nonce: u64) {
-        self.nonce = Some(nonce);
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_nonce(self.as_mut(), nonce);
     }
 
     fn input(&self) -> Option<&Bytes> {
-        self.input.input()
+        <TransactionRequest as TransactionBuilder<Ethereum>>::input(self.as_ref())
     }
 
     fn set_input<T: Into<Bytes>>(&mut self, input: T) {
-        self.input.input = Some(input.into());
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_input(self.as_mut(), input);
     }
 
     fn from(&self) -> Option<Address> {
-        self.from
+        <TransactionRequest as TransactionBuilder<Ethereum>>::from(self.as_ref())
     }
 
     fn set_from(&mut self, from: Address) {
-        self.from = Some(from);
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_from(self.as_mut(), from);
     }
 
     fn kind(&self) -> Option<TxKind> {
-        self.to
+        <TransactionRequest as TransactionBuilder<Ethereum>>::kind(self.as_ref())
     }
 
     fn clear_kind(&mut self) {
-        self.to = None;
+        <TransactionRequest as TransactionBuilder<Ethereum>>::clear_kind(self.as_mut());
     }
 
     fn set_kind(&mut self, kind: TxKind) {
-        self.to = Some(kind);
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_kind(self.as_mut(), kind);
     }
 
     fn value(&self) -> Option<U256> {
-        self.value
+        <TransactionRequest as TransactionBuilder<Ethereum>>::value(self.as_ref())
     }
 
     fn set_value(&mut self, value: U256) {
-        self.value = Some(value)
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_value(self.as_mut(), value);
     }
 
     fn gas_price(&self) -> Option<u128> {
-        self.gas_price
+        <TransactionRequest as TransactionBuilder<Ethereum>>::gas_price(self.as_ref())
     }
 
     fn set_gas_price(&mut self, gas_price: u128) {
-        self.gas_price = Some(gas_price);
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_gas_price(
+            self.as_mut(),
+            gas_price,
+        );
     }
 
     fn max_fee_per_gas(&self) -> Option<u128> {
-        self.max_fee_per_gas
+        <TransactionRequest as TransactionBuilder<Ethereum>>::max_fee_per_gas(self.as_ref())
     }
 
     fn set_max_fee_per_gas(&mut self, max_fee_per_gas: u128) {
-        self.max_fee_per_gas = Some(max_fee_per_gas);
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_max_fee_per_gas(
+            self.as_mut(),
+            max_fee_per_gas,
+        );
     }
 
     fn max_priority_fee_per_gas(&self) -> Option<u128> {
-        self.max_priority_fee_per_gas
+        <TransactionRequest as TransactionBuilder<Ethereum>>::max_priority_fee_per_gas(
+            self.as_ref(),
+        )
     }
 
     fn set_max_priority_fee_per_gas(&mut self, max_priority_fee_per_gas: u128) {
-        self.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_max_priority_fee_per_gas(
+            self.as_mut(),
+            max_priority_fee_per_gas,
+        );
     }
 
-    fn max_fee_per_blob_gas(&self) -> Option<u128> {
-        self.max_fee_per_blob_gas
+    fn gas_limit(&self) -> Option<u64> {
+        <TransactionRequest as TransactionBuilder<Ethereum>>::gas_limit(self.as_ref())
     }
 
-    fn set_max_fee_per_blob_gas(&mut self, max_fee_per_blob_gas: u128) {
-        self.max_fee_per_blob_gas = Some(max_fee_per_blob_gas)
-    }
-
-    fn gas_limit(&self) -> Option<u128> {
-        self.gas
-    }
-
-    fn set_gas_limit(&mut self, gas_limit: u128) {
-        self.gas = Some(gas_limit);
+    fn set_gas_limit(&mut self, gas_limit: u64) {
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_gas_limit(
+            self.as_mut(),
+            gas_limit,
+        );
     }
 
     fn access_list(&self) -> Option<&AccessList> {
-        self.access_list.as_ref()
+        <TransactionRequest as TransactionBuilder<Ethereum>>::access_list(self.as_ref())
     }
 
     fn set_access_list(&mut self, access_list: AccessList) {
-        self.access_list = Some(access_list);
-    }
-
-    fn blob_sidecar(&self) -> Option<&BlobTransactionSidecar> {
-        self.sidecar.as_ref()
-    }
-
-    fn set_blob_sidecar(&mut self, sidecar: BlobTransactionSidecar) {
-        TransactionBuilder::<Ethereum>::set_blob_sidecar(self, sidecar)
+        <TransactionRequest as TransactionBuilder<Ethereum>>::set_access_list(
+            self.as_mut(),
+            access_list,
+        );
     }
 
     fn complete_type(&self, ty: OpTxType) -> Result<(), Vec<&'static str>> {
@@ -257,38 +265,48 @@ impl TransactionBuilder<OpStack> for TransactionRequest {
             OpTxType::Deposit => Err(vec!["not implemented for deposit tx"]),
             _ => {
                 let ty = TxType::try_from(ty as u8).unwrap();
-                TransactionBuilder::<Ethereum>::complete_type(self, ty)
+                <TransactionRequest as TransactionBuilder<Ethereum>>::complete_type(
+                    self.as_ref(),
+                    ty,
+                )
             }
         }
     }
 
     fn can_submit(&self) -> bool {
-        TransactionBuilder::<Ethereum>::can_submit(self)
+        <TransactionRequest as TransactionBuilder<Ethereum>>::can_submit(self.as_ref())
     }
 
     fn can_build(&self) -> bool {
-        TransactionBuilder::<Ethereum>::can_build(self)
+        <TransactionRequest as TransactionBuilder<Ethereum>>::can_build(self.as_ref())
     }
 
     #[doc(alias = "output_transaction_type")]
     fn output_tx_type(&self) -> OpTxType {
-        OpTxType::try_from(self.preferred_type() as u8).unwrap()
+        match self.as_ref().preferred_type() {
+            TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
+            TxType::Eip2930 => OpTxType::Eip2930,
+            TxType::Eip7702 => OpTxType::Eip7702,
+            TxType::Legacy => OpTxType::Legacy,
+        }
     }
 
     #[doc(alias = "output_transaction_type_checked")]
     fn output_tx_type_checked(&self) -> Option<OpTxType> {
-        self.buildable_type()
-            .map(|tx_ty| OpTxType::try_from(tx_ty as u8).unwrap())
+        self.as_ref().buildable_type().map(|tx_ty| match tx_ty {
+            TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
+            TxType::Eip2930 => OpTxType::Eip2930,
+            TxType::Eip7702 => OpTxType::Eip7702,
+            TxType::Legacy => OpTxType::Legacy,
+        })
     }
 
     fn prep_for_submission(&mut self) {
-        self.transaction_type = Some(self.preferred_type() as u8);
-        self.trim_conflicting_keys();
-        self.populate_blob_hashes();
+        <TransactionRequest as TransactionBuilder<Ethereum>>::prep_for_submission(self.as_mut());
     }
 
-    fn build_unsigned(self) -> BuildResult<TypedTransaction, OpStack> {
-        if let Err((tx_type, missing)) = self.missing_keys() {
+    fn build_unsigned(self) -> BuildResult<OpTypedTransaction, OpStack> {
+        if let Err((tx_type, missing)) = self.as_ref().missing_keys() {
             let tx_type = OpTxType::try_from(tx_type as u8).unwrap();
             return Err(
                 TransactionBuilderError::InvalidTransactionRequest(tx_type, missing)

--- a/tests/rpc_equivalence.rs
+++ b/tests/rpc_equivalence.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 use alloy::eips::BlockNumberOrTag;
+use alloy::network::primitives::BlockTransactionsKind;
 use alloy::primitives::address;
 use alloy::providers::{Provider, ProviderBuilder, RootProvider};
 use alloy::rpc::client::ClientBuilder as AlloyClientBuilder;
@@ -54,7 +55,7 @@ async fn get_transaction_by_hash() {
     let (_handle, helios_provider, provider) = setup().await;
 
     let block = helios_provider
-        .get_block_by_number(BlockNumberOrTag::Latest, false)
+        .get_block_by_number(BlockNumberOrTag::Latest, BlockTransactionsKind::Hashes)
         .await
         .unwrap()
         .unwrap();
@@ -99,7 +100,7 @@ async fn get_transaction_receipt() {
     let (_handle, helios_provider, provider) = setup().await;
 
     let block = helios_provider
-        .get_block_by_number(BlockNumberOrTag::Latest, false)
+        .get_block_by_number(BlockNumberOrTag::Latest, BlockTransactionsKind::Hashes)
         .await
         .unwrap()
         .unwrap();
@@ -125,12 +126,12 @@ async fn get_block_receipts() {
     let (_handle, helios_provider, provider) = setup().await;
 
     let block = helios_provider
-        .get_block_by_number(BlockNumberOrTag::Latest, false)
+        .get_block_by_number(BlockNumberOrTag::Latest, BlockTransactionsKind::Hashes)
         .await
         .unwrap()
         .unwrap();
 
-    let block_num = block.header.number.unwrap().into();
+    let block_num = block.header.number.into();
 
     let helios_receipts = helios_provider
         .get_block_receipts(block_num)


### PR DESCRIPTION
This is my take on issue #484 . I tried to keep it as simple as possible without any rework of underlying structure.

Key changes:
`alloy` crates have been updated to latest version of `9.0`

Some breaking changes are likely to be introduced because of change `TransactionRequest` -> `OpTransactionRequest` type for OPStack.

I invite anyone interested to review and regression test this PR, feedback is much appreciated. I'd be happy to fix whatever has to be fixed.