### PR TITLE
chore: pin, align deps; fmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ helios-ts/helios-*.tgz
 helios-ts/pkg
 
 .vscode
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,45 +1137,11 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
- "axum-core 0.5.0",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1185,7 +1151,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1198,27 +1164,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1250,8 +1195,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
 dependencies = [
- "axum 0.8.1",
- "axum-core 0.5.0",
+ "axum",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -3243,7 +3188,7 @@ dependencies = [
  "alloy",
  "alloy-rlp",
  "alloy-trie",
- "axum 0.7.9",
+ "axum",
  "clap",
  "discv5",
  "ethereum_ssz",
@@ -3333,7 +3278,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "async-trait",
- "axum 0.8.1",
+ "axum",
  "axum-extra",
  "clap",
  "eyre",
@@ -4670,12 +4615,6 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,17 @@ version = "0.8.7"
 
 [workspace]
 members = [
-    "cli",
-    "common",
-    "core",
-    "ethereum",
-    "ethereum/consensus-core",
-    "opstack",
-    "helios-ts",
-    "tests/test-utils",        # ToDo(@eshaan7): find a better way to include this
-    "verifiable-api/client",
-    "verifiable-api/server",
-    "verifiable-api/types", "linea",
+ "cli",
+ "common",
+ "core",
+ "ethereum",
+ "ethereum/consensus-core",
+ "opstack",
+ "helios-ts",
+ "tests/test-utils", # ToDo(@eshaan7): find a better way to include this
+ "verifiable-api/client",
+ "verifiable-api/server",
+ "verifiable-api/types", "linea",
 ]
 
 default-members = ["cli"]
@@ -41,25 +41,28 @@ bls12_381 = { version = "0.8.0", features = ["experimental"] }
 
 # execution
 alloy = { version = "0.9.1", features = [
-    "rpc-types",
-    "consensus",
-    "rlp",
-    "k256",
-    "provider-http",
-    "sol-types",
-    "network",
-    "ssz",
-    "json-rpc",
-    "signers",
+ "rpc-types",
+ "consensus",
+ "rlp",
+ "k256",
+ "provider-http",
+ "sol-types",
+ "network",
+ "ssz",
+ "json-rpc",
+ "signers",
 ] }
 alloy-trie = "0.7.8"
+op-alloy-consensus = "0.9.0"
+op-alloy-network = "0.9.0"
 op-alloy-rpc-types = "0.9.0"
+alloy-rlp = "0.3.10"
 revm = { version = "19.7.0", default-features = false, features = [
-    "std",
-    "serde",
-    "optional_block_gas_limit",
-    "optional_eip3607",
-    "optional_no_base_fee",
+ "std",
+ "serde",
+ "optional_block_gas_limit",
+ "optional_eip3607",
+ "optional_no_base_fee",
 ] }
 
 # async/futures
@@ -85,6 +88,35 @@ openssl = { version = "0.10", features = ["vendored"] }
 zduny-wasm-timer = "0.2.8"
 retri = "0.1.0"
 typenum = "1.17.0"
+figment = "0.10.7"
+clap = "4.5.4"
+tracing-subscriber = "0.3.17"
+dirs = "5.0.1"
+ctrlc = "3.2.3"
+snap = "1"
+strum = "0.26.2"
+serde_yaml = "0.9.34"
+
+# web/server
+axum = "0.8.1"
+axum-extra = "0.10.0"
+jsonrpsee = "0.19.0"
+libp2p = "0.51.3"
+libp2p-identity = "0.1.2"
+discv5 = "0.7.0"
+unsigned-varint = "0.7.1"
+
+# wasm related
+wasm-bindgen = "0.2.84"
+wasm-bindgen-futures = "0.4.37"
+wasm-bindgen-test = "0.3.0"
+serde-wasm-bindgen = "0.6.5"
+console_error_panic_hook = "0.1.7"
+gloo-timers = "0.3.0"
+wasmtimer = "0.2.0"
+parking_lot = "0.12.2"
+getrandom = "0.2.1"
+web-sys = "0.3"
 
 ######################################
 # Top Level Dependencies
@@ -105,12 +137,12 @@ dotenv = "0.15.0"
 helios-verifiable-api-server = { path = "verifiable-api/server" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-alloy = { version = "0.9.1", features = ["full"] }
-tokio = { version = "1", features = ["full"] }
-eyre = "0.6.8"
-dirs = "5.0.1"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-tracing = "0.1.37"
+alloy = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
+eyre.workspace = true
+dirs.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing.workspace = true
 tracing-test = "0.2.4"
 criterion = { version = "0.5.1", features = ["async_tokio", "plotters"] }
 plotters = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,18 @@ version = "0.8.7"
 
 [workspace]
 members = [
- "cli",
- "common",
- "core",
- "ethereum",
- "ethereum/consensus-core",
- "opstack",
- "helios-ts",
- "tests/test-utils", # ToDo(@eshaan7): find a better way to include this
- "verifiable-api/client",
- "verifiable-api/server",
- "verifiable-api/types", "linea",
+    "cli",
+    "common",
+    "core",
+    "ethereum",
+    "ethereum/consensus-core",
+    "opstack",
+    "helios-ts",
+    "tests/test-utils", # ToDo(@eshaan7): find a better way to include this
+    "verifiable-api/client",
+    "verifiable-api/server",
+    "verifiable-api/types",
+    "linea",
 ]
 
 default-members = ["cli"]
@@ -41,16 +42,16 @@ bls12_381 = { version = "0.8.0", features = ["experimental"] }
 
 # execution
 alloy = { version = "0.9.1", features = [
- "rpc-types",
- "consensus",
- "rlp",
- "k256",
- "provider-http",
- "sol-types",
- "network",
- "ssz",
- "json-rpc",
- "signers",
+    "rpc-types",
+    "consensus",
+    "rlp",
+    "k256",
+    "provider-http",
+    "sol-types",
+    "network",
+    "ssz",
+    "json-rpc",
+    "signers",
 ] }
 alloy-trie = "0.7.8"
 op-alloy-consensus = "0.9.0"
@@ -58,11 +59,11 @@ op-alloy-network = "0.9.0"
 op-alloy-rpc-types = "0.9.0"
 alloy-rlp = "0.3.10"
 revm = { version = "19.7.0", default-features = false, features = [
- "std",
- "serde",
- "optional_block_gas_limit",
- "optional_eip3607",
- "optional_no_base_fee",
+    "std",
+    "serde",
+    "optional_block_gas_limit",
+    "optional_eip3607",
+    "optional_no_base_fee",
 ] }
 
 # async/futures

--- a/benches/get_balance.rs
+++ b/benches/get_balance.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use alloy::primitives::Address;
 use criterion::{criterion_group, criterion_main, Criterion};
-
 use helios_common::types::BlockTag;
 
 mod harness;

--- a/benches/get_code.rs
+++ b/benches/get_code.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use alloy::primitives::Address;
 use criterion::{criterion_group, criterion_main, Criterion};
-
 use helios_common::types::BlockTag;
 
 mod harness;

--- a/benches/harness.rs
+++ b/benches/harness.rs
@@ -2,7 +2,6 @@
 use std::{path::PathBuf, str::FromStr};
 
 use alloy::primitives::{Address, B256, U256};
-
 use helios_common::types::BlockTag;
 use helios_ethereum::{
     config::{checkpoints, networks},

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -1,6 +1,5 @@
 use alloy::primitives::Address;
 use criterion::{criterion_group, criterion_main, Criterion};
-
 use helios_common::types::BlockTag;
 
 mod harness;

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,13 +13,14 @@ eyre.workspace = true
 tracing.workspace = true
 futures.workspace = true
 alloy.workspace = true
-figment = { version = "0.10.7", features = ["toml", "env"] }
 
-clap = { version = "4.5.4", features = ["derive", "env"] }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-dirs = "5.0.1"
-ctrlc = "3.2.3"
-url = "2.5.0"
+dirs.workspace = true
+ctrlc.workspace = true
+url.workspace = true
+
+figment = { workspace = true, features = ["toml", "env"] }
+clap = { workspace = true, features = ["derive", "env"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 # self crates
 helios-common = { path = "../common" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,37 +1,37 @@
-use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
 use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
     path::PathBuf,
     process::exit,
     str::FromStr,
     sync::{Arc, Mutex},
 };
 
-use alloy::primitives::hex;
-use alloy::primitives::B256;
+use alloy::primitives::{hex, B256};
 use clap::{Args, Parser, Subcommand};
 use dirs::home_dir;
 use eyre::Result;
-use figment::providers::Serialized;
-use figment::value::Value;
+use figment::{providers::Serialized, value::Value};
 use futures::executor::block_on;
-use tracing::{error, info};
-use tracing_subscriber::filter::{EnvFilter, LevelFilter};
-use tracing_subscriber::FmtSubscriber;
-use url::Url;
-
 use helios_common::network_spec::NetworkSpec;
-use helios_core::client::Client;
-use helios_core::consensus::Consensus;
-use helios_ethereum::config::{cli::CliConfig, Config as EthereumConfig};
-use helios_ethereum::database::FileDB;
-use helios_ethereum::{EthereumClient, EthereumClientBuilder};
-use helios_opstack::{config::Config as OpStackConfig, OpStackClient, OpStackClientBuilder};
-
-use helios_linea::{
-    builder::LineaClientBuilder, config::CliConfig as LineaCliConfig,
-    config::Config as LineaConfig, types::LineaClient,
+use helios_core::{client::Client, consensus::Consensus};
+use helios_ethereum::{
+    config::{cli::CliConfig, Config as EthereumConfig},
+    database::FileDB,
+    EthereumClient, EthereumClientBuilder,
 };
+use helios_linea::{
+    builder::LineaClientBuilder,
+    config::{CliConfig as LineaCliConfig, Config as LineaConfig},
+    types::LineaClient,
+};
+use helios_opstack::{config::Config as OpStackConfig, OpStackClient, OpStackClientBuilder};
+use tracing::{error, info};
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    FmtSubscriber,
+};
+use url::Url;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,16 +30,16 @@ tracing.workspace = true
 thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-jsonrpsee = { version = "0.19.0", features = ["full"] }
+jsonrpsee = { workspace = true, features = ["full"] }
 openssl.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-futures = "0.4.33"
-gloo-timers = "0.3.0"
-wasmtimer = "0.2.0"
+wasm-bindgen-futures.workspace = true
+gloo-timers.workspace = true
+wasmtimer.workspace = true
 
 [target.wasm32-unknown-unknown.dependencies]
-parking_lot = { version = "0.12.2" }
+parking_lot.workspace = true
 
 [dev-dependencies]
 helios-test-utils = { path = "../tests/test-utils" }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -1,26 +1,23 @@
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-use alloy::primitives::{Address, Bytes, B256, U256};
-use alloy::rpc::types::{
-    AccessListResult, EIP1186AccountProofResponse, Filter, FilterChanges, Log, SyncStatus,
+use alloy::{
+    primitives::{Address, Bytes, B256, U256},
+    rpc::types::{
+        AccessListResult, EIP1186AccountProofResponse, Filter, FilterChanges, Log, SyncStatus,
+    },
 };
 use eyre::Result;
-use tracing::{info, warn};
-
 use helios_common::{
     execution_mode::ExecutionMode,
     fork_schedule::ForkSchedule,
     network_spec::NetworkSpec,
     types::{BlockTag, SubEventRx, SubscriptionType},
 };
+use tracing::{info, warn};
 
-use crate::client::node::Node;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::client::rpc::Rpc;
-use crate::consensus::Consensus;
-use crate::time::interval;
+use crate::{client::node::Node, consensus::Consensus, time::interval};
 
 pub mod node;
 #[cfg(not(target_arch = "wasm32"))]

--- a/core/src/client/node.rs
+++ b/core/src/client/node.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 
-use alloy::consensus::BlockHeader;
-use alloy::network::BlockResponse;
-use alloy::primitives::{Address, Bytes, B256, U256};
-use alloy::rpc::types::{
-    AccessListResult, EIP1186AccountProofResponse, Filter, FilterChanges, Log, SyncInfo, SyncStatus,
+use alloy::{
+    consensus::BlockHeader,
+    network::BlockResponse,
+    primitives::{Address, Bytes, B256, U256},
+    rpc::types::{
+        AccessListResult, EIP1186AccountProofResponse, Filter, FilterChanges, Log, SyncInfo,
+        SyncStatus,
+    },
 };
 use eyre::{eyre, Result};
-
 use helios_common::{
     execution_mode::ExecutionMode,
     fork_schedule::ForkSchedule,
@@ -16,16 +18,20 @@ use helios_common::{
 };
 use helios_verifiable_api_client::http::HttpVerifiableApi;
 
-use crate::consensus::Consensus;
-use crate::errors::ClientError;
-use crate::execution::client::ExecutionInnerClient;
-use crate::execution::constants::MAX_STATE_HISTORY_LENGTH;
-use crate::execution::evm::Evm;
-use crate::execution::rpc::http_rpc::HttpRpc;
-use crate::execution::spec::ExecutionSpec;
-use crate::execution::state::{start_state_updater, State};
-use crate::execution::ExecutionClient;
-use crate::time::{SystemTime, UNIX_EPOCH};
+use crate::{
+    consensus::Consensus,
+    errors::ClientError,
+    execution::{
+        client::ExecutionInnerClient,
+        constants::MAX_STATE_HISTORY_LENGTH,
+        evm::Evm,
+        rpc::http_rpc::HttpRpc,
+        spec::ExecutionSpec,
+        state::{start_state_updater, State},
+        ExecutionClient,
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 pub struct Node<N: NetworkSpec, C: Consensus<N::BlockResponse>> {
     pub consensus: C,

--- a/core/src/client/rpc.rs
+++ b/core/src/client/rpc.rs
@@ -1,12 +1,20 @@
 use std::{fmt::Display, net::SocketAddr, sync::Arc};
 
-use alloy::network::{BlockResponse, ReceiptResponse, TransactionResponse};
-use alloy::primitives::{Address, Bytes, B256, U256, U64};
-use alloy::rpc::json_rpc::RpcObject;
-use alloy::rpc::types::{
-    AccessListResult, EIP1186AccountProofResponse, Filter, FilterChanges, Log, SyncStatus,
+use alloy::{
+    network::{BlockResponse, ReceiptResponse, TransactionResponse},
+    primitives::{Address, Bytes, B256, U256, U64},
+    rpc::{
+        json_rpc::RpcObject,
+        types::{
+            AccessListResult, EIP1186AccountProofResponse, Filter, FilterChanges, Log, SyncStatus,
+        },
+    },
 };
 use eyre::Result;
+use helios_common::{
+    network_spec::NetworkSpec,
+    types::{BlockTag, SubEventRx, SubscriptionType},
+};
 use jsonrpsee::{
     core::{async_trait, server::Methods, SubscriptionResult},
     proc_macros::rpc,
@@ -15,13 +23,7 @@ use jsonrpsee::{
 };
 use tracing::info;
 
-use helios_common::{
-    network_spec::NetworkSpec,
-    types::{BlockTag, SubEventRx, SubscriptionType},
-};
-
-use crate::client::node::Node;
-use crate::consensus::Consensus;
+use crate::{client::node::Node, consensus::Consensus};
 
 pub struct Rpc<N: NetworkSpec, C: Consensus<N::BlockResponse>> {
     node: Arc<Node<N, C>>,

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -1,7 +1,6 @@
 use eyre::Report;
-use thiserror::Error;
-
 use helios_common::types::BlockTag;
+use thiserror::Error;
 
 use crate::execution::errors::{EvmError, ExecutionError};
 

--- a/core/src/execution/client/mod.rs
+++ b/core/src/execution/client/mod.rs
@@ -2,14 +2,11 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use eyre::Result;
-use tracing::info;
-
 use helios_common::{execution_mode::ExecutionMode, network_spec::NetworkSpec};
 use helios_verifiable_api_client::VerifiableApi;
+use tracing::info;
 
-use super::rpc::ExecutionRpc;
-use super::spec::ExecutionSpec;
-use super::state::State;
+use super::{rpc::ExecutionRpc, spec::ExecutionSpec, state::State};
 
 pub mod rpc;
 pub mod verifiable_api;

--- a/core/src/execution/client/rpc.rs
+++ b/core/src/execution/client/rpc.rs
@@ -1,33 +1,33 @@
 use std::collections::{HashMap, HashSet};
 
-use alloy::consensus::{Account as TrieAccount, BlockHeader};
-use alloy::eips::BlockId;
-use alloy::network::{BlockResponse, ReceiptResponse, TransactionBuilder};
-use alloy::primitives::{Address, B256, U256};
-use alloy::rlp;
-use alloy::rpc::types::{EIP1186AccountProofResponse, Filter, FilterChanges, Log};
+use alloy::{
+    consensus::{Account as TrieAccount, BlockHeader},
+    eips::BlockId,
+    network::{BlockResponse, ReceiptResponse, TransactionBuilder},
+    primitives::{Address, B256, U256},
+    rlp,
+    rpc::types::{EIP1186AccountProofResponse, Filter, FilterChanges, Log},
+};
 use async_trait::async_trait;
 use eyre::Result;
 use futures::future::{join_all, try_join_all};
-use revm::primitives::AccessListItem;
-
 use helios_common::{
     network_spec::NetworkSpec,
     types::{Account, BlockTag},
 };
-
-use crate::execution::constants::{
-    MAX_SUPPORTED_BLOCKS_TO_PROVE_FOR_LOGS, PARALLEL_QUERY_BATCH_SIZE,
-};
-use crate::execution::errors::ExecutionError;
-use crate::execution::proof::{
-    ordered_trie_root_noop_encoder, verify_account_proof, verify_block_receipts,
-    verify_code_hash_proof, verify_storage_proof,
-};
-use crate::execution::rpc::ExecutionRpc;
-use crate::execution::state::State;
+use revm::primitives::AccessListItem;
 
 use super::{ExecutionInner, ExecutionSpec};
+use crate::execution::{
+    constants::{MAX_SUPPORTED_BLOCKS_TO_PROVE_FOR_LOGS, PARALLEL_QUERY_BATCH_SIZE},
+    errors::ExecutionError,
+    proof::{
+        ordered_trie_root_noop_encoder, verify_account_proof, verify_block_receipts,
+        verify_code_hash_proof, verify_storage_proof,
+    },
+    rpc::ExecutionRpc,
+    state::State,
+};
 
 #[derive(Clone)]
 pub struct ExecutionInnerRpcClient<N: NetworkSpec, R: ExecutionRpc<N>> {
@@ -373,12 +373,11 @@ mod tests {
     use std::sync::Arc;
 
     use alloy::rpc::types::TransactionRequest;
-
-    use crate::execution::rpc::mock_rpc::MockRpc;
     use helios_ethereum::spec::Ethereum as EthereumSpec;
     use helios_test_utils::*;
 
     use super::*;
+    use crate::execution::rpc::mock_rpc::MockRpc;
 
     async fn get_client() -> ExecutionInnerRpcClient<EthereumSpec, MockRpc> {
         let base_path = testdata_dir().join("rpc/");

--- a/core/src/execution/client/verifiable_api.rs
+++ b/core/src/execution/client/verifiable_api.rs
@@ -1,28 +1,30 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use alloy::consensus::BlockHeader;
-use alloy::eips::BlockId;
-use alloy::network::{BlockResponse, ReceiptResponse};
-use alloy::primitives::{Address, B256, U256};
-use alloy::rlp;
-use alloy::rpc::types::{EIP1186AccountProofResponse, Filter, FilterChanges, Log};
+use alloy::{
+    consensus::BlockHeader,
+    eips::BlockId,
+    network::{BlockResponse, ReceiptResponse},
+    primitives::{Address, B256, U256},
+    rlp,
+    rpc::types::{EIP1186AccountProofResponse, Filter, FilterChanges, Log},
+};
 use async_trait::async_trait;
 use eyre::Result;
-
 use helios_common::{
     network_spec::NetworkSpec,
     types::{Account, BlockTag},
 };
 use helios_verifiable_api_client::{types::*, VerifiableApi};
 
-use crate::execution::errors::ExecutionError;
-use crate::execution::proof::{
-    verify_account_proof, verify_block_receipts, verify_code_hash_proof, verify_receipt_proof,
-    verify_storage_proof,
-};
-use crate::execution::state::State;
-
 use super::{ExecutionInner, ExecutionSpec};
+use crate::execution::{
+    errors::ExecutionError,
+    proof::{
+        verify_account_proof, verify_block_receipts, verify_code_hash_proof, verify_receipt_proof,
+        verify_storage_proof,
+    },
+    state::State,
+};
 
 #[derive(Clone)]
 pub struct ExecutionInnerVerifiableApiClient<N: NetworkSpec, A: VerifiableApi<N>> {

--- a/core/src/execution/errors.rs
+++ b/core/src/execution/errors.rs
@@ -1,9 +1,10 @@
-use alloy::primitives::{Address, Bytes, B256, U256};
-use alloy::sol_types::decode_revert_reason;
+use alloy::{
+    primitives::{Address, Bytes, B256, U256},
+    sol_types::decode_revert_reason,
+};
 use eyre::Report;
-use thiserror::Error;
-
 use helios_common::types::BlockTag;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ExecutionError {

--- a/core/src/execution/evm.rs
+++ b/core/src/execution/evm.rs
@@ -5,6 +5,11 @@ use alloy::{
     rpc::types::{AccessListResult, EIP1186StorageProof},
 };
 use eyre::{Report, Result};
+use helios_common::{
+    fork_schedule::ForkSchedule,
+    network_spec::NetworkSpec,
+    types::{Account, BlockTag},
+};
 use revm::{
     primitives::{
         address, AccessListItem, AccountInfo, Address, Bytecode, Bytes, CfgEnv, Env,
@@ -13,12 +18,6 @@ use revm::{
     Database, Evm as Revm,
 };
 use tracing::trace;
-
-use helios_common::{
-    fork_schedule::ForkSchedule,
-    network_spec::NetworkSpec,
-    types::{Account, BlockTag},
-};
 
 use super::{
     errors::{EvmError, ExecutionError},

--- a/core/src/execution/mod.rs
+++ b/core/src/execution/mod.rs
@@ -1,27 +1,28 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use alloy::consensus::BlockHeader;
-use alloy::eips::BlockId;
-use alloy::network::primitives::HeaderResponse;
-use alloy::network::BlockResponse;
-use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::{EIP1186AccountProofResponse, Filter, FilterChanges, Log};
+use alloy::{
+    consensus::BlockHeader,
+    eips::BlockId,
+    network::{primitives::HeaderResponse, BlockResponse},
+    primitives::{Address, B256, U256},
+    rpc::types::{EIP1186AccountProofResponse, Filter, FilterChanges, Log},
+};
 use async_trait::async_trait;
 use eyre::Result;
-use revm::primitives::BlobExcessGasAndPrice;
-use tracing::warn;
-
 use helios_common::{
     fork_schedule::ForkSchedule,
     network_spec::NetworkSpec,
     types::{Account, BlockTag, SubEventRx, SubscriptionType},
 };
+use revm::primitives::BlobExcessGasAndPrice;
+use tracing::warn;
 
-use self::client::ExecutionInner;
-use self::errors::ExecutionError;
-use self::spec::ExecutionSpec;
-use self::state::{FilterType, State};
+use self::{
+    client::ExecutionInner,
+    errors::ExecutionError,
+    spec::ExecutionSpec,
+    state::{FilterType, State},
+};
 
 pub mod client;
 pub mod constants;

--- a/core/src/execution/proof.rs
+++ b/core/src/execution/proof.rs
@@ -1,16 +1,16 @@
-use alloy::consensus::BlockHeader;
-use alloy::network::{BlockResponse, ReceiptResponse};
-use alloy::primitives::{keccak256, Bytes, B256, U256};
-use alloy::rlp;
-use alloy::rpc::types::EIP1186AccountProofResponse;
-use alloy_trie::root::ordered_trie_root_with_encoder;
+use alloy::{
+    consensus::BlockHeader,
+    network::{BlockResponse, ReceiptResponse},
+    primitives::{keccak256, Bytes, B256, U256},
+    rlp,
+    rpc::types::EIP1186AccountProofResponse,
+};
 use alloy_trie::{
     proof::{verify_proof, ProofRetainer},
-    root::adjust_index_for_rlp,
+    root::{adjust_index_for_rlp, ordered_trie_root_with_encoder},
     HashBuilder, Nibbles, TrieAccount, KECCAK_EMPTY,
 };
 use eyre::{eyre, Result};
-
 use helios_common::{network_spec::NetworkSpec, types::BlockTag};
 
 use super::errors::ExecutionError;
@@ -185,7 +185,6 @@ pub fn ordered_trie_root_noop_encoder(items: &[Vec<u8>]) -> B256 {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::b256;
-
     use helios_ethereum::spec::Ethereum as EthereumSpec;
     use helios_test_utils::*;
 

--- a/core/src/execution/rpc/http_rpc.rs
+++ b/core/src/execution/rpc/http_rpc.rs
@@ -1,22 +1,26 @@
-use alloy::primitives::{Address, B256, U256};
-use alloy::providers::{Provider, ProviderBuilder, RootProvider};
-use alloy::rpc::client::ClientBuilder;
-use alloy::rpc::types::{
-    BlockId, BlockTransactionsKind, EIP1186AccountProofResponse, FeeHistory, Filter, FilterChanges,
-    Log,
+use alloy::{
+    primitives::{Address, B256, U256},
+    providers::{Provider, ProviderBuilder, RootProvider},
+    rpc::{
+        client::ClientBuilder,
+        types::{
+            BlockId, BlockTransactionsKind, EIP1186AccountProofResponse, FeeHistory, Filter,
+            FilterChanges, Log,
+        },
+    },
+    transports::{
+        http::Http,
+        layers::{RetryBackoffLayer, RetryBackoffService},
+    },
 };
-use alloy::transports::http::Http;
-use alloy::transports::layers::{RetryBackoffLayer, RetryBackoffService};
 use async_trait::async_trait;
 use eyre::Result;
+use helios_common::network_spec::NetworkSpec;
 use reqwest::Client;
 use revm::primitives::AccessList;
 
-use helios_common::network_spec::NetworkSpec;
-
-use crate::errors::RpcError;
-
 use super::ExecutionRpc;
+use crate::errors::RpcError;
 
 pub struct HttpRpc<N: NetworkSpec> {
     url: String,

--- a/core/src/execution/rpc/mock_rpc.rs
+++ b/core/src/execution/rpc/mock_rpc.rs
@@ -1,19 +1,19 @@
 use std::{fs::read_to_string, path::PathBuf, str::FromStr};
 
-use alloy::network::TransactionResponse;
-use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::{
-    AccessList, BlockId, BlockTransactionsKind, EIP1186AccountProofResponse, FeeHistory, Filter,
-    FilterChanges, Log,
+use alloy::{
+    network::TransactionResponse,
+    primitives::{Address, B256, U256},
+    rpc::types::{
+        AccessList, BlockId, BlockTransactionsKind, EIP1186AccountProofResponse, FeeHistory,
+        Filter, FilterChanges, Log,
+    },
 };
 use async_trait::async_trait;
 use eyre::{Ok, Result};
-
 use helios_common::{network_spec::NetworkSpec, types::Account};
 
-use crate::execution::errors::ExecutionError;
-
 use super::ExecutionRpc;
+use crate::execution::errors::ExecutionError;
 
 #[derive(Clone)]
 pub struct MockRpc {

--- a/core/src/execution/rpc/mod.rs
+++ b/core/src/execution/rpc/mod.rs
@@ -1,11 +1,12 @@
-use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::{
-    AccessList, BlockId, BlockTransactionsKind, EIP1186AccountProofResponse, FeeHistory, Filter,
-    FilterChanges, Log,
+use alloy::{
+    primitives::{Address, B256, U256},
+    rpc::types::{
+        AccessList, BlockId, BlockTransactionsKind, EIP1186AccountProofResponse, FeeHistory,
+        Filter, FilterChanges, Log,
+    },
 };
 use async_trait::async_trait;
 use eyre::Result;
-
 use helios_common::network_spec::NetworkSpec;
 
 pub mod http_rpc;

--- a/core/src/execution/spec.rs
+++ b/core/src/execution/spec.rs
@@ -7,7 +7,6 @@ use alloy::{
 };
 use async_trait::async_trait;
 use eyre::Result;
-
 use helios_common::{
     network_spec::NetworkSpec,
     types::{Account, BlockTag},

--- a/core/src/execution/state.rs
+++ b/core/src/execution/state.rs
@@ -11,16 +11,15 @@ use alloy::{
     rpc::types::{BlockTransactions, Filter},
 };
 use eyre::{eyre, Result};
+use helios_common::{
+    network_spec::NetworkSpec,
+    types::{BlockTag, SubEventRx, SubscriptionEvent},
+};
 use tokio::{
     select,
     sync::{broadcast, mpsc::Receiver, watch, RwLock},
 };
 use tracing::{info, warn};
-
-use helios_common::{
-    network_spec::NetworkSpec,
-    types::{BlockTag, SubEventRx, SubscriptionEvent},
-};
 
 use super::spec::ExecutionSpec;
 

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -1,5 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
 pub use std::time::{SystemTime, UNIX_EPOCH};
+
 #[cfg(not(target_arch = "wasm32"))]
 pub use tokio::time::{interval, interval_at, Instant};
 #[cfg(target_arch = "wasm32")]

--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -10,10 +10,10 @@ tree_hash.workspace = true
 revm.workspace = true
 
 # config
-figment = { version = "0.10.7", features = ["toml", "env"] }
-serde_yaml = "0.9.14"
-strum = { version = "0.26.2", features = ["derive"] }
-url = {version = "2.5.0", features = ["serde"] }
+figment = { workspace = true, features = ["toml", "env"] }
+serde_yaml.workspace = true
+strum = { workspace = true, features = ["derive"] }
+url = { workspace = true, features = ["serde"] }
 
 # async/futures
 tokio.workspace = true
@@ -42,12 +42,12 @@ helios-core = { path = "../core" }
 helios-consensus-core = { path = "consensus-core" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-futures = "0.4.37"
-getrandom = { version = "0.2.1", features = ["js"] }
+wasm-bindgen-futures.workspace = true
+getrandom = { workspace = true, features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 openssl.workspace = true
-dirs = "5.0.1"
+dirs.workspace = true
 
 [target.wasm32-unknown-unknown.dependencies]
-parking_lot = { version = "0.12.2" }
+parking_lot.workspace = true

--- a/ethereum/consensus-core/Cargo.toml
+++ b/ethereum/consensus-core/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-alloy = { version = "0.9.1", features = [
+alloy = { workspace = true, features = [
     "consensus",
     "rpc-types",
     "ssz",
@@ -12,7 +12,7 @@ alloy = { version = "0.9.1", features = [
     "k256",
     "eips",
 ] }
-alloy-rlp = "0.3.10"
+alloy-rlp.workspace = true
 bls12_381.workspace = true
 ssz_types.workspace = true
 ethereum_ssz_derive.workspace = true
@@ -29,10 +29,10 @@ tracing.workspace = true
 zduny-wasm-timer.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
-wasmtimer = "0.2.0"
+getrandom = { workspace = true, features = ["js"] }
+wasmtimer.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
-snap = "1"
-serde_yaml = "0.9.34"
+tokio = { workspace = true, features = ["full"] }
+snap.workspace = true
+serde_yaml.workspace = true

--- a/ethereum/consensus-core/src/consensus_core.rs
+++ b/ethereum/consensus-core/src/consensus_core.rs
@@ -10,20 +10,22 @@ use tree_hash::TreeHash;
 #[cfg(target_arch = "wasm32")]
 use wasmtimer::std::{SystemTime, UNIX_EPOCH};
 
-use crate::consensus_spec::ConsensusSpec;
-use crate::errors::ConsensusError;
-use crate::proof::{
-    is_current_committee_proof_valid, is_execution_payload_proof_valid, is_finality_proof_valid,
-    is_next_committee_proof_valid,
-};
-use crate::types::bls::{PublicKey, Signature};
-use crate::types::{
-    BeaconBlockHeader, Bootstrap, ExecutionPayloadHeader, FinalityUpdate, Forks, GenericUpdate,
-    LightClientHeader, LightClientStore, OptimisticUpdate, Update,
-};
-use crate::utils::{
-    calculate_fork_version, compute_committee_sign_root, compute_fork_data_root,
-    get_participating_keys,
+use crate::{
+    consensus_spec::ConsensusSpec,
+    errors::ConsensusError,
+    proof::{
+        is_current_committee_proof_valid, is_execution_payload_proof_valid,
+        is_finality_proof_valid, is_next_committee_proof_valid,
+    },
+    types::{
+        bls::{PublicKey, Signature},
+        BeaconBlockHeader, Bootstrap, ExecutionPayloadHeader, FinalityUpdate, Forks, GenericUpdate,
+        LightClientHeader, LightClientStore, OptimisticUpdate, Update,
+    },
+    utils::{
+        calculate_fork_version, compute_committee_sign_root, compute_fork_data_root,
+        get_participating_keys,
+    },
 };
 
 pub fn verify_bootstrap<S: ConsensusSpec>(

--- a/ethereum/consensus-core/src/types/mod.rs
+++ b/ethereum/consensus-core/src/types/mod.rs
@@ -9,12 +9,11 @@ use ssz_types::{serde_utils::quoted_u64_var_list, BitList, BitVector, FixedVecto
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
 
-use crate::consensus_spec::ConsensusSpec;
-
 use self::{
     bls::{PublicKey, Signature},
     bytes::{ByteList, ByteVector},
 };
+use crate::consensus_spec::ConsensusSpec;
 
 pub mod bls;
 pub mod bytes;

--- a/ethereum/consensus-core/tests/runner/mod.rs
+++ b/ethereum/consensus-core/tests/runner/mod.rs
@@ -1,11 +1,6 @@
 use std::path::PathBuf;
 
 use alloy::primitives::{fixed_bytes, B256};
-use serde::Deserialize;
-use serde_yaml::{Mapping, Value};
-use ssz::Decode;
-use tree_hash::TreeHash;
-
 use helios_consensus_core::{
     apply_bootstrap, apply_generic_update,
     consensus_spec::MinimalConsensusSpec,
@@ -16,6 +11,10 @@ use helios_consensus_core::{
     },
     verify_bootstrap, verify_generic_update,
 };
+use serde::Deserialize;
+use serde_yaml::{Mapping, Value};
+use ssz::Decode;
+use tree_hash::TreeHash;
 
 pub fn run<P: Into<PathBuf>>(test_data_dir: P, with_electra: bool) {
     let test_data_dir: PathBuf = test_data_dir.into();

--- a/ethereum/src/builder.rs
+++ b/ethereum/src/builder.rs
@@ -6,18 +6,18 @@ use std::sync::Arc;
 
 use alloy::primitives::B256;
 use eyre::{eyre, Result};
-
 use helios_common::execution_mode::ExecutionMode;
 use helios_consensus_core::consensus_spec::MainnetConsensusSpec;
 use helios_core::client::Client;
 
-use crate::config::networks::Network;
-use crate::config::Config;
-use crate::consensus::ConsensusClient;
-use crate::database::Database;
-use crate::rpc::http_rpc::HttpRpc;
-use crate::spec::Ethereum;
-use crate::EthereumClient;
+use crate::{
+    config::{networks::Network, Config},
+    consensus::ConsensusClient,
+    database::Database,
+    rpc::http_rpc::HttpRpc,
+    spec::Ethereum,
+    EthereumClient,
+};
 
 #[derive(Default)]
 pub struct EthereumClientBuilder {

--- a/ethereum/src/config/base.rs
+++ b/ethereum/src/config/base.rs
@@ -1,13 +1,15 @@
-use std::default::Default;
-use std::net::{IpAddr, Ipv4Addr};
-use std::path::PathBuf;
+use std::{
+    default::Default,
+    net::{IpAddr, Ipv4Addr},
+    path::PathBuf,
+};
 
 use alloy::primitives::B256;
+use helios_common::fork_schedule::ForkSchedule;
+use helios_consensus_core::types::Forks;
 use serde::Serialize;
 
 use crate::config::types::ChainConfig;
-use helios_common::fork_schedule::ForkSchedule;
-use helios_consensus_core::types::Forks;
 
 /// The base configuration for a network.
 #[derive(Serialize)]

--- a/ethereum/src/config/cli.rs
+++ b/ethereum/src/config/cli.rs
@@ -1,10 +1,9 @@
-use std::net::IpAddr;
-use std::{collections::HashMap, path::PathBuf};
-use url::Url;
+use std::{collections::HashMap, net::IpAddr, path::PathBuf};
 
 use alloy::primitives::B256;
 use figment::{providers::Serialized, value::Value};
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 /// Cli Config
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/ethereum/src/config/mod.rs
+++ b/ethereum/src/config/mod.rs
@@ -1,21 +1,20 @@
-use std::net::{IpAddr, Ipv4Addr};
-use std::str::FromStr;
-use std::{path::PathBuf, process::exit};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    path::PathBuf,
+    process::exit,
+    str::FromStr,
+};
 
 use alloy::primitives::B256;
 use figment::{
     providers::{Format, Serialized, Toml},
     Figment,
 };
-use serde::Deserialize;
-
 use helios_common::fork_schedule::ForkSchedule;
 use helios_consensus_core::types::Forks;
+use serde::Deserialize;
 
-use self::base::BaseConfig;
-use self::cli::CliConfig;
-use self::networks::Network;
-use self::types::ChainConfig;
+use self::{base::BaseConfig, cli::CliConfig, networks::Network, types::ChainConfig};
 
 pub mod checkpoints;
 pub mod cli;

--- a/ethereum/src/config/networks.rs
+++ b/ethereum/src/config/networks.rs
@@ -1,20 +1,17 @@
-use std::fmt::Display;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 
 use alloy::primitives::{b256, fixed_bytes};
 #[cfg(not(target_arch = "wasm32"))]
 use dirs::home_dir;
 use eyre::Result;
+use helios_common::fork_schedule::ForkSchedule;
+use helios_consensus_core::types::{Fork, Forks};
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 
-use helios_common::fork_schedule::ForkSchedule;
-use helios_consensus_core::types::{Fork, Forks};
-
-use crate::config::base::BaseConfig;
-use crate::config::types::ChainConfig;
+use crate::config::{base::BaseConfig, types::ChainConfig};
 
 #[derive(
     Debug, Clone, Copy, Serialize, Deserialize, EnumIter, Hash, Eq, PartialEq, PartialOrd, Ord,

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -1,25 +1,18 @@
-use std::marker::PhantomData;
-use std::process;
-use std::sync::Arc;
+use std::{marker::PhantomData, process, sync::Arc};
 
-use alloy::consensus::proofs::{calculate_transaction_root, calculate_withdrawals_root};
-use alloy::consensus::{Header as ConsensusHeader, Transaction as TxTrait, TxEnvelope};
-use alloy::eips::eip4895::{Withdrawal, Withdrawals};
-use alloy::primitives::{b256, fixed_bytes, Bloom, BloomInput, B256, U256};
-use alloy::rlp::Decodable;
-use alloy::rpc::types::{Block, BlockTransactions, Header, Transaction};
+use alloy::{
+    consensus::{
+        proofs::{calculate_transaction_root, calculate_withdrawals_root},
+        Header as ConsensusHeader, Transaction as TxTrait, TxEnvelope,
+    },
+    eips::eip4895::{Withdrawal, Withdrawals},
+    primitives::{b256, fixed_bytes, Bloom, BloomInput, B256, U256},
+    rlp::Decodable,
+    rpc::types::{Block, BlockTransactions, Header, Transaction},
+};
 use chrono::Duration;
-use eyre::eyre;
-use eyre::Result;
+use eyre::{eyre, Result};
 use futures::future::join_all;
-use tracing::{debug, error, info, warn};
-use tree_hash::TreeHash;
-
-use tokio::sync::mpsc::channel;
-use tokio::sync::mpsc::Receiver;
-use tokio::sync::mpsc::Sender;
-use tokio::sync::watch;
-
 use helios_consensus_core::{
     apply_bootstrap, apply_finality_update, apply_update, calc_sync_period,
     consensus_spec::ConsensusSpec,
@@ -28,15 +21,23 @@ use helios_consensus_core::{
     types::{ExecutionPayload, FinalityUpdate, LightClientStore, Update},
     verify_bootstrap, verify_finality_update, verify_update,
 };
-use helios_core::consensus::Consensus;
-use helios_core::time::{interval_at, Instant, SystemTime, UNIX_EPOCH};
+use helios_core::{
+    consensus::Consensus,
+    time::{interval_at, Instant, SystemTime, UNIX_EPOCH},
+};
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    watch,
+};
+use tracing::{debug, error, info, warn};
+use tree_hash::TreeHash;
 
-use crate::config::checkpoints::CheckpointFallback;
-use crate::config::networks::Network;
-use crate::config::Config;
-use crate::constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES;
-use crate::database::Database;
-use crate::rpc::ConsensusRpc;
+use crate::{
+    config::{checkpoints::CheckpointFallback, networks::Network, Config},
+    constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES,
+    database::Database,
+    rpc::ConsensusRpc,
+};
 
 pub struct ConsensusClient<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> {
     pub block_recv: Option<Receiver<Block<Transaction>>>,
@@ -682,17 +683,19 @@ mod tests {
     use std::sync::Arc;
 
     use alloy::primitives::b256;
+    use helios_consensus_core::{
+        consensus_spec::MainnetConsensusSpec,
+        errors::ConsensusError,
+        types::{
+            bls::{PublicKey, Signature},
+            Update,
+        },
+    };
     use tokio::sync::{mpsc::channel, watch};
-
-    use helios_consensus_core::consensus_spec::MainnetConsensusSpec;
-    use helios_consensus_core::errors::ConsensusError;
-    use helios_consensus_core::types::bls::{PublicKey, Signature};
-    use helios_consensus_core::types::Update;
 
     use crate::{
         config::{networks, Config},
-        consensus::calc_sync_period,
-        consensus::Inner,
+        consensus::{calc_sync_period, Inner},
         constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES,
         rpc::{mock_rpc::MockRpc, ConsensusRpc},
     };

--- a/ethereum/src/rpc/http_rpc.rs
+++ b/ethereum/src/rpc/http_rpc.rs
@@ -3,14 +3,13 @@ use std::cmp;
 use alloy::primitives::B256;
 use async_trait::async_trait;
 use eyre::Result;
-use retri::{retry, BackoffSettings};
-use serde::{de::DeserializeOwned, Deserialize};
-
 use helios_consensus_core::{
     consensus_spec::ConsensusSpec,
     types::{BeaconBlock, Bootstrap, FinalityUpdate, OptimisticUpdate, Update},
 };
 use helios_core::errors::RpcError;
+use retri::{retry, BackoffSettings};
+use serde::{de::DeserializeOwned, Deserialize};
 
 use super::ConsensusRpc;
 use crate::constants::MAX_REQUEST_LIGHT_CLIENT_UPDATES;

--- a/ethereum/src/rpc/mock_rpc.rs
+++ b/ethereum/src/rpc/mock_rpc.rs
@@ -7,7 +7,6 @@ use std::{
 use alloy::primitives::B256;
 use async_trait::async_trait;
 use eyre::Result;
-
 use helios_consensus_core::{
     consensus_spec::ConsensusSpec,
     types::{BeaconBlock, Bootstrap, FinalityUpdate, OptimisticUpdate, Update},

--- a/ethereum/src/rpc/mod.rs
+++ b/ethereum/src/rpc/mod.rs
@@ -4,7 +4,6 @@ pub mod mock_rpc;
 use alloy::primitives::B256;
 use async_trait::async_trait;
 use eyre::Result;
-
 use helios_consensus_core::{
     consensus_spec::ConsensusSpec,
     types::{BeaconBlock, Bootstrap, FinalityUpdate, OptimisticUpdate, Update},

--- a/ethereum/src/spec.rs
+++ b/ethereum/src/spec.rs
@@ -7,9 +7,8 @@ use alloy::{
     primitives::{Address, Bytes, ChainId, TxKind, U256},
     rpc::types::{AccessList, Log, TransactionRequest},
 };
-use revm::primitives::{BlobExcessGasAndPrice, BlockEnv, TxEnv};
-
 use helios_common::{fork_schedule::ForkSchedule, network_spec::NetworkSpec};
+use revm::primitives::{BlobExcessGasAndPrice, BlockEnv, TxEnv};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Ethereum;

--- a/ethereum/tests/sync.rs
+++ b/ethereum/tests/sync.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
 
 use alloy::primitives::b256;
-
 use helios_consensus_core::consensus_spec::MainnetConsensusSpec;
-use helios_ethereum::config::{networks, Config};
-use helios_ethereum::{consensus::ConsensusClient, database::ConfigDB, rpc::mock_rpc::MockRpc};
+use helios_ethereum::{
+    config::{networks, Config},
+    consensus::ConsensusClient,
+    database::ConfigDB,
+    rpc::mock_rpc::MockRpc,
+};
 
 async fn setup() -> ConsensusClient<MainnetConsensusSpec, MockRpc, ConfigDB> {
     let base_config = networks::mainnet();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,13 +2,16 @@ use std::{path::PathBuf, str::FromStr};
 
 use alloy::primitives::{utils::format_ether, Address};
 use eyre::Result;
+use helios::{
+    common::types::BlockTag,
+    ethereum::{
+        config::networks::Network, database::FileDB, EthereumClient, EthereumClientBuilder,
+    },
+};
 use tracing::info;
-use tracing_subscriber::filter::{EnvFilter, LevelFilter};
-use tracing_subscriber::FmtSubscriber;
-
-use helios::common::types::BlockTag;
-use helios::ethereum::{
-    config::networks::Network, database::FileDB, EthereumClient, EthereumClientBuilder,
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    FmtSubscriber,
 };
 
 #[tokio::main]

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -2,16 +2,21 @@
 
 use std::path::PathBuf;
 
-use alloy::primitives::{Address, Bytes};
-use alloy::rpc::types::TransactionRequest;
+use alloy::{
+    primitives::{Address, Bytes},
+    rpc::types::TransactionRequest,
+};
 use dotenv::dotenv;
+use helios::{
+    common::types::BlockTag,
+    ethereum::{
+        config::networks::Network, database::FileDB, EthereumClient, EthereumClientBuilder,
+    },
+};
 use tracing::info;
-use tracing_subscriber::filter::{EnvFilter, LevelFilter};
-use tracing_subscriber::FmtSubscriber;
-
-use helios::common::types::BlockTag;
-use helios::ethereum::{
-    config::networks::Network, database::FileDB, EthereumClient, EthereumClientBuilder,
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    FmtSubscriber,
 };
 
 #[tokio::main]

--- a/examples/checkpoints.rs
+++ b/examples/checkpoints.rs
@@ -1,5 +1,4 @@
 use eyre::Result;
-
 // From helios::config
 use helios::ethereum::config::{checkpoints, networks};
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use alloy::primitives::b256;
 use eyre::Result;
-
 use helios::ethereum::{
     config::networks::Network, database::FileDB, EthereumClient, EthereumClientBuilder,
 };

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -1,6 +1,5 @@
 use dirs::home_dir;
 use eyre::Result;
-
 use helios::ethereum::config::{cli::CliConfig, Config};
 
 #[tokio::main]

--- a/helios-ts/Cargo.toml
+++ b/helios-ts/Cargo.toml
@@ -9,19 +9,19 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.84"
-wasm-bindgen-futures = "0.4.33"
-wasm-bindgen-test = "0.3.0"
-serde-wasm-bindgen = "0.6.5"
-console_error_panic_hook = "0.1.7"
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
+wasm-bindgen-test.workspace = true
+serde-wasm-bindgen.workspace = true
+console_error_panic_hook.workspace = true
 
 eyre.workspace = true
 alloy.workspace = true
 op-alloy-rpc-types.workspace = true
 
-hex = "0.4.3"
-serde = { version = "1.0.143", features = ["derive"] }
-serde_json = "1.0.85"
+hex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 
 # self crates
 helios-common = { path = "../common" }
@@ -29,6 +29,4 @@ helios-ethereum = { path = "../ethereum" }
 helios-opstack = { path = "../opstack" }
 helios-linea = { path = "../linea" }
 
-[dependencies.web-sys]
-version = "0.3"
-features = ["console", "Storage", "Window"]
+web-sys = { workspace = true, features = ["console", "Storage", "Window"] }

--- a/helios-ts/src/ethereum.rs
+++ b/helios-ts/src/ethereum.rs
@@ -1,25 +1,25 @@
 extern crate console_error_panic_hook;
 extern crate web_sys;
 
-use std::collections::HashMap;
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 
-use alloy::hex::FromHex;
-use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::{Filter, TransactionRequest};
+use alloy::{
+    hex::FromHex,
+    primitives::{Address, B256, U256},
+    rpc::types::{Filter, TransactionRequest},
+};
 use eyre::Result;
+use helios_common::types::{BlockTag, SubscriptionType};
+use helios_ethereum::{
+    config::{networks, Config},
+    database::{ConfigDB, Database},
+    spec::Ethereum,
+    EthereumClientBuilder,
+};
 use wasm_bindgen::prelude::*;
 use web_sys::js_sys::Function;
 
-use helios_common::types::{BlockTag, SubscriptionType};
-use helios_ethereum::config::{networks, Config};
-use helios_ethereum::database::{ConfigDB, Database};
-use helios_ethereum::spec::Ethereum;
-use helios_ethereum::EthereumClientBuilder;
-
-use crate::map_err;
-use crate::storage::LocalStorageDB;
-use crate::subscription::Subscription;
+use crate::{map_err, storage::LocalStorageDB, subscription::Subscription};
 
 #[derive(Clone)]
 pub enum DatabaseType {

--- a/helios-ts/src/linea.rs
+++ b/helios-ts/src/linea.rs
@@ -1,22 +1,18 @@
 extern crate console_error_panic_hook;
 extern crate web_sys;
 
-use std::collections::HashMap;
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 
-use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::{Filter, TransactionRequest};
+use alloy::{
+    primitives::{Address, B256, U256},
+    rpc::types::{Filter, TransactionRequest},
+};
+use helios_common::types::{BlockTag, SubscriptionType};
+use helios_linea::{config::Config, spec::Linea, LineaClientBuilder};
 use wasm_bindgen::prelude::*;
 use web_sys::js_sys::Function;
 
-use helios_common::types::{BlockTag, SubscriptionType};
-
-use helios_linea::config::Config;
-use helios_linea::spec::Linea;
-use helios_linea::LineaClientBuilder;
-
-use crate::map_err;
-use crate::subscription::Subscription;
+use crate::{map_err, subscription::Subscription};
 
 #[wasm_bindgen]
 pub struct LineaClient {

--- a/helios-ts/src/opstack.rs
+++ b/helios-ts/src/opstack.rs
@@ -1,23 +1,23 @@
 extern crate console_error_panic_hook;
 extern crate web_sys;
 
-use std::collections::HashMap;
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 
-use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::Filter;
+use alloy::{
+    primitives::{Address, B256, U256},
+    rpc::types::Filter,
+};
+use helios_common::types::{BlockTag, SubscriptionType};
+use helios_opstack::{
+    config::{Config, Network, NetworkConfig},
+    spec::OpStack,
+    OpStackClientBuilder,
+};
+use op_alloy_rpc_types::OpTransactionRequest;
 use wasm_bindgen::prelude::*;
 use web_sys::js_sys::Function;
 
-use op_alloy_rpc_types::OpTransactionRequest;
-
-use helios_common::types::{BlockTag, SubscriptionType};
-use helios_opstack::config::{Config, Network, NetworkConfig};
-use helios_opstack::spec::OpStack;
-use helios_opstack::OpStackClientBuilder;
-
-use crate::map_err;
-use crate::subscription::Subscription;
+use crate::{map_err, subscription::Subscription};
 
 #[wasm_bindgen]
 pub struct OpStackClient {

--- a/helios-ts/src/storage.rs
+++ b/helios-ts/src/storage.rs
@@ -3,9 +3,8 @@ extern crate web_sys;
 
 use alloy::{hex::FromHex, primitives::B256};
 use eyre::Result;
-use wasm_bindgen::prelude::*;
-
 use helios_ethereum::{config::Config, database::Database};
+use wasm_bindgen::prelude::*;
 
 #[derive(Clone)]
 pub struct LocalStorageDB;

--- a/helios-ts/src/subscription.rs
+++ b/helios-ts/src/subscription.rs
@@ -1,11 +1,8 @@
-use std::cell::Cell;
-use std::marker::PhantomData;
-use std::rc::Rc;
+use std::{cell::Cell, marker::PhantomData, rc::Rc};
+
+use helios_common::{network_spec::NetworkSpec, types::SubEventRx};
 use wasm_bindgen::prelude::*;
 use web_sys::js_sys::Function;
-
-use helios_common::network_spec::NetworkSpec;
-use helios_common::types::SubEventRx;
 
 pub struct Subscription<N: NetworkSpec> {
     id: String,

--- a/linea/Cargo.toml
+++ b/linea/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # config
-figment = { version = "0.10.7", features = ["toml", "env"] }
+figment = { workspace = true, features = ["toml", "env"] }
 
 # async/futures
 tokio.workspace = true
@@ -17,12 +17,12 @@ serde.workspace = true
 alloy.workspace = true
 eyre.workspace = true
 tracing.workspace = true
-strum = { version = "0.26.2", features = ["derive"] }
-url = "2.5.0"
+strum = { workspace = true, features = ["derive"] }
+url.workspace = true
 
 helios-common = { path = "../common" }
 helios-core = { path = "../core" }
 helios-ethereum = { path = "../ethereum" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-futures = "0.4.37"
+wasm-bindgen-futures.workspace = true

--- a/linea/src/builder.rs
+++ b/linea/src/builder.rs
@@ -1,14 +1,15 @@
-use eyre::{eyre, Result};
 #[cfg(not(target_arch = "wasm32"))]
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
+use eyre::{eyre, Result};
 use helios_common::{execution_mode::ExecutionMode, fork_schedule::ForkSchedule};
 
-use crate::config::Config;
-use crate::config::Network;
-use crate::consensus::ConsensusClient;
-use crate::types::LineaClient;
+use crate::{
+    config::{Config, Network},
+    consensus::ConsensusClient,
+    types::LineaClient,
+};
 
 #[derive(Default)]
 pub struct LineaClientBuilder {

--- a/linea/src/config.rs
+++ b/linea/src/config.rs
@@ -8,19 +8,16 @@ use std::{
     str::FromStr,
 };
 
+use alloy::primitives::{address, Address};
+use eyre::Result;
 use figment::{
     providers::{Format, Serialized, Toml},
     value::Value,
     Figment,
 };
-
 use serde::{Deserialize, Serialize};
-
-use eyre::Result;
 use strum::EnumIter;
 use url::Url;
-
-use alloy::primitives::{address, Address};
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct ChainConfig {

--- a/linea/src/consensus.rs
+++ b/linea/src/consensus.rs
@@ -10,18 +10,15 @@ use alloy::{
     rpc::types::{Block, BlockTransactionsKind, Transaction},
     transports::http::reqwest::Url,
 };
-
-use tokio::sync::{
-    mpsc::{channel, Receiver, Sender},
-    watch,
-};
-
+use eyre::{eyre, Result};
 use helios_core::{
     consensus::Consensus,
     time::{interval, SystemTime, UNIX_EPOCH},
 };
-
-use eyre::{eyre, Result};
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    watch,
+};
 use tracing::error;
 
 use crate::config::Config;

--- a/linea/src/types.rs
+++ b/linea/src/types.rs
@@ -1,6 +1,5 @@
 use helios_core::client::Client;
 
-use crate::consensus::ConsensusClient;
-use crate::spec::Linea;
+use crate::{consensus::ConsensusClient, spec::Linea};
 
 pub type LineaClient = Client<Linea, ConsensusClient>;

--- a/opstack/Cargo.toml
+++ b/opstack/Cargo.toml
@@ -14,7 +14,7 @@ tracing.workspace = true
 hex.workspace = true
 serde.workspace = true
 typenum.workspace = true
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 reqwest.workspace = true
 url.workspace = true
 futures.workspace = true
@@ -27,14 +27,14 @@ sha2.workspace = true
 ethereum_ssz_derive.workspace = true
 ethereum_ssz.workspace = true
 ssz_types.workspace = true
-alloy-rlp = "0.3.0"
-op-alloy-network = "0.9.0"
-op-alloy-consensus = "0.9.0"
+alloy-rlp.workspace = true
+op-alloy-network.workspace = true
+op-alloy-consensus.workspace = true
 op-alloy-rpc-types.workspace = true
-snap = "1"
+snap.workspace = true
 
 # config
-figment = { version = "0.10.7", features = ["toml", "env"] }
+figment = { workspace = true, features = ["toml", "env"] }
 
 # self crates
 helios-common = { path = "../common" }
@@ -44,17 +44,17 @@ helios-consensus-core = { path = "../ethereum/consensus-core" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # server
-axum = "0.7.6"
-clap = { version = "4.5.4", features = ["derive", "env"] }
+axum.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
 # networking
-libp2p = { version = "0.51.3", features = ["macros", "tokio", "tcp", "mplex", "noise", "gossipsub", "ping"] }
-discv5 = "0.7.0"
-libp2p-identity = { version = "0.1.2", features = ["secp256k1"] }
-unsigned-varint = "0.7.1"
+libp2p = { workspace = true, features = ["macros", "tokio", "tcp", "mplex", "noise", "gossipsub", "ping"] }
+discv5.workspace = true
+libp2p-identity = { workspace = true, features = ["secp256k1"] }
+unsigned-varint.workspace = true
 
 [target.wasm32-unknown-unknown.dependencies]
-parking_lot = { version = "0.12.2" }
+parking_lot.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-futures = "0.4.37"
-getrandom = { version = "0.2.1", features = ["js"] }
+wasm-bindgen-futures.workspace = true
+getrandom.workspace = true

--- a/opstack/bin/server.rs
+++ b/opstack/bin/server.rs
@@ -3,14 +3,13 @@ use std::net::SocketAddr;
 #[cfg(not(target_arch = "wasm32"))]
 use clap::Parser;
 use eyre::Result;
-use tracing_subscriber::{EnvFilter, FmtSubscriber};
-use url::Url;
-
 #[cfg(not(target_arch = "wasm32"))]
 use helios_opstack::{
     config::{Network, NetworkConfig},
     server::start_server,
 };
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+use url::Url;
 
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]

--- a/opstack/src/builder.rs
+++ b/opstack/src/builder.rs
@@ -1,12 +1,11 @@
-use eyre::Result;
-use reqwest::{IntoUrl, Url};
 use std::net::SocketAddr;
 
+use eyre::Result;
 use helios_common::{execution_mode::ExecutionMode, fork_schedule::ForkSchedule};
+use reqwest::{IntoUrl, Url};
 
 use crate::{
-    config::Network,
-    config::{Config, NetworkConfig},
+    config::{Config, Network, NetworkConfig},
     consensus::ConsensusClient,
     OpStackClient,
 };

--- a/opstack/src/config.rs
+++ b/opstack/src/config.rs
@@ -9,10 +9,9 @@ use figment::{
     value::Value,
     Figment,
 };
+use helios_ethereum::config::networks::Network as EthNetwork;
 use serde::{Deserialize, Serialize};
 use url::Url;
-
-use helios_ethereum::config::networks::Network as EthNetwork;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Config {

--- a/opstack/src/consensus.rs
+++ b/opstack/src/consensus.rs
@@ -1,34 +1,37 @@
-use std::str::FromStr;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::{
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
-use alloy::consensus::proofs::{calculate_transaction_root, calculate_withdrawals_root};
-use alloy::consensus::{Header as ConsensusHeader, Transaction as TxTrait};
-use alloy::eips::eip4895::{Withdrawal, Withdrawals};
-use alloy::primitives::{b256, fixed_bytes, Address, Bloom, BloomInput, B256, U256};
-use alloy::rlp::Decodable;
-use alloy::rpc::types::{
-    Block, EIP1186AccountProofResponse, Header, Transaction as EthTransaction,
+use alloy::{
+    consensus::{
+        proofs::{calculate_transaction_root, calculate_withdrawals_root},
+        Header as ConsensusHeader, Transaction as TxTrait,
+    },
+    eips::eip4895::{Withdrawal, Withdrawals},
+    primitives::{b256, fixed_bytes, Address, Bloom, BloomInput, B256, U256},
+    rlp::Decodable,
+    rpc::types::{Block, EIP1186AccountProofResponse, Header, Transaction as EthTransaction},
 };
 use eyre::{eyre, OptionExt, Result};
+use helios_consensus_core::consensus_spec::MainnetConsensusSpec;
+use helios_core::{
+    consensus::Consensus,
+    execution::proof::{verify_account_proof, verify_mpt_proof},
+    time::{interval, SystemTime, UNIX_EPOCH},
+};
+use helios_ethereum::{
+    consensus::ConsensusClient as EthConsensusClient, database::ConfigDB, rpc::http_rpc::HttpRpc,
+};
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_network::primitives::BlockTransactions;
 use op_alloy_rpc_types::Transaction;
-use tokio::sync::mpsc::Sender;
 use tokio::sync::{
-    mpsc::{channel, Receiver},
+    mpsc::{channel, Receiver, Sender},
     watch,
 };
 use tracing::{error, info, warn};
-
-use helios_consensus_core::consensus_spec::MainnetConsensusSpec;
-use helios_core::consensus::Consensus;
-use helios_core::execution::proof::{verify_account_proof, verify_mpt_proof};
-use helios_core::time::{interval, SystemTime, UNIX_EPOCH};
-use helios_ethereum::consensus::ConsensusClient as EthConsensusClient;
-
-use helios_ethereum::database::ConfigDB;
-use helios_ethereum::rpc::http_rpc::HttpRpc;
 
 use crate::{config::Config, types::ExecutionPayload, SequencerCommitment};
 

--- a/opstack/src/lib.rs
+++ b/opstack/src/lib.rs
@@ -2,14 +2,12 @@ use alloy::{
     primitives::{keccak256, Address, Bytes, B256},
     signers::Signature,
 };
+use consensus::ConsensusClient;
 use eyre::Result;
+use helios_core::client::Client;
 use serde::{Deserialize, Serialize};
 use spec::OpStack;
 use ssz::Decode;
-
-use helios_core::client::Client;
-
-use consensus::ConsensusClient;
 use types::ExecutionPayload;
 
 mod builder;

--- a/opstack/src/server/mod.rs
+++ b/opstack/src/server/mod.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 use alloy::{
     primitives::{Address, FixedBytes, B256},
@@ -11,6 +11,8 @@ use axum::{
     Json, Router,
 };
 use eyre::Result;
+use helios_core::execution::rpc::{http_rpc::HttpRpc, ExecutionRpc};
+use helios_ethereum::spec::Ethereum;
 use tokio::{
     sync::{
         mpsc::{channel, Receiver},
@@ -20,12 +22,8 @@ use tokio::{
 };
 use url::Url;
 
-use crate::{types::ExecutionPayload, SequencerCommitment};
-
 use self::net::{block_handler::BlockHandler, gossip::GossipService};
-use helios_core::execution::rpc::{http_rpc::HttpRpc, ExecutionRpc};
-use helios_ethereum::spec::Ethereum;
-use std::str::FromStr;
+use crate::{types::ExecutionPayload, SequencerCommitment};
 
 pub mod net;
 mod poller;

--- a/opstack/src/spec.rs
+++ b/opstack/src/spec.rs
@@ -6,8 +6,6 @@ use alloy::{
     primitives::{Address, Bytes, ChainId, TxKind, U256},
     rpc::types::{AccessList, Log, TransactionRequest},
 };
-use revm::primitives::{BlobExcessGasAndPrice, BlockEnv, TxEnv};
-
 use helios_common::{fork_schedule::ForkSchedule, network_spec::NetworkSpec};
 use op_alloy_consensus::{
     OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxEnvelope, OpTxType,
@@ -17,6 +15,7 @@ use op_alloy_network::{
     BuildResult, Ethereum, Network, NetworkWallet, TransactionBuilder, TransactionBuilderError,
 };
 use op_alloy_rpc_types::{OpTransactionRequest, Transaction};
+use revm::primitives::{BlobExcessGasAndPrice, BlockEnv, TxEnv};
 
 #[derive(Clone, Copy, Debug)]
 pub struct OpStack;

--- a/tests/rpc_equivalence.rs
+++ b/tests/rpc_equivalence.rs
@@ -1,24 +1,24 @@
 use std::env;
 
-use alloy::eips::BlockNumberOrTag;
-use alloy::network::primitives::BlockTransactionsKind;
-use alloy::primitives::address;
-use alloy::providers::{Provider, ProviderBuilder, RootProvider};
-use alloy::rpc::client::ClientBuilder as AlloyClientBuilder;
-use alloy::rpc::types::Filter;
-use alloy::sol;
-use alloy::transports::http::{Client as ReqwestClient, Http};
+use alloy::{
+    eips::BlockNumberOrTag,
+    network::primitives::BlockTransactionsKind,
+    primitives::address,
+    providers::{Provider, ProviderBuilder, RootProvider},
+    rpc::{client::ClientBuilder as AlloyClientBuilder, types::Filter},
+    sol,
+    transports::http::{Client as ReqwestClient, Http},
+};
 use futures::future::join_all;
-use pretty_assertions::assert_eq;
-use rand::Rng;
-use url::Url;
-
 use helios::ethereum::{
     config::networks::Network, database::ConfigDB, EthereumClient, EthereumClientBuilder,
 };
 use helios_verifiable_api_server::server::{
     Network as ApiNetwork, ServerArgs, VerifiableApiServer,
 };
+use pretty_assertions::assert_eq;
+use rand::Rng;
+use url::Url;
 
 async fn setup() -> (
     EthereumClient<ConfigDB>,

--- a/tests/test-utils/src/lib.rs
+++ b/tests/test-utils/src/lib.rs
@@ -5,7 +5,6 @@ use alloy::{
     primitives::{B256, U256},
     rpc::types::{EIP1186AccountProofResponse, Log, TransactionReceipt},
 };
-
 use helios_common::types::Account;
 use helios_ethereum::spec::Ethereum as EthereumSpec;
 use helios_verifiable_api_types::{

--- a/verifiable-api/client/src/http.rs
+++ b/verifiable-api/client/src/http.rs
@@ -5,11 +5,10 @@ use alloy::{
 };
 use async_trait::async_trait;
 use eyre::{eyre, Result};
-use reqwest::{Client, Response};
-use serde::de::DeserializeOwned;
-
 use helios_common::network_spec::NetworkSpec;
 use helios_verifiable_api_types::*;
+use reqwest::{Client, Response};
+use serde::de::DeserializeOwned;
 
 use super::VerifiableApi;
 

--- a/verifiable-api/client/src/lib.rs
+++ b/verifiable-api/client/src/lib.rs
@@ -5,7 +5,6 @@ use alloy::{
 };
 use async_trait::async_trait;
 use eyre::Result;
-
 use helios_common::network_spec::NetworkSpec;
 use helios_verifiable_api_types::*;
 

--- a/verifiable-api/client/src/mock.rs
+++ b/verifiable-api/client/src/mock.rs
@@ -8,7 +8,6 @@ use alloy::{
 };
 use async_trait::async_trait;
 use eyre::{eyre, Result};
-
 use helios_common::network_spec::NetworkSpec;
 use helios_verifiable_api_types::*;
 

--- a/verifiable-api/server/Cargo.toml
+++ b/verifiable-api/server/Cargo.toml
@@ -14,7 +14,7 @@ eyre.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url.workspace = true
 futures.workspace = true
 async-trait.workspace = true
@@ -27,9 +27,10 @@ helios-core = { path = "../../core" }
 helios-ethereum = { path = "../../ethereum" }
 helios-opstack = { path = "../../opstack" }
 
-axum = "0.8.1"
-axum-extra = { version = "0.10.0", features = ["query"] }
-clap = { version = "4.5.4", features = ["derive", "env"] }
+axum.workspace = true
+axum-extra = { workspace = true, features = ["query"] }
+clap = { workspace = true, features = ["derive", "env"] }
 
 [dev-dependencies]
 helios-test-utils = { path = "../../tests/test-utils" }
+tokio.workspace = true

--- a/verifiable-api/server/bin/server.rs
+++ b/verifiable-api/server/bin/server.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
+use helios_verifiable_api_server::server::{Network, VerifiableApiServer};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
-
-use helios_verifiable_api_server::server::{Network, VerifiableApiServer};
 
 #[tokio::main]
 async fn main() {

--- a/verifiable-api/server/src/handlers.rs
+++ b/verifiable-api/server/src/handlers.rs
@@ -12,12 +12,11 @@ use axum::{
 };
 use axum_extra::extract::Query;
 use eyre::{eyre, OptionExt, Report, Result};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-
 use helios_common::network_spec::NetworkSpec;
 use helios_core::execution::{errors::ExecutionError, rpc::ExecutionRpc};
 use helios_verifiable_api_client::VerifiableApi;
 use helios_verifiable_api_types::*;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::state::ApiState;
 

--- a/verifiable-api/server/src/router.rs
+++ b/verifiable-api/server/src/router.rs
@@ -2,7 +2,6 @@ use axum::{
     routing::{delete, get, post},
     Router,
 };
-
 use helios_common::network_spec::NetworkSpec;
 use helios_core::execution::rpc::ExecutionRpc;
 

--- a/verifiable-api/server/src/server.rs
+++ b/verifiable-api/server/src/server.rs
@@ -1,19 +1,15 @@
 use std::net::SocketAddr;
 
 use clap::{Args, Subcommand};
-use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
-use tracing::debug;
-use url::Url;
-
 use helios_core::execution::rpc::http_rpc::HttpRpc;
 use helios_ethereum::spec::Ethereum as EthereumSpec;
 use helios_opstack::spec::OpStack as OpStackSpec;
 use helios_verifiable_api_client::VerifiableApi;
+use tokio::{sync::oneshot, task::JoinHandle};
+use tracing::debug;
+use url::Url;
 
-use crate::router::build_router;
-use crate::service::ApiService;
-use crate::state::ApiState;
+use crate::{router::build_router, service::ApiService, state::ApiState};
 
 pub struct VerifiableApiServer {
     network: Network,

--- a/verifiable-api/server/src/service.rs
+++ b/verifiable-api/server/src/service.rs
@@ -1,6 +1,8 @@
-use std::collections::{HashMap, HashSet};
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    marker::PhantomData,
+    sync::Arc,
+};
 
 use alloy::{
     consensus::{Account as TrieAccount, BlockHeader},
@@ -12,7 +14,6 @@ use alloy::{
 use async_trait::async_trait;
 use eyre::{Ok, OptionExt, Report, Result};
 use futures::future::try_join_all;
-
 use helios_common::{fork_schedule::ForkSchedule, network_spec::NetworkSpec, types::BlockTag};
 use helios_core::execution::{
     client::{rpc::ExecutionInnerRpcClient, ExecutionInner},

--- a/verifiable-api/types/src/lib.rs
+++ b/verifiable-api/types/src/lib.rs
@@ -5,9 +5,8 @@ use alloy::{
     primitives::{Address, Bytes, B256, U256},
     rpc::types::{Filter, Log},
 };
-use serde::{Deserialize, Serialize};
-
 use helios_common::{network_spec::NetworkSpec, types::Account};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub struct ErrorResponse {


### PR DESCRIPTION
#### TL;DR
Pins all workspace dependencies and runs cargo +nightly fmt. Zero functional changes.

#### Motivation
We'd love to use helios inside TEE. But our current approach uses sgx sdk for pretty old version of toolchain - so we need to downgrade a lot of deps. While it's not so hard task and most of the future changes are not relevant to main repo, it would be great to have all dependencies in one place.


Formatted with:
```sh
cargo +nightly fmt -- --check \
    --config imports_granularity=Crate \
    --config group_imports=StdExternalCrate
```
If the formatting config feel heavy-handed, let me know and I'll dial them back.