### PR TITLE
fix: evm state fetch infinite loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,7 +3066,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helios"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "alloy",
  "criterion",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "helios-cli"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "alloy",
  "clap",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "helios-common"
-version = "0.1.0"
+version = "0.8.4"
 dependencies = [
  "alloy",
  "eyre",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "helios-core"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "alloy",
  "alloy-trie",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "helios-ethereum"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "alloy",
  "alloy-trie",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "helios-opstack"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/core/src/execution/evm.rs
+++ b/core/src/execution/evm.rs
@@ -168,7 +168,6 @@ impl<N: NetworkSpec> ProofDB<N> {
     }
 }
 
-#[derive(Debug)]
 enum StateAccess {
     Basic(Address),
     BlockHash(u64),


### PR DESCRIPTION
Some evm executions get stuck in an infinite loop when it needs to fetch slot a and b but does not realize it at the same time. This leads to fetching a, then fetching b (and evicting a from our state cache), leading to fetching a again, and repeating the cycle.