### PR TITLE
fix: consensus tests

### DIFF
--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -376,11 +376,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
         Ok(())
     }
 
-    pub async fn get_updates(
-        &mut self,
-        // expected_current_period: u64,
-        // next_update_fetch_period: &mut u64,
-    ) -> Result<Vec<Update<S>>> {
+    pub async fn get_updates(&self) -> Result<Vec<Update<S>>> {
         let expected_current_slot = self.expected_current_slot();
         let expected_current_period = calc_sync_period::<S>(expected_current_slot);
         let mut next_update_fetch_period =
@@ -402,6 +398,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
                 next_update_fetch_period += batch_size;
             }
         }
+
         let update: Vec<Update<S>> = self
             .rpc
             .get_updates(next_update_fetch_period, MAX_REQUEST_LIGHT_CLIENT_UPDATES)
@@ -842,11 +839,13 @@ mod tests {
         let period = calc_sync_period::<MainnetConsensusSpec>(
             client.store.finalized_header.beacon().slot.into(),
         );
+        *client.rpc.fetched_updates.lock().unwrap() = false;
         let updates: Vec<Update<MainnetConsensusSpec>> = client
             .rpc
             .get_updates(period, MAX_REQUEST_LIGHT_CLIENT_UPDATES)
             .await
             .unwrap();
+
         // Replace here to test invalid finality proof
         *update.finalized_header_mut() = updates[0].finalized_header().clone();
 

--- a/ethereum/src/rpc/mock_rpc.rs
+++ b/ethereum/src/rpc/mock_rpc.rs
@@ -1,5 +1,4 @@
 use std::{
-    cell::RefCell,
     fs::read_to_string,
     path::PathBuf,
     sync::{Arc, Mutex},

--- a/ethereum/src/rpc/mock_rpc.rs
+++ b/ethereum/src/rpc/mock_rpc.rs
@@ -1,4 +1,9 @@
-use std::{fs::read_to_string, path::PathBuf};
+use std::{
+    cell::RefCell,
+    fs::read_to_string,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 use alloy::primitives::B256;
 use async_trait::async_trait;
@@ -14,6 +19,7 @@ use super::ConsensusRpc;
 
 pub struct MockRpc {
     testdata: PathBuf,
+    pub fetched_updates: Arc<Mutex<bool>>,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -22,6 +28,7 @@ impl<S: ConsensusSpec> ConsensusRpc<S> for MockRpc {
     fn new(path: &str) -> Self {
         MockRpc {
             testdata: PathBuf::from(path),
+            fetched_updates: Arc::new(Mutex::new(false)),
         }
     }
 
@@ -32,6 +39,10 @@ impl<S: ConsensusSpec> ConsensusRpc<S> for MockRpc {
     }
 
     async fn get_updates(&self, _period: u64, _count: u8) -> Result<Vec<Update<S>>> {
+        if *self.fetched_updates.lock().unwrap() {
+            return Ok(Vec::new());
+        }
+        *self.fetched_updates.lock().unwrap() = true;
         let res = read_to_string(self.testdata.join("updates.json"))?;
         let updates: Vec<UpdateData<S>> = serde_json::from_str(&res)?;
         Ok(updates.into_iter().map(|update| update.data).collect())

--- a/tests/rpc_equivalence.rs
+++ b/tests/rpc_equivalence.rs
@@ -50,8 +50,16 @@ async fn setup() -> (
     (helios_client, helios_provider, provider)
 }
 
+fn rpc_exists() -> bool {
+    env::var("MAINNET_EXECUTION_RPC").is_ok()
+}
+
 #[tokio::test]
 async fn get_transaction_by_hash() {
+    if !rpc_exists() {
+        return;
+    }
+
     let (_handle, helios_provider, provider) = setup().await;
 
     let block = helios_provider
@@ -97,6 +105,10 @@ async fn get_transaction_by_hash() {
 
 #[tokio::test]
 async fn get_transaction_receipt() {
+    if !rpc_exists() {
+        return;
+    }
+
     let (_handle, helios_provider, provider) = setup().await;
 
     let block = helios_provider
@@ -123,6 +135,10 @@ async fn get_transaction_receipt() {
 
 #[tokio::test]
 async fn get_block_receipts() {
+    if !rpc_exists() {
+        return;
+    }
+
     let (_handle, helios_provider, provider) = setup().await;
 
     let block = helios_provider
@@ -150,6 +166,10 @@ async fn get_block_receipts() {
 
 #[tokio::test]
 async fn get_balance() {
+    if !rpc_exists() {
+        return;
+    }
+
     let (_handle, helios_provider, provider) = setup().await;
     let num = helios_provider.get_block_number().await.unwrap();
 
@@ -171,6 +191,10 @@ async fn get_balance() {
 
 #[tokio::test]
 async fn call() {
+    if !rpc_exists() {
+        return;
+    }
+
     let (_handle, helios_provider, provider) = setup().await;
     let num = helios_provider.get_block_number().await.unwrap();
     let usdc = address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");


### PR DESCRIPTION
-  fixes tests failures from #528 making the mock rpc act strange
- disables rpc equivalence tests when rpc url is not available so we don't miss test failures in the future