### PR TITLE
Remove vendored OpenSSL usage, fix build warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5175,15 +5175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.4.2+3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5191,7 +5182,6 @@ checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ default-members = ["cli"]
 # consensus
 ssz_types = "0.10"
 ethereum_ssz_derive = "0.8"
+openssl = { version = "0.10" }
 ethereum_ssz = "0.8"
 tree_hash_derive = "0.9.0"
 tree_hash = "0.9.0"
@@ -78,7 +79,6 @@ tracing = "0.1.37"
 chrono = "0.4.23"
 thiserror = "1.0.37"
 superstruct = "0.7.0"
-openssl = { version = "0.10", features = ["vendored"] }
 zduny-wasm-timer = "0.2.8"
 retri = "0.1.0"
 typenum = "1.17.0"


### PR DESCRIPTION
**Summary**
- Removes vendored OpenSSL usage, switching to system-provided OpenSSL.
- Fixes Clippy build issues and avoids errors on macOS where `openssl@1.1` is disabled.

**Why It’s Important**
- Homebrew no longer supports `openssl@1.1`, so vendored builds fail.
- Relying on the system’s OpenSSL ensures a clean, up-to-date build environment.
