### PR TITLE
fix: increase MAX_SUPPORTED_LOGS_NUMBER from 5 to 100

### DIFF
--- a/core/src/execution/constants.rs
+++ b/core/src/execution/constants.rs
@@ -2,6 +2,8 @@ pub const PARALLEL_QUERY_BATCH_SIZE: usize = 20;
 
 // We currently limit the max number of logs to fetch,
 // to avoid blocking the client for too long.
-pub const MAX_SUPPORTED_LOGS_NUMBER: usize = 5;
+// Increased from 5 to 100 to better support dApps that generate more logs
+// while still maintaining reasonable performance.
+pub const MAX_SUPPORTED_LOGS_NUMBER: usize = 100;
 
 pub const MAX_STATE_HISTORY_LENGTH: usize = 64;


### PR DESCRIPTION
This change increases the maximum number of logs that can be fetched from 5 to 100. 

The current limit is too restrictive for modern dApps that generate more logs during transactions. 

It improves usability while maintaining reasonable performance.