### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:24.04
+
+# Install curl
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN useradd -m -s /bin/bash helios
+
+# Switch to non-root user
+USER helios
+WORKDIR /home/helios
+
+# Set environment variable for helios
+ENV PATH="/home/helios/.helios/bin:${PATH}"
+
+# Install heliosup first, then use it to install helios
+RUN curl -fsSL https://raw.githubusercontent.com/a16z/helios/master/heliosup/install | bash && \
+    /bin/bash -c 'heliosup'
+
+# Set a default command
+CMD ["/bin/bash"]


### PR DESCRIPTION
Title: Add Dockerfile for containerized Helios installation

Description:
This PR adds a Dockerfile to simplify the installation and running of Helios in a containerized environment.

Key features:
- Uses Ubuntu 24.04 as the base image for long-term stability
- Implements security best practices by running as non-root user
- Minimizes image size by including only essential dependencies (curl)
- Properly installs Helios using the official heliosup installer

Usage:
```bash
# Build the image
docker build -t helios-ubuntu .

# Run interactive shell
docker run -it helios-ubuntu

# Run specific helios commands
docker run helios-ubuntu helios <command>