### PR TITLE
fix: incorrect naming: verify_unsafe_singer -> verify_unsafe_signer

### DIFF
--- a/opstack/src/builder.rs
+++ b/opstack/src/builder.rs
@@ -17,7 +17,7 @@ pub struct OpStackClientBuilder {
     consensus_rpc: Option<Url>,
     execution_rpc: Option<Url>,
     rpc_socket: Option<SocketAddr>,
-    verify_unsafe_singer: Option<bool>,
+    verify_unsafe_signer: Option<bool>,
 }
 
 impl OpStackClientBuilder {
@@ -50,8 +50,8 @@ impl OpStackClientBuilder {
         self
     }
 
-    pub fn verify_unsafe_singer(mut self, value: bool) -> Self {
-        self.verify_unsafe_singer = Some(value);
+    pub fn verify_unsafe_signer(mut self, value: bool) -> Self {
+        self.verify_unsafe_signer = Some(value);
         self
     }
 
@@ -78,7 +78,7 @@ impl OpStackClientBuilder {
                 chain: NetworkConfig::from(network).chain,
                 load_external_fallback: None,
                 checkpoint: None,
-                verify_unsafe_signer: self.verify_unsafe_singer.unwrap_or_default(),
+                verify_unsafe_signer: self.verify_unsafe_signer.unwrap_or_default(),
             }
         };
 


### PR DESCRIPTION
Fixed a typo in OpStackClientBuilder where "singer" was incorrectly used instead of "signer" in field and method names. This improves code clarity and consistency with cryptographic terminology.