### PR TITLE
fix: Trim the ending slash from consensus RPC

### DIFF
--- a/ethereum/src/rpc/http_rpc.rs
+++ b/ethereum/src/rpc/http_rpc.rs
@@ -66,7 +66,7 @@ async fn get<R: DeserializeOwned>(req: &str) -> Result<R> {
 impl<S: ConsensusSpec> ConsensusRpc<S> for HttpRpc {
     fn new(rpc: &str) -> Self {
         HttpRpc {
-            rpc: rpc.to_string(),
+            rpc: rpc.trim_end_matches('/').to_string(),
         }
     }
 


### PR DESCRIPTION
Without this fix, helios doesn't work when `--consensus-rpc` is given:
```
$ cargo run -- ethereum --rpc-port 14433 --network mainnet --execution-rpc https://ethereum-rpc.publicnode.com --consensus-rpc https://ethereum.operationsolarstorm.org
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.40s
     Running `target/debug/helios ethereum --rpc-port 14433 --network mainnet --execution-rpc 'https://ethereum-rpc.publicnode.com' --consensus-rpc 'https://ethereum.operationsolarstorm.org'`
2025-01-08T02:21:17.908637Z  INFO helios::rpc: rpc server started at 127.0.0.1:14433
2025-01-08T02:21:18.591966Z ERROR helios::consensus: sync failed err=could not fetch bootstrap: rpc error on method: bootstrap, message: status: 404, raw response: b""
```