### PR TITLE
fix: handle empty filter topic in ensure_logs_match_filter

### DIFF
--- a/core/src/execution/mod.rs
+++ b/core/src/execution/mod.rs
@@ -280,7 +280,7 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> ExecutionClient<N, R> {
                 ExecutionError::TooManyLogsToProve(logs.len(), MAX_SUPPORTED_LOGS_NUMBER).into(),
             );
         }
-        self.ensure_logs_match_filter(&logs, &filter)?;
+        ensure_logs_match_filter(&logs, &filter)?;
         self.verify_logs(&logs).await?;
         Ok(logs)
     }
@@ -304,7 +304,7 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> ExecutionClient<N, R> {
                     )
                     .into());
                 }
-                self.ensure_logs_match_filter(logs, filter)?;
+                ensure_logs_match_filter(logs, filter)?;
                 self.verify_logs(logs).await?;
                 FilterChanges::Logs(logs.to_vec())
             }
@@ -348,7 +348,7 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> ExecutionClient<N, R> {
                     )
                     .into());
                 }
-                self.ensure_logs_match_filter(&logs, filter)?;
+                ensure_logs_match_filter(&logs, filter)?;
                 self.verify_logs(&logs).await?;
                 Ok(logs)
             }
@@ -411,50 +411,6 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> ExecutionClient<N, R> {
             .await;
 
         Ok(filter_id)
-    }
-
-    /// Ensure that each log entry in the given array of logs match the given filter.
-    fn ensure_logs_match_filter(&self, logs: &[Log], filter: &Filter) -> Result<()> {
-        fn log_matches_filter(log: &Log, filter: &Filter) -> bool {
-            if let Some(block_hash) = filter.get_block_hash() {
-                if log.block_hash.unwrap() != block_hash {
-                    return false;
-                }
-            }
-            if let Some(from_block) = filter.get_from_block() {
-                if log.block_number.unwrap() < from_block {
-                    return false;
-                }
-            }
-            if let Some(to_block) = filter.get_to_block() {
-                if log.block_number.unwrap() > to_block {
-                    return false;
-                }
-            }
-            if !filter.address.matches(&log.address()) {
-                return false;
-            }
-            for (i, filter_topic) in filter.topics.iter().enumerate() {
-                if filter_topic.is_empty() {
-                    return true; // empty filter topic matches any log topic
-                }
-                if let Some(log_topic) = log.topics().get(i) {
-                    return filter_topic.matches(log_topic);
-                } else {
-                    // if filter topic is not present in log, it's a mismatch
-                    return false;
-                }
-            }
-            true
-        }
-
-        for log in logs {
-            if !log_matches_filter(log, filter) {
-                return Err(ExecutionError::LogFilterMismatch().into());
-            }
-        }
-
-        Ok(())
     }
 
     /// Verify the integrity of each log entry in the given array of logs by
@@ -524,4 +480,49 @@ fn ordered_trie_root(items: &[Vec<u8>]) -> B256 {
     }
 
     ordered_trie_root_with_encoder(items, noop_encoder)
+}
+
+/// Ensure that each log entry in the given array of logs match the given filter.
+fn ensure_logs_match_filter(logs: &[Log], filter: &Filter) -> Result<()> {
+    fn log_matches_filter(log: &Log, filter: &Filter) -> bool {
+        if let Some(block_hash) = filter.get_block_hash() {
+            if log.block_hash.unwrap() != block_hash {
+                return false;
+            }
+        }
+        if let Some(from_block) = filter.get_from_block() {
+            if log.block_number.unwrap() < from_block {
+                return false;
+            }
+        }
+        if let Some(to_block) = filter.get_to_block() {
+            if log.block_number.unwrap() > to_block {
+                return false;
+            }
+        }
+        if !filter.address.matches(&log.address()) {
+            return false;
+        }
+        for (i, filter_topic) in filter.topics.iter().enumerate() {
+            if !filter_topic.is_empty() {
+                if let Some(log_topic) = log.topics().get(i) {
+                    if !filter_topic.matches(log_topic) {
+                        return false;
+                    }
+                } else {
+                    // if filter topic is not present in log, it's a mismatch
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    for log in logs {
+        if !log_matches_filter(log, filter) {
+            return Err(ExecutionError::LogFilterMismatch().into());
+        }
+    }
+
+    Ok(())
 }

--- a/core/src/execution/mod.rs
+++ b/core/src/execution/mod.rs
@@ -18,7 +18,7 @@ use crate::types::BlockTag;
 
 use self::constants::MAX_SUPPORTED_LOGS_NUMBER;
 use self::errors::ExecutionError;
-use self::proof::{verify_account_proof, verify_storage_proof};
+use self::proof::{ensure_logs_match_filter, verify_account_proof, verify_storage_proof};
 use self::rpc::ExecutionRpc;
 use self::state::{FilterType, State};
 use self::types::Account;
@@ -280,7 +280,7 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> ExecutionClient<N, R> {
                 ExecutionError::TooManyLogsToProve(logs.len(), MAX_SUPPORTED_LOGS_NUMBER).into(),
             );
         }
-        self.ensure_logs_match_filter(&logs, &filter).await?;
+        ensure_logs_match_filter(&logs, &filter)?;
         self.verify_logs(&logs).await?;
         Ok(logs)
     }
@@ -304,7 +304,7 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> ExecutionClient<N, R> {
                     )
                     .into());
                 }
-                self.ensure_logs_match_filter(logs, filter).await?;
+                ensure_logs_match_filter(logs, filter)?;
                 self.verify_logs(logs).await?;
                 FilterChanges::Logs(logs.to_vec())
             }
@@ -348,7 +348,7 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> ExecutionClient<N, R> {
                     )
                     .into());
                 }
-                self.ensure_logs_match_filter(&logs, filter).await?;
+                ensure_logs_match_filter(&logs, filter)?;
                 self.verify_logs(&logs).await?;
                 Ok(logs)
             }
@@ -411,47 +411,6 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> ExecutionClient<N, R> {
             .await;
 
         Ok(filter_id)
-    }
-
-    /// Ensure that each log entry in the given array of logs match the given filter.
-    async fn ensure_logs_match_filter(&self, logs: &[Log], filter: &Filter) -> Result<()> {
-        fn log_matches_filter(log: &Log, filter: &Filter) -> bool {
-            if let Some(block_hash) = filter.get_block_hash() {
-                if log.block_hash.unwrap() != block_hash {
-                    return false;
-                }
-            }
-            if let Some(from_block) = filter.get_from_block() {
-                if log.block_number.unwrap() < from_block {
-                    return false;
-                }
-            }
-            if let Some(to_block) = filter.get_to_block() {
-                if log.block_number.unwrap() > to_block {
-                    return false;
-                }
-            }
-            if !filter.address.matches(&log.address()) {
-                return false;
-            }
-            for (i, topic) in filter.topics.iter().enumerate() {
-                if let Some(log_topic) = log.topics().get(i) {
-                    if !topic.matches(log_topic) {
-                        return false;
-                    }
-                } else {
-                    // if filter topic is not present in log, it's a mismatch
-                    return false;
-                }
-            }
-            true
-        }
-        for log in logs {
-            if !log_matches_filter(log, filter) {
-                return Err(ExecutionError::LogFilterMismatch().into());
-            }
-        }
-        Ok(())
     }
 
     /// Verify the integrity of each log entry in the given array of logs by

--- a/core/src/execution/proof.rs
+++ b/core/src/execution/proof.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use alloy::primitives::{keccak256, Bytes, B256, U256};
 use alloy::rlp;
-use alloy::rpc::types::EIP1186AccountProofResponse;
+use alloy::rpc::types::{EIP1186AccountProofResponse, Filter, Log};
 use alloy_trie::{
     proof::verify_proof,
     {Nibbles, TrieAccount},
@@ -86,4 +86,52 @@ fn is_empty_value(value: &[u8]) -> bool {
     let is_empty_slot = value.len() == 1 && value[0] == 0x80;
     let is_empty_account = value == empty_account || value == new_empty_account;
     is_empty_slot || is_empty_account
+}
+
+/// Ensure that each log entry in the given array of logs match the given filter.
+pub fn ensure_logs_match_filter(logs: &[Log], filter: &Filter) -> Result<()> {
+    fn log_matches_filter(log: &Log, filter: &Filter) -> bool {
+        if let Some(block_hash) = filter.get_block_hash() {
+            if log.block_hash.unwrap() != block_hash {
+                return false;
+            }
+        }
+        if let Some(from_block) = filter.get_from_block() {
+            if log.block_number.unwrap() < from_block {
+                return false;
+            }
+        }
+        if let Some(to_block) = filter.get_to_block() {
+            if log.block_number.unwrap() > to_block {
+                return false;
+            }
+        }
+        if !filter.address.matches(&log.address()) {
+            return false;
+        }
+        for (i, topic) in filter
+            .topics
+            .iter()
+            .filter(|topic| !topic.is_empty())
+            .enumerate()
+        {
+            if let Some(log_topic) = log.topics().get(i) {
+                if !topic.matches(log_topic) {
+                    return false;
+                }
+            } else {
+                // if filter topic is not present in log, it's a mismatch
+                return false;
+            }
+        }
+        true
+    }
+
+    for log in logs {
+        if !log_matches_filter(log, filter) {
+            return Err(ExecutionError::LogFilterMismatch().into());
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
This fixes a bug introduced in PR #507.

## Changes

- The `ensure_logs_match_filter` fn was not handling the null case for filter topics.
- Removed the unnecessary `async` on `ensure_logs_match_filter` fn.