### PR TITLE
chore: fix 404 status URL

### DIFF
--- a/benches/harness.rs
+++ b/benches/harness.rs
@@ -111,8 +111,8 @@ pub fn get_balance(
     })
 }
 
-// h/t @ https://github.com/smrpn
-// rev: https://github.com/smrpn/casbin-rs/commit/7a0a75d8075440ee65acdac3ee9c0de6fcbd5c48
+// h/t @ https://github.com/0xethsign
+// rev: https://github.com/0xethsign/casbin-rs/commit/7a0a75d8075440ee65acdac3ee9c0de6fcbd5c48
 pub fn await_future<F: std::future::Future<Output = T>, T>(future: F) -> T {
     tokio::runtime::Runtime::new().unwrap().block_on(future)
 }


### PR DESCRIPTION
I found that the address in the comment has expired, the purpose of this PR is to fix this problem