### PR TITLE
fix: update armv7 build to use latest ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-linux-armv7:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
Ubuntu 20.04 was deprecated by GitHub so broke our release CI on linux-armv7. Updating to ubuntu-latest seems to resolve.