### PR TITLE
Update deprecated actions/checkout@v1 to actions/checkout@v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: install rust
         uses: actions-rs/toolchain@v1
@@ -47,7 +47,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: install rust
         uses: actions-rs/toolchain@v1
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: install rust
         uses: actions-rs/toolchain@v1
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: install rust
         uses: actions-rs/toolchain@v1
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: install rust
         uses: actions-rs/toolchain@v1
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: install rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Replaced all instances of `actions/checkout@v1` with `actions/checkout@v4` to use the latest stable version of the GitHub Action.  
This improves performance, compatibility, and ensures long-term support as `v1` is deprecated.

Reference:
- [actions/checkout](https://github.com/actions/checkout/releases/tag/v4.2.2)





