### PR TITLE
fix: #501 accidental blocks backfill due to a race condition

### DIFF
--- a/core/src/execution/state.rs
+++ b/core/src/execution/state.rs
@@ -53,7 +53,7 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> State<N, R> {
                     _ = finalized_block_recv.changed() => {
                         let block = finalized_block_recv.borrow_and_update().clone();
                         if let Some(block) = block {
-                            inner_ref.write().await.push_finalized_block(block).await;
+                            inner_ref.write().await.push_finalized_block(block);
                         }
 
                     },
@@ -345,15 +345,14 @@ impl<N: NetworkSpec, R: ExecutionRpc<N>> Inner<N, R> {
         }
     }
 
-    pub async fn push_finalized_block(&mut self, block: N::BlockResponse) {
+    pub fn push_finalized_block(&mut self, block: N::BlockResponse) {
         if let Some(old_block) = self.blocks.get(&block.header().number()) {
             if old_block.header().hash() != block.header().hash() {
                 self.blocks = BTreeMap::new();
             }
         }
 
-        self.finalized_block = Some(block.clone());
-        self.push_block(block).await;
+        self.finalized_block = Some(block);
     }
 
     fn remove_block(&mut self, number: u64) {


### PR DESCRIPTION
fixes #501 

There's little need to push finalized blocks into `blocks` state because they would either repeat existing blocks, or cause unexpected backfills. Thus, I suppose we can remove this step.