### PR TITLE
refactor(builder): improve error handling in URL parsing

### DIFF
--- a/opstack/src/builder.rs
+++ b/opstack/src/builder.rs
@@ -30,14 +30,14 @@ impl OpStackClientBuilder {
         self
     }
 
-    pub fn consensus_rpc<T: IntoUrl>(mut self, consensus_rpc: T) -> Self {
-        self.consensus_rpc = Some(consensus_rpc.into_url().unwrap());
-        self
+    pub fn consensus_rpc<T: IntoUrl>(mut self, consensus_rpc: T) -> Result<Self> {
+        self.consensus_rpc = Some(consensus_rpc.into_url()?);
+        Ok(self)
     }
 
-    pub fn execution_rpc<T: IntoUrl>(mut self, execution_rpc: T) -> Self {
-        self.execution_rpc = Some(execution_rpc.into_url().unwrap());
-        self
+    pub fn execution_rpc<T: IntoUrl>(mut self, execution_rpc: T) -> Result<Self> {
+        self.execution_rpc = Some(execution_rpc.into_url()?);
+        Ok(self)
     }
 
     pub fn rpc_socket(mut self, socket: SocketAddr) -> Self {


### PR DESCRIPTION
Commit Description:
Replace unwrap() calls with proper error handling in OpStackClientBuilder. This change makes the builder more robust by:
- Converting consensus_rpc and execution_rpc methods to return Result
- Using the ? operator for proper error propagation
- Preventing potential panics from invalid URLs

This improves the reliability and safety of the client builder pattern.