### PR TITLE
Fix client crate link in verifiable-api README

### DIFF
--- a/verifiable-api/README.md
+++ b/verifiable-api/README.md
@@ -52,7 +52,7 @@ $ cargo run -- opstack --execution-rpc https://base-rpc.publicnode.com
 
 ## Client Usage
 
-See [helios-verifiable-api-client](verifiable-api/client) crate.
+See [helios-verifiable-api-client](./client) crate.
 
 ## JSON-RPC to REST API map
 


### PR DESCRIPTION
Changed the broken relative path from verifiable-api/client to ./client to correctly point to the client crate directory from the README location.