### PR TITLE
refactor: custom EVM support

### DIFF
--- a/core/src/client/node.rs
+++ b/core/src/client/node.rs
@@ -46,16 +46,22 @@ impl<N: NetworkSpec, C: Consensus<N::BlockResponse>> Node<N, C> {
     ) -> Result<Bytes, ClientError> {
         self.check_blocktag_age(&block).await?;
 
-        let mut evm = Evm::new(self.execution.clone(), self.chain_id(), block);
-        evm.call(tx).await.map_err(ClientError::EvmError)
+        N::call(tx, self.execution.clone(), self.chain_id(), block)
+            .await
+            .map_err(ClientError::EvmError)
     }
 
     pub async fn estimate_gas(&self, tx: &N::TransactionRequest) -> Result<u64, ClientError> {
         self.check_head_age().await?;
 
-        let mut evm = Evm::new(self.execution.clone(), self.chain_id(), BlockTag::Latest);
-
-        evm.estimate_gas(tx).await.map_err(ClientError::EvmError)
+        N::estimate_gas(
+            tx,
+            self.execution.clone(),
+            self.chain_id(),
+            BlockTag::Latest,
+        )
+        .await
+        .map_err(ClientError::EvmError)
     }
 
     pub async fn get_balance(&self, address: Address, tag: BlockTag) -> Result<U256> {

--- a/core/src/execution/evm.rs
+++ b/core/src/execution/evm.rs
@@ -1,4 +1,4 @@
-use std::{borrow::BorrowMut, collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use alloy::{
     consensus::BlockHeader,
@@ -7,12 +7,11 @@ use alloy::{
 use eyre::{Report, Result};
 use futures::future::join_all;
 use revm::{
-    db,
     primitives::{
         address, AccessListItem, AccountInfo, Address, Bytecode, Bytes, Env, ExecutionResult,
         ResultAndState, B256, U256,
     },
-    Database, Evm as Revm,
+    Database,
 };
 use tracing::trace;
 
@@ -67,7 +66,7 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> Evm<N, R> {
         _ = db.state.prefetch_state(tx).await;
 
         let env = Box::new(self.get_env(tx, self.tag).await);
-        let mut evm = N::get_evm(db, env);
+        let mut evm = N::evm(db, env);
 
         let tx_res = loop {
             let db = evm.db_mut();

--- a/core/src/network_spec.rs
+++ b/core/src/network_spec.rs
@@ -1,17 +1,28 @@
-use alloy::{network::Network, rpc::types::Log};
-use revm::{
-    primitives::{BlockEnv, Env, TxEnv},
-    Database, Evm,
+use std::{future::Future, sync::Arc};
+
+use alloy::{network::Network, primitives::Bytes, rpc::types::Log};
+
+use crate::{
+    execution::{errors::EvmError, rpc::http_rpc::HttpRpc, ExecutionClient},
+    types::BlockTag,
 };
 
 pub trait NetworkSpec: Network {
-    type EvmExt: Send + Sync;
+    fn call(
+        tx: &Self::TransactionRequest,
+        execution: Arc<ExecutionClient<Self, HttpRpc<Self>>>,
+        chain_id: u64,
+        tag: BlockTag,
+    ) -> impl Future<Output = Result<Bytes, EvmError>> + Send;
+    fn estimate_gas(
+        tx: &Self::TransactionRequest,
+        execution: Arc<ExecutionClient<Self, HttpRpc<Self>>>,
+        chain_id: u64,
+        tag: BlockTag,
+    ) -> impl Future<Output = Result<u64, EvmError>> + Send;
 
-    fn evm<DB: Database>(db: DB, env: Box<Env>) -> Evm<'static, Self::EvmExt, DB>;
     fn encode_receipt(receipt: &Self::ReceiptResponse) -> Vec<u8>;
     fn is_hash_valid(block: &Self::BlockResponse) -> bool;
     fn receipt_contains(list: &[Self::ReceiptResponse], elem: &Self::ReceiptResponse) -> bool;
     fn receipt_logs(receipt: &Self::ReceiptResponse) -> Vec<Log>;
-    fn tx_env(request: &Self::TransactionRequest) -> TxEnv;
-    fn block_env(block: &Self::BlockResponse) -> BlockEnv;
 }

--- a/core/src/network_spec.rs
+++ b/core/src/network_spec.rs
@@ -1,7 +1,11 @@
 use alloy::{network::Network, rpc::types::Log};
-use revm::primitives::{BlockEnv, TxEnv};
+use revm::{
+    primitives::{BlockEnv, Env, TxEnv},
+    Database, Evm,
+};
 
 pub trait NetworkSpec: Network {
+    fn get_evm<DB: Database>(db: DB, env: Box<Env>) -> Evm<'static, (), DB>;
     fn encode_receipt(receipt: &Self::ReceiptResponse) -> Vec<u8>;
     fn is_hash_valid(block: &Self::BlockResponse) -> bool;
     fn receipt_contains(list: &[Self::ReceiptResponse], elem: &Self::ReceiptResponse) -> bool;

--- a/core/src/network_spec.rs
+++ b/core/src/network_spec.rs
@@ -5,7 +5,9 @@ use revm::{
 };
 
 pub trait NetworkSpec: Network {
-    fn get_evm<DB: Database>(db: DB, env: Box<Env>) -> Evm<'static, (), DB>;
+    type EvmExt: Send + Sync;
+
+    fn evm<DB: Database>(db: DB, env: Box<Env>) -> Evm<'static, Self::EvmExt, DB>;
     fn encode_receipt(receipt: &Self::ReceiptResponse) -> Vec<u8>;
     fn is_hash_valid(block: &Self::BlockResponse) -> bool;
     fn receipt_contains(list: &[Self::ReceiptResponse], elem: &Self::ReceiptResponse) -> bool;

--- a/ethereum/src/spec.rs
+++ b/ethereum/src/spec.rs
@@ -7,7 +7,10 @@ use alloy::{
     primitives::{Address, Bytes, ChainId, TxKind, U256},
     rpc::types::{AccessList, Log, TransactionRequest},
 };
-use revm::primitives::{BlobExcessGasAndPrice, BlockEnv, TxEnv};
+use revm::{
+    primitives::{BlobExcessGasAndPrice, BlockEnv, EnvWithHandlerCfg, HandlerCfg, SpecId, TxEnv},
+    EvmBuilder,
+};
 
 use helios_core::network_spec::NetworkSpec;
 
@@ -15,6 +18,19 @@ use helios_core::network_spec::NetworkSpec;
 pub struct Ethereum;
 
 impl NetworkSpec for Ethereum {
+    type EvmExt = ();
+
+    fn evm<DB: revm::Database>(
+        db: DB,
+        env: Box<revm::primitives::Env>,
+    ) -> revm::Evm<'static, Self::EvmExt, DB> {
+        EvmBuilder::default()
+            .with_db(db)
+            .with_env(env)
+            .with_handler_cfg(HandlerCfg::new(SpecId::LATEST))
+            .build()
+    }
+
     fn encode_receipt(receipt: &Self::ReceiptResponse) -> Vec<u8> {
         let tx_type = receipt.transaction_type();
         let receipt = receipt.inner.as_receipt_with_bloom().unwrap();

--- a/ethereum/src/spec.rs
+++ b/ethereum/src/spec.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use alloy::{
     consensus::{
@@ -97,7 +97,7 @@ impl Ethereum {
 
     async fn call_inner(
         tx: &<Self as alloy::providers::Network>::TransactionRequest,
-        execution: std::sync::Arc<helios_core::execution::ExecutionClient<Self, HttpRpc<Self>>>,
+        execution: Arc<ExecutionClient<Self, HttpRpc<Self>>>,
         chain_id: u64,
         tag: helios_core::types::BlockTag,
     ) -> Result<ResultAndState, EvmError> {
@@ -130,7 +130,7 @@ impl Ethereum {
 
     async fn get_env(
         tx: &<Self as alloy::providers::Network>::TransactionRequest,
-        execution: std::sync::Arc<helios_core::execution::ExecutionClient<Self, HttpRpc<Self>>>,
+        execution: Arc<ExecutionClient<Self, HttpRpc<Self>>>,
         chain_id: u64,
         tag: BlockTag,
     ) -> Env {
@@ -159,7 +159,7 @@ impl NetworkSpec for Ethereum {
         execution: Arc<ExecutionClient<Self, HttpRpc<Self>>>,
         chain_id: u64,
         tag: BlockTag,
-    ) -> impl std::future::Future<Output = Result<Bytes, EvmError>> + Send {
+    ) -> impl Future<Output = Result<Bytes, EvmError>> + Send {
         async move {
             let tx = Self::call_inner(tx, execution, chain_id, tag).await?;
 
@@ -178,7 +178,7 @@ impl NetworkSpec for Ethereum {
         execution: Arc<ExecutionClient<Self, HttpRpc<Self>>>,
         chain_id: u64,
         tag: BlockTag,
-    ) -> impl std::future::Future<Output = Result<u64, EvmError>> + Send {
+    ) -> impl Future<Output = Result<u64, EvmError>> + Send {
         async move {
             let tx = Self::call_inner(tx, execution, chain_id, tag).await?;
 

--- a/opstack/src/spec.rs
+++ b/opstack/src/spec.rs
@@ -24,18 +24,164 @@ use revm::{
 #[derive(Clone, Copy, Debug)]
 pub struct OpStack;
 
-impl NetworkSpec for OpStack {
-    type EvmExt = ();
-
+impl OpStack {
     fn evm<DB: revm::Database>(
         db: DB,
         env: Box<revm::primitives::Env>,
-    ) -> revm::Evm<'static, Self::EvmExt, DB> {
+    ) -> revm::Evm<'static, (), DB> {
         EvmBuilder::default()
             .with_db(db)
             .with_env(env)
             .with_handler_cfg(HandlerCfg::new(SpecId::LATEST))
             .build()
+    }
+
+    fn tx_env(tx: &Self::TransactionRequest) -> TxEnv {
+        let mut tx_env = TxEnv::default();
+        tx_env.caller =
+            <OpTransactionRequest as TransactionBuilder<Self>>::from(tx).unwrap_or_default();
+        tx_env.gas_limit = <OpTransactionRequest as TransactionBuilder<Self>>::gas_limit(tx)
+            .map(|v| v as u64)
+            .unwrap_or(u64::MAX);
+        tx_env.gas_price = <OpTransactionRequest as TransactionBuilder<Self>>::gas_price(tx)
+            .map(U256::from)
+            .unwrap_or_default();
+        tx_env.transact_to =
+            <OpTransactionRequest as TransactionBuilder<Self>>::kind(tx).unwrap_or_default();
+        tx_env.value =
+            <OpTransactionRequest as TransactionBuilder<Self>>::value(tx).unwrap_or_default();
+        tx_env.data = <OpTransactionRequest as TransactionBuilder<Self>>::input(tx)
+            .unwrap_or_default()
+            .clone();
+        tx_env.nonce = <OpTransactionRequest as TransactionBuilder<Self>>::nonce(tx);
+        tx_env.chain_id = <OpTransactionRequest as TransactionBuilder<Self>>::chain_id(tx);
+        tx_env.access_list = <OpTransactionRequest as TransactionBuilder<Self>>::access_list(tx)
+            .map(|v| v.to_vec())
+            .unwrap_or_default();
+        tx_env.gas_priority_fee =
+            <OpTransactionRequest as TransactionBuilder<Self>>::max_priority_fee_per_gas(tx)
+                .map(U256::from);
+        tx_env.max_fee_per_blob_gas =
+            <OpTransactionRequest as TransactionBuilder<Self>>::max_fee_per_gas(tx).map(U256::from);
+        tx_env.blob_hashes = tx
+            .clone()
+            .build_typed_tx()
+            .unwrap()
+            .blob_versioned_hashes()
+            .as_ref()
+            .map(|v| v.to_vec())
+            .unwrap_or_default();
+
+        tx_env
+    }
+
+    fn block_env(block: &Self::BlockResponse) -> BlockEnv {
+        let mut block_env = BlockEnv::default();
+        block_env.number = U256::from(block.header.number());
+        block_env.coinbase = block.header.beneficiary();
+        block_env.timestamp = U256::from(block.header.timestamp());
+        block_env.gas_limit = U256::from(block.header.gas_limit());
+        block_env.basefee = U256::from(block.header.base_fee_per_gas().unwrap_or(0_u64));
+        block_env.difficulty = block.header.difficulty();
+        block_env.prevrandao = block.header.mix_hash();
+        block_env.blob_excess_gas_and_price = block
+            .header
+            .excess_blob_gas()
+            .map(|v| BlobExcessGasAndPrice::new(v.into()));
+
+        block_env
+    }
+
+    async fn call_inner(
+        tx: &<Self as alloy::providers::Network>::TransactionRequest,
+        execution: std::sync::Arc<helios_core::execution::ExecutionClient<Self, HttpRpc<Self>>>,
+        chain_id: u64,
+        tag: helios_core::types::BlockTag,
+    ) -> Result<ResultAndState, EvmError> {
+        let mut db = ProofDB::new(tag, execution.clone());
+        _ = db.state.prefetch_state(tx).await;
+
+        let env = Box::new(Self::get_env(tx, execution, chain_id, tag).await);
+        let mut evm = Self::evm(db, env);
+
+        let tx_res = loop {
+            let db = evm.db_mut();
+            if db.state.needs_update() {
+                db.state.update_state().await.unwrap();
+            }
+
+            let res = evm.transact();
+            let db = evm.db_mut();
+            let needs_update = db.state.needs_update();
+
+            if res.is_ok() || !needs_update {
+                break res;
+            }
+        };
+
+        tx_res.map_err(|_| EvmError::Generic("evm error".to_string()))
+    }
+
+    async fn get_env(
+        tx: &<Self as alloy::providers::Network>::TransactionRequest,
+        execution: std::sync::Arc<helios_core::execution::ExecutionClient<Self, HttpRpc<Self>>>,
+        chain_id: u64,
+        tag: BlockTag,
+    ) -> Env {
+        let mut env = Env::default();
+        env.tx = Self::tx_env(tx);
+
+        let block = execution
+            .get_block(tag, false)
+            .await
+            .ok_or(ExecutionError::BlockNotFound(tag))
+            .unwrap();
+        env.block = Self::block_env(&block);
+
+        env.cfg.chain_id = chain_id;
+        env.cfg.disable_block_gas_limit = true;
+        env.cfg.disable_eip3607 = true;
+        env.cfg.disable_base_fee = true;
+
+        env
+    }
+}
+
+impl NetworkSpec for OpStack {
+    fn call(
+        tx: &Self::TransactionRequest,
+        execution: Arc<ExecutionClient<Self, HttpRpc<Self>>>,
+        chain_id: u64,
+        tag: BlockTag,
+    ) -> impl std::future::Future<Output = Result<Bytes, EvmError>> + Send {
+        async move {
+            let tx = Self::call_inner(tx, execution, chain_id, tag).await?;
+
+            match tx.result {
+                ExecutionResult::Success { output, .. } => Ok(output.into_data()),
+                ExecutionResult::Revert { output, .. } => {
+                    Err(EvmError::Revert(Some(output.to_vec().into())))
+                }
+                ExecutionResult::Halt { .. } => Err(EvmError::Revert(None)),
+            }
+        }
+    }
+
+    fn estimate_gas(
+        tx: &Self::TransactionRequest,
+        execution: Arc<ExecutionClient<Self, HttpRpc<Self>>>,
+        chain_id: u64,
+        tag: BlockTag,
+    ) -> impl std::future::Future<Output = Result<u64, EvmError>> + Send {
+        async move {
+            let tx = Self::call_inner(tx, execution, chain_id, tag).await?;
+
+            match tx.result {
+                ExecutionResult::Success { gas_used, .. } => Ok(gas_used),
+                ExecutionResult::Revert { gas_used, .. } => Ok(gas_used),
+                ExecutionResult::Halt { gas_used, .. } => Ok(gas_used),
+            }
+        }
     }
 
     fn encode_receipt(receipt: &Self::ReceiptResponse) -> Vec<u8> {
@@ -126,62 +272,6 @@ impl NetworkSpec for OpStack {
 
     fn receipt_logs(receipt: &Self::ReceiptResponse) -> Vec<Log> {
         receipt.inner.inner.logs().to_vec()
-    }
-
-    fn tx_env(tx: &Self::TransactionRequest) -> TxEnv {
-        let mut tx_env = TxEnv::default();
-        tx_env.caller =
-            <OpTransactionRequest as TransactionBuilder<Self>>::from(tx).unwrap_or_default();
-        tx_env.gas_limit = <OpTransactionRequest as TransactionBuilder<Self>>::gas_limit(tx)
-            .map(|v| v as u64)
-            .unwrap_or(u64::MAX);
-        tx_env.gas_price = <OpTransactionRequest as TransactionBuilder<Self>>::gas_price(tx)
-            .map(U256::from)
-            .unwrap_or_default();
-        tx_env.transact_to =
-            <OpTransactionRequest as TransactionBuilder<Self>>::kind(tx).unwrap_or_default();
-        tx_env.value =
-            <OpTransactionRequest as TransactionBuilder<Self>>::value(tx).unwrap_or_default();
-        tx_env.data = <OpTransactionRequest as TransactionBuilder<Self>>::input(tx)
-            .unwrap_or_default()
-            .clone();
-        tx_env.nonce = <OpTransactionRequest as TransactionBuilder<Self>>::nonce(tx);
-        tx_env.chain_id = <OpTransactionRequest as TransactionBuilder<Self>>::chain_id(tx);
-        tx_env.access_list = <OpTransactionRequest as TransactionBuilder<Self>>::access_list(tx)
-            .map(|v| v.to_vec())
-            .unwrap_or_default();
-        tx_env.gas_priority_fee =
-            <OpTransactionRequest as TransactionBuilder<Self>>::max_priority_fee_per_gas(tx)
-                .map(U256::from);
-        tx_env.max_fee_per_blob_gas =
-            <OpTransactionRequest as TransactionBuilder<Self>>::max_fee_per_gas(tx).map(U256::from);
-        tx_env.blob_hashes = tx
-            .clone()
-            .build_typed_tx()
-            .unwrap()
-            .blob_versioned_hashes()
-            .as_ref()
-            .map(|v| v.to_vec())
-            .unwrap_or_default();
-
-        tx_env
-    }
-
-    fn block_env(block: &Self::BlockResponse) -> BlockEnv {
-        let mut block_env = BlockEnv::default();
-        block_env.number = U256::from(block.header.number());
-        block_env.coinbase = block.header.beneficiary();
-        block_env.timestamp = U256::from(block.header.timestamp());
-        block_env.gas_limit = U256::from(block.header.gas_limit());
-        block_env.basefee = U256::from(block.header.base_fee_per_gas().unwrap_or(0_u64));
-        block_env.difficulty = block.header.difficulty();
-        block_env.prevrandao = block.header.mix_hash();
-        block_env.blob_excess_gas_and_price = block
-            .header
-            .excess_blob_gas()
-            .map(|v| BlobExcessGasAndPrice::new(v.into()));
-
-        block_env
     }
 }
 

--- a/opstack/src/spec.rs
+++ b/opstack/src/spec.rs
@@ -16,12 +16,28 @@ use op_alloy_network::{
     BuildResult, Ethereum, Network, NetworkWallet, TransactionBuilder, TransactionBuilderError,
 };
 use op_alloy_rpc_types::{OpTransactionRequest, Transaction};
-use revm::primitives::{BlobExcessGasAndPrice, BlockEnv, TxEnv};
+use revm::{
+    primitives::{BlobExcessGasAndPrice, BlockEnv, HandlerCfg, TxEnv},
+    EvmBuilder,
+};
 
 #[derive(Clone, Copy, Debug)]
 pub struct OpStack;
 
 impl NetworkSpec for OpStack {
+    type EvmExt = ();
+
+    fn evm<DB: revm::Database>(
+        db: DB,
+        env: Box<revm::primitives::Env>,
+    ) -> revm::Evm<'static, Self::EvmExt, DB> {
+        EvmBuilder::default()
+            .with_db(db)
+            .with_env(env)
+            .with_handler_cfg(HandlerCfg::new(SpecId::LATEST))
+            .build()
+    }
+
     fn encode_receipt(receipt: &Self::ReceiptResponse) -> Vec<u8> {
         let receipt = &receipt.inner.inner;
         let bloom = receipt.bloom();


### PR DESCRIPTION
closes #406 

## Description 

This PR adds a new method on the `network_spec` called `evm()` to retrieve the evm with custom handlers and configuration. The evm build is now handled on the respective network implementation that enables support for evms based on the active hard fork. 

## Note

Basic implementation of the `evm` method on the network is added currently, but should be modified to suit our requirements before merging