### PR TITLE
bug fix: Sync failing for checkpoint > 128

### DIFF
--- a/ethereum/consensus-core/src/consensus_core.rs
+++ b/ethereum/consensus-core/src/consensus_core.rs
@@ -275,7 +275,6 @@ pub fn verify_generic_update<S: ConsensusSpec>(
     } else {
         update_sig_period == store_period
     };
-
     if !valid_period {
         return Err(ConsensusError::InvalidPeriod.into());
     }

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -363,21 +363,18 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
 
         let mut updates: Vec<Update<S>> = vec![];
         if expected_current_period - bootstrap_period >= 128 {
-            println!("Over 128");
             while bootstrap_period < expected_current_period {
-
                 let batch_size = std::cmp::min(
                     expected_current_period - bootstrap_period,
                     MAX_REQUEST_LIGHT_CLIENT_UPDATES.into(),
                 );
-                println!("Running for {} and batch size:{}",bootstrap_period,batch_size);
                 let update = self
                     .rpc
                     .get_updates(bootstrap_period, batch_size.try_into().unwrap())
                     .await?;
                 updates.extend(update);
 
-                bootstrap_period +=batch_size;
+                bootstrap_period += batch_size;
             }
         }
         let update: Vec<Update<S>> = self

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -357,31 +357,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
 
         self.bootstrap(checkpoint).await?;
 
-        let expected_current_slot = self.expected_current_slot();
-        let expected_current_period = calc_sync_period::<S>(expected_current_slot);
-        let mut bootstrap_period = calc_sync_period::<S>(self.store.finalized_header.beacon().slot);
-
-        let mut updates: Vec<Update<S>> = vec![];
-        if expected_current_period - bootstrap_period >= 128 {
-            while bootstrap_period < expected_current_period {
-                let batch_size = std::cmp::min(
-                    expected_current_period - bootstrap_period,
-                    MAX_REQUEST_LIGHT_CLIENT_UPDATES.into(),
-                );
-                let update = self
-                    .rpc
-                    .get_updates(bootstrap_period, batch_size.try_into().unwrap())
-                    .await?;
-                updates.extend(update);
-
-                bootstrap_period += batch_size;
-            }
-        }
-        let update: Vec<Update<S>> = self
-            .rpc
-            .get_updates(bootstrap_period, MAX_REQUEST_LIGHT_CLIENT_UPDATES)
-            .await?;
-        updates.extend(update);
+        let updates: Vec<Update<S>> = self.get_updates().await?;
 
         for update in updates {
             self.verify_update(&update)?;
@@ -398,6 +374,41 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
         );
 
         Ok(())
+    }
+
+    pub async fn get_updates(
+        &mut self,
+        // expected_current_period: u64,
+        // next_update_fetch_period: &mut u64,
+    ) -> Result<Vec<Update<S>>> {
+        let expected_current_slot = self.expected_current_slot();
+        let expected_current_period = calc_sync_period::<S>(expected_current_slot);
+        let mut next_update_fetch_period =
+            calc_sync_period::<S>(self.store.finalized_header.beacon().slot);
+
+        let mut updates: Vec<Update<S>> = vec![];
+        if expected_current_period - next_update_fetch_period >= 128 {
+            while next_update_fetch_period < expected_current_period {
+                let batch_size = std::cmp::min(
+                    expected_current_period - next_update_fetch_period,
+                    MAX_REQUEST_LIGHT_CLIENT_UPDATES.into(),
+                );
+                let update = self
+                    .rpc
+                    .get_updates(next_update_fetch_period, batch_size.try_into().unwrap())
+                    .await?;
+                updates.extend(update);
+
+                next_update_fetch_period += batch_size;
+            }
+        }
+        let update: Vec<Update<S>> = self
+            .rpc
+            .get_updates(next_update_fetch_period, MAX_REQUEST_LIGHT_CLIENT_UPDATES)
+            .await?;
+        updates.extend(update);
+
+        Ok(updates)
     }
 
     pub async fn advance(&mut self) -> Result<()> {


### PR DESCRIPTION
Ref #388 


Run the following command to check that the issue is resolved:
```
cargo run ethereum --execution-rpc 'https://eth-mainnet.g.alchemy.com/v2/<API_KEY>' --checkpoint 0xc7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce
```