### PR TITLE
fix: fix syntax compatibility with older Rust versions

### DIFF
--- a/opstack/src/builder.rs
+++ b/opstack/src/builder.rs
@@ -66,11 +66,13 @@ impl OpStackClientBuilder {
         let config = if let Some(config) = self.config {
             config
         } else {
-            let Some(network) = self.network else {
+            if let Some(network) = self.network {
+            } else {
                 eyre::bail!("network required");
             };
 
-            let Some(consensus_rpc) = self.consensus_rpc else {
+            if let Some(consensus_rpc) = self.consensus_rpc {
+            } else {
                 eyre::bail!("consensus rpc required");
             };
 


### PR DESCRIPTION
Replaced the newer syntax (`let Some(variable) = option else { ... }`) with `if let`, ensuring compatibility with older Rust versions and improving readability.