### PR TITLE
fix: correct block hash validation in get_payloads function

### DIFF
--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -334,7 +334,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
                 continue;
             }
             let payload = result.unwrap().body.execution_payload().clone();
-            if payload.block_hash() != &prev_parent_hash {
+            if payload.parent_hash() != &prev_parent_hash {
                 warn!(
                     target: "helios::consensus",
                     error = %ConsensusError::InvalidHeaderHash(


### PR DESCRIPTION
The get_payloads function was comparing block_hash() with prev_parent_hash, which is incorrect for validating block chain consistency. Changed to compare parent_hash() with prev_parent_hash to ensure proper block linking.

Impact:
- Fixes potential block synchronization issues
- Ensures correct block chain validation
- Prevents false-positive chain breaks