### PR TITLE
fix: correct OpenAPI documentation formatting issues

### DIFF
--- a/verifiable-api/server/openapi.yaml
+++ b/verifiable-api/server/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: Helios Verifiable API
   version: 0.0.0
@@ -277,7 +277,6 @@ paths:
         ### How to verify response?
 
         > Note: Only applicable for filters of logs type.
-
 
         For each log:
 


### PR DESCRIPTION
This commit addresses a formatting issue in the OpenAPI documentation:
Removed an improperly formatted empty line in the endpoint description for /eth/v1/proof/filterChanges/{filterId}
Updated OpenAPI version from 3.0.0 to 3.1.0 to match the required pattern