### PR TITLE
fix: add serde feature for url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,7 +2956,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helios"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "criterion",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "helios-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "clap",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "helios-consensus-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "helios-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "alloy-trie",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "helios-ethereum"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "alloy-trie",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "helios-opstack"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -13,7 +13,7 @@ revm.workspace = true
 figment = { version = "0.10.7", features = ["toml", "env"] }
 serde_yaml = "0.9.14"
 strum = { version = "0.26.2", features = ["derive"] }
-url = "2.5.0"
+url = {version = "2.5.0", features = ["serde"] }
 
 # async/futures
 tokio.workspace = true


### PR DESCRIPTION
I have a build error in latest helios here:

https://github.com/a16z/helios/blob/d35a0b7e776b6284cf3ec042f96df17ae90f0239/ethereum/src/config/cli.rs#L10-L13

because the `url` serde feature is not enabled. So I added it.