### PR TITLE
fix: Improve error handling by using String(err) for safer conversion…

### DIFF
--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -50,7 +50,7 @@ export class HeliosProvider {
     try {
       return await this.#req(req);
     } catch (err) {
-      throw new Error(err.toString());
+      throw new Error(String(err));
     }
   }
 


### PR DESCRIPTION
I updated the error handling in the catch block to use `String(err)` instead of `err.toString()`.
While this isn't a bug fix, it's an improvement to ensure consistent and reliable string conversion, especially in cases where `err` might not be an object. 