### PR TITLE
feat: prepare helios-ts for publishing on NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,45 @@
+name: Publish NPM Package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: ./helios-ts
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+        
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        
+      - name: Install Node.js dependencies
+        run: npm ci
+        
+      - name: Run tests
+        run: npm run test
+        
+      - name: Build and publish to NPM
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,3 +258,56 @@ jobs:
             helios_linux_riscv64gc.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-npm-package:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./helios-ts
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Build helios-ts package
+        run: npm run build
+
+      - name: Create npm package tarball
+        id: pack
+        run: |
+          PACKAGE_FILENAME=$(npm pack)
+          echo "Packed file: $PACKAGE_FILENAME"
+          echo "::set-output name=package_filename::$PACKAGE_FILENAME"
+
+      - name: Generate tag name
+        id: tag
+        # This step runs in the workspace root, not ./helios-ts default
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "::set-output name=release_tag::nightly-${GITHUB_SHA}"
+
+      - name: Release npm package to GitHub Releases
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.tag.outputs.release_tag }}
+          prerelease: true
+          files: helios-ts/${{ steps.pack.outputs.package_filename }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ helios-ts/node_modules
 helios-ts/dist
 helios-ts/helios-*.tgz
 helios-ts/pkg
+helios-ts/LICENSE
 
 .vscode

--- a/helios-ts/README.md
+++ b/helios-ts/README.md
@@ -1,0 +1,91 @@
+# @a16z/helios
+
+Helios is a trustless, efficient, and portable Ethereum light client written in Rust with TypeScript bindings for web and Node.js environments. It comes both as a UMD and ES module.
+
+## Installation & Basic Setup Examples
+
+### 1. Installing using NPM
+
+Install the package:
+```bash
+npm install @a16z/helios
+```
+
+Basic usage in your project (e.g., `index.js` or `index.mjs` or `main.ts`):
+```typescript
+import { init, HeliosProvider } from '@a16z/helios';
+
+async function main() {
+  await init(); // Initialize Helios WASM
+  const heliosProvider = new HeliosProvider({
+    network: 'mainnet',
+    executionRpc: 'https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY',
+    checkpoint: "0x..."
+  });
+
+  await heliosProvider.waitSynced();
+  console.log('Helios is synced and ready!');
+  
+  // Example: Get latest block number
+  const blockNumber = await heliosProvider.request({ method: 'eth_blockNumber' });
+  console.log('Latest block number:', parseInt(blockNumber, 16));
+}
+```
+
+### 2. Loading on a webpage from a CDN
+
+For a quick test, you can try Helios directly in an HTML file using a CDN like unpkg.
+
+**As a UMD module:**
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Helios UMD Test</title>
+  <script src="https://unpkg.com/@a16z/helios/dist/lib.umd.js"></script>
+</head>
+<body>
+  <script>
+    // Helios will be available via a global variable `helios`, call helios.init() to initialize it
+    // and use helios.HeliosProvider constructor to create a provider
+  </script>
+</body>
+</html>
+```
+
+**As an ES module:**
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Helios ESM Test</title>
+</head>
+<body>
+  <script type="module">
+    import { init, HeliosProvider } from 'https://unpkg.com/@a16z/helios/dist/lib.mjs';
+    // your code here
+  </script>
+</body>
+</html>
+```
+
+## Usage as EIP-1193 provider
+
+Helios can be used as an EIP-1193 provider. Once initialized and synced (as shown in the examples above), `heliosProvider` can be used with libraries like ethers.js, web3.js, etc.
+
+Example with ethers.js:
+```typescript
+import { ethers } from 'ethers';
+// Assuming heliosProvider is initialized and synced as shown in the Node.js/Bundler example
+const ethersProvider = new ethers.providers.Web3Provider(heliosProvider);
+const blockNumber = await ethersProvider.getBlockNumber();
+console.log('Latest block number:', blockNumber);
+```
+
+## Documentation
+
+See [helios github repo](https://github.com/a16z/helios/) for more details.
+
+## License
+
+This project is licensed under the MIT License - see the main repository for details.

--- a/helios-ts/package.json
+++ b/helios-ts/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "helios",
-  "version": "0.1.0",
+  "name": "@a16z/helios",
+  "description": "A fast, secure, and portable multichain light client for Ethereum",
+  "version": "0.8.8",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.mjs",
   "types": "./dist/lib.d.ts",
@@ -15,11 +16,33 @@
     "build": "npm run build:wasm && npm run build:js",
     "build:js": "vite build && npm run build:types",
     "build:wasm": "wasm-pack build --target web --out-name index --out-dir pkg",
-    "build:types": "tsc --emitDeclarationOnly"
+    "build:types": "tsc --emitDeclarationOnly",
+    "test": "echo \"No tests yet\" && exit 0",
+    "prepack": "cp ../LICENSE LICENSE && rm -f pkg/.gitignore",
+    "prepublishOnly": "npm run build"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "ethereum",
+    "light-client",
+    "blockchain",
+    "multichain",
+    "wasm",
+    "rust"
+  ],
+  "author": "a16z crypto",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/a16z/helios.git",
+    "directory": "helios-ts"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/a16z/helios",
+  "bugs": {
+    "url": "https://github.com/a16z/helios/issues"
+  },
   "devDependencies": {
     "@rollup/plugin-wasm": "^6.2.2",
     "@types/uuid": "^10.0.0",
@@ -30,5 +53,12 @@
   "dependencies": {
     "eventemitter3": "^5.0.1",
     "uuid": "^11.0.5"
-  }
+  },
+  "files": [
+    "dist",
+    "pkg/**/*.js",
+    "pkg/**/*.d.ts",
+    "pkg/**/*.wasm",
+    "lib.ts"
+  ]
 }


### PR DESCRIPTION
This PR:
- amends `release.yml` workflow with creating an Node package of helios-ts
- creates a new `npm-publish.yml` workflow that publishes helios to NPM
- adjusts package.json and adds a separate README file for helios-ts

Please note:
- I used the same version for helios-ts as the whole workspace's
- I named the package `@a16z/helios`, not `@a16z/helios-ts`.