### PR TITLE
fix: fix incorrect `B256` conversion for `chain_id`

### DIFF
--- a/opstack/src/lib.rs
+++ b/opstack/src/lib.rs
@@ -64,7 +64,7 @@ impl TryFrom<&SequencerCommitment> for ExecutionPayload {
 
 fn signature_msg(data: &[u8], chain_id: u64) -> B256 {
     let domain = B256::ZERO;
-    let chain_id = B256::left_padding_from(&chain_id.to_be_bytes());
+    let chain_id = B256::from_uint(&U256::from(chain_id));
     let payload_hash = keccak256(data);
 
     let signing_data = [


### PR DESCRIPTION
I noticed that `B256::left_padding_from(&chain_id.to_be_bytes())` is incorrect because this method doesn't exist in `B256`. It looks like the intention was to convert `chain_id` to a 256-bit value.  

This fixes the issue by using:  

```rust
let chain_id = B256::from_uint(&U256::from(chain_id));
```

Why is this a problem?  
- `B256` expects a 256-bit value, but `chain_id.to_be_bytes()` only returns 8 bytes.