### PR TITLE
Fix: process Map into an Object for blocks in helios-ts

### DIFF
--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -144,7 +144,8 @@ export class HeliosProvider {
         return this.#chainId;
       }
       case "eth_getBlockByNumber": {
-        return this.#client.get_block_by_number(req.params[0], req.params[1]);
+        const block = await this.#client.get_block_by_number(req.params[0], req.params[1]);
+        return mapToObj(block);
       }
       case "web3_clientVersion": {
         return this.#client.client_version();


### PR DESCRIPTION
fixes: #496

After latest changes, `Block` is serialized differently which results in `Map` in JavaScript. This is not an expected type from a provider.

This PR uses existing `mapToObj` function to process the `Map` into an `Object`.