### PR TITLE
fix: incorrect field usage in `tx_env()`

### DIFF
--- a/ethereum/src/spec.rs
+++ b/ethereum/src/spec.rs
@@ -100,7 +100,7 @@ impl NetworkSpec for Ethereum {
                 <TransactionRequest as TransactionBuilder<Self>>::max_priority_fee_per_gas(tx)
                     .map(U256::from),
             max_fee_per_blob_gas:
-                <TransactionRequest as TransactionBuilder<Self>>::max_fee_per_gas(tx)
+                <TransactionRequest as TransactionBuilder<Self>>::max_fee_per_blob_gas(tx)
                     .map(U256::from),
             blob_hashes: tx
                 .blob_versioned_hashes


### PR DESCRIPTION
`tx_env()` sets `max_fee_per_blob_gas`, but it mistakenly assigns the value from `max_fee_per_gas()`.
this seems to be an oversight, as the correct method to use is `max_fee_per_blob_gas()`.  
