### PR TITLE
Update Ethereum JSON RPC Spec link to the latest official documentation

### DIFF
--- a/rpc.md
+++ b/rpc.md
@@ -1,6 +1,6 @@
 # Helios Remote Procedure Calls
 
-Helios provides a variety of RPC methods for interacting with the Ethereum network. These methods are exposed via the `Client` struct.  The RPC methods follow the [Ethereum JSON RPC Spec](https://ethereum.org/en/developers/docs/apis/json-rpc/). See [examples](./examples) of running remote procedure calls with Helios.
+Helios provides a variety of RPC methods for interacting with the Ethereum network. These methods are exposed via the `Client` struct.  The RPC methods follow the [Ethereum JSON RPC Spec](https://ethereum.github.io/execution-apis/). See [examples](./examples) of running remote procedure calls with Helios.
 
 ## RPC Methods
 

--- a/rpc.md
+++ b/rpc.md
@@ -1,6 +1,6 @@
 # Helios Remote Procedure Calls
 
-Helios provides a variety of RPC methods for interacting with the Ethereum network. These methods are exposed via the `Client` struct.  The RPC methods follow the [Ethereum JSON RPC Spec](https://ethereum.github.io/execution-apis/api-documentation). See [examples](./examples) of running remote procedure calls with Helios.
+Helios provides a variety of RPC methods for interacting with the Ethereum network. These methods are exposed via the `Client` struct.  The RPC methods follow the [Ethereum JSON RPC Spec](https://ethereum.org/en/developers/docs/apis/json-rpc/). See [examples](./examples) of running remote procedure calls with Helios.
 
 ## RPC Methods
 


### PR DESCRIPTION
Replaced the outdated link to the Ethereum JSON RPC specification (https://ethereum.github.io/execution-apis/api-documentation) with the current official documentation URL (https://ethereum.org/en/developers/docs/apis/json-rpc/) in the rpc.md file. This ensures users are directed to the most up-to-date and maintained resource. No other content was changed.