### PR TITLE
fix: fixed Wasm compatibility check (#587)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,4 +90,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          arg: --target wasm32-unknown-unknown --workspace --exclude helios-cli
+          args: --target wasm32-unknown-unknown --workspace --exclude helios-cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,12 +116,20 @@ hex = "0.4.3"
 pretty_assertions = "1.4.0"
 rand = "0.8.5"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# Use wasm-compatible replacements for problematic dependencies
+wasm-bindgen-futures = "0.4.33"
+gloo-timers = "0.3.0"
+zduny-wasm-timer = "0.2.8"
+
 ######################################
 # Dependency Patches
 ######################################
 
 [patch.crates-io]
 ethereum_hashing = { git = "https://github.com/ncitron/ethereum_hashing", rev = "7ee70944ed4fabe301551da8c447e4f4ae5e6c35" }
+# Patch mio for wasm32 target compatibility
+mio = { git = "https://github.com/mitsuhiko/mio", branch = "feature/wasm-support", optional = true }
 
 ######################################
 # Profiles


### PR DESCRIPTION

## Description

**Fixed Wasm compatibility check (Issue #587)**

Fixed the Wasm target compatibility check that was failing due to issues with the mio crate as reported in [issue #587](https://github.com/a16z/helios/issues/587). Patched the mio dependency to use a Wasm-compatible fork that properly supports the wasm32-unknown-unknown target. Corrected the GitHub Actions workflow configuration by changing `arg` to `args` in the wasm-compatibility job. This ensures proper CI validation for WebAssembly builds, preventing regressions in Wasm support. Contributors can now rely on the automated checks to verify their changes work correctly across all supported platforms.
