### PR TITLE
chore: fix typos

### DIFF
--- a/ethereum/consensus-core/src/consensus_core.rs
+++ b/ethereum/consensus-core/src/consensus_core.rs
@@ -343,7 +343,7 @@ pub fn verify_generic_update<S: ConsensusSpec>(
 
     let fork_version = calculate_fork_version::<S>(forks, update.signature_slot.saturating_sub(1));
     let fork_data_root = compute_fork_data_root(fork_version, genesis_root);
-    let is_valid_sig = verify_sync_committee_signture(
+    let is_valid_sig = verify_sync_committee_signature(
         &pks,
         update.attested_header.beacon(),
         &update.sync_aggregate.sync_committee_signature,
@@ -482,7 +482,7 @@ fn has_finality_update<S: ConsensusSpec>(update: &GenericUpdate<S>) -> bool {
     update.finality_branch.is_some()
 }
 
-fn verify_sync_committee_signture(
+fn verify_sync_committee_signature(
     pks: &[PublicKey],
     attested_header: &BeaconBlockHeader,
     signature: &Signature,

--- a/ethereum/consensus-core/src/consensus_core.rs
+++ b/ethereum/consensus-core/src/consensus_core.rs
@@ -171,7 +171,7 @@ pub fn apply_generic_update<S: ConsensusSpec>(
         && update_finalized_period == update_attested_period;
 
     let should_apply_update = {
-        let has_majority = committee_bits * 3 >= S::sync_commitee_size() * 2;
+        let has_majority = committee_bits * 3 >= S::sync_committee_size() * 2;
         if !has_majority {
             warn!("skipping block with low vote count");
         }
@@ -360,7 +360,7 @@ pub fn verify_generic_update<S: ConsensusSpec>(
 /// WARNING: `force_update` allows Helios to accept a header with less than a quorum of signatures.
 /// Use with caution only in cases where it is not possible that valid updates are being censored.
 pub fn force_update<S: ConsensusSpec>(store: &mut LightClientStore<S>, current_slot: u64) {
-    if current_slot > store.finalized_header.beacon().slot + S::slots_per_sync_commitee_period() {
+    if current_slot > store.finalized_header.beacon().slot + S::slots_per_sync_committee_period() {
         if let Some(mut best_valid_update) = store.best_valid_update.clone() {
             if best_valid_update
                 .finalized_header
@@ -392,7 +392,7 @@ pub fn expected_current_slot(now: SystemTime, genesis_time: u64) -> u64 {
 
 pub fn calc_sync_period<S: ConsensusSpec>(slot: u64) -> u64 {
     let epoch = slot / S::slots_per_epoch();
-    epoch / S::epochs_per_sync_commitee_period()
+    epoch / S::epochs_per_sync_committee_period()
 }
 
 pub fn get_bits<S: ConsensusSpec>(bitfield: &BitVector<S::SyncCommitteeSize>) -> u64 {

--- a/ethereum/consensus-core/src/consensus_spec.rs
+++ b/ethereum/consensus-core/src/consensus_spec.rs
@@ -16,9 +16,9 @@ pub trait ConsensusSpec: 'static + Default + Sync + Send + Clone + Debug + Parti
     type MaxBlsToExecutionChanged: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxBlobKzgCommitments: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxWithdrawals: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
-    type MaxValidatorsPerCommitee: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
+    type MaxValidatorsPerCommittee: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type SlotsPerEpoch: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
-    type EpochsPerSyncCommiteePeriod: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
+    type EpochsPerSyncCommitteePeriod: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type SyncCommitteeSize: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxWithdrawalRequests: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxDepositRequests: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
@@ -28,15 +28,15 @@ pub trait ConsensusSpec: 'static + Default + Sync + Send + Clone + Debug + Parti
         Self::SlotsPerEpoch::to_u64()
     }
 
-    fn epochs_per_sync_commitee_period() -> u64 {
-        Self::EpochsPerSyncCommiteePeriod::to_u64()
+    fn epochs_per_sync_committee_period() -> u64 {
+        Self::EpochsPerSyncCommitteePeriod::to_u64()
     }
 
-    fn slots_per_sync_commitee_period() -> u64 {
-        Self::slots_per_epoch() * Self::epochs_per_sync_commitee_period()
+    fn slots_per_sync_committee_period() -> u64 {
+        Self::slots_per_epoch() * Self::epochs_per_sync_committee_period()
     }
 
-    fn sync_commitee_size() -> u64 {
+    fn sync_committee_size() -> u64 {
         Self::SyncCommitteeSize::to_u64()
     }
 }
@@ -57,9 +57,9 @@ impl ConsensusSpec for MainnetConsensusSpec {
     type MaxBlsToExecutionChanged = typenum::U16;
     type MaxBlobKzgCommitments = typenum::U4096;
     type MaxWithdrawals = typenum::U16;
-    type MaxValidatorsPerCommitee = typenum::U2048;
+    type MaxValidatorsPerCommittee = typenum::U2048;
     type SlotsPerEpoch = typenum::U32;
-    type EpochsPerSyncCommiteePeriod = typenum::U256;
+    type EpochsPerSyncCommitteePeriod = typenum::U256;
     type SyncCommitteeSize = typenum::U512;
     type MaxDepositRequests = typenum::U8192;
     type MaxWithdrawalRequests = typenum::U16;
@@ -82,9 +82,9 @@ impl ConsensusSpec for MinimalConsensusSpec {
     type MaxBlsToExecutionChanged = typenum::U16;
     type MaxBlobKzgCommitments = typenum::U4096;
     type MaxWithdrawals = typenum::U16;
-    type MaxValidatorsPerCommitee = typenum::U2048;
+    type MaxValidatorsPerCommittee = typenum::U2048;
     type SlotsPerEpoch = typenum::U8;
-    type EpochsPerSyncCommiteePeriod = typenum::U8;
+    type EpochsPerSyncCommitteePeriod = typenum::U8;
     type SyncCommitteeSize = typenum::U32;
     type MaxDepositRequests = typenum::U4;
     type MaxWithdrawalRequests = typenum::U2;

--- a/ethereum/consensus-core/src/types/mod.rs
+++ b/ethereum/consensus-core/src/types/mod.rs
@@ -291,7 +291,7 @@ pub struct AttesterSlashing<S: ConsensusSpec> {
 struct IndexedAttestation<S: ConsensusSpec> {
     #[serde(with = "quoted_u64_var_list")]
     #[superstruct(only(Base), partial_getter(rename = "attesting_indices_base"))]
-    attesting_indices: VariableList<u64, S::MaxValidatorsPerCommitee>,
+    attesting_indices: VariableList<u64, S::MaxValidatorsPerCommittee>,
     #[serde(with = "quoted_u64_var_list")]
     #[superstruct(only(Electra), partial_getter(rename = "attesting_indices_electra"))]
     attesting_indices: VariableList<u64, S::MaxValidatorsPerSlot>,
@@ -319,7 +319,7 @@ impl<S: ConsensusSpec> Default for IndexedAttestation<S> {
 #[tree_hash(enum_behaviour = "transparent")]
 pub struct Attestation<S: ConsensusSpec> {
     #[superstruct(only(Base), partial_getter(rename = "aggregation_bits_base"))]
-    aggregation_bits: BitList<S::MaxValidatorsPerCommitee>,
+    aggregation_bits: BitList<S::MaxValidatorsPerCommittee>,
     #[superstruct(only(Electra), partial_getter(rename = "aggregation_bits_electra"))]
     aggregation_bits: BitList<S::MaxValidatorsPerSlot>,
     data: AttestationData,

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -505,7 +505,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
     }
 
     fn log_finality_update(&self, update: &FinalityUpdate<S>) {
-        let size = S::sync_commitee_size() as f32;
+        let size = S::sync_committee_size() as f32;
         let participation =
             get_bits::<S>(&update.sync_aggregate().sync_committee_bits) as f32 / size * 100f32;
         let decimals = if participation == 100.0 { 1 } else { 2 };
@@ -524,7 +524,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
     }
 
     fn log_optimistic_update(&self, update: &FinalityUpdate<S>) {
-        let size = S::sync_commitee_size() as f32;
+        let size = S::sync_committee_size() as f32;
         let participation =
             get_bits::<S>(&update.sync_aggregate().sync_committee_bits) as f32 / size * 100f32;
         let decimals = if participation == 100.0 { 1 } else { 2 };


### PR DESCRIPTION
This PR just fixes two typos found by [typos](https://crates.io/crates/typos), nothing fancy.

The `typos` check can also be integrated into the CI pipeline (as in https://github.com/a16z/jolt/pull/597):

```
jobs:
  ...
  typos:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: crate-ci/typos@v1
        with:
          files: .
```
