### PR TITLE
fix: fixed incorrectly formatted link in OpenAPI documentation

### DIFF
--- a/verifiable-api/server/openapi.yaml
+++ b/verifiable-api/server/openapi.yaml
@@ -6,7 +6,7 @@ info:
     Helios Verifiable API for Ethereum Execution Layer.
 
 
-    GitHub: [https://github.com/a16z/helios/tree/master/verifiable-api]([https://github.com/a16z/helios/tree/master/verifiable-api)
+    GitHub: [https://github.com/a16z/helios/tree/master/verifiable-api](https://github.com/a16z/helios/tree/master/verifiable-api)
 paths:
   /eth/v1/proof/account/{address}:
     get:


### PR DESCRIPTION
Fixed a link to GitHub repository in verifiable-api/server/openapi.yaml, 
which contained duplicate square and parentheses. As a result of the 
fix, the documentation will display correctly and links will work properly.

Modified file:
- verifiable-api/server/openapi.yaml