### PR TITLE
Update rpc.md

### DIFF
--- a/rpc.md
+++ b/rpc.md
@@ -37,5 +37,5 @@ Helios provides a variety of RPC methods for interacting with the Ethereum netwo
 | `eth_getProof` | `get_proof` | Returns the merkle proof for a given account and optionally some storage keys. | `client.get_proof(&self, address: &str, slots: [H256], block: BlockTag)` |
 | `eth_coinbase` | `get_coinbase` | Returns the client coinbase address. | `client.get_coinbase(&self)` |
 | `eth_syncing` | `syncing` | Returns an object with data about the sync status or false. | `client.syncing(&self)` |
-| `eth_subscribe` | `subscribe` | Subscribes to events. Only "newHeads" is currently supported. | `client.subscribe(&self, event_type: &str)` |
+| `eth_subscribe` | `subscribe` | Subscribes to specified event types. Currently supports "newHeads" event type, which notifies about new block headers being added to the chain. Additional event types may be supported in future versions. | `client.subscribe(&self, event_type: &str)` |
 | `web3_clientVersion` | `client_version` | Returns the current version of the chain client. | `client.client_version(&self)` |


### PR DESCRIPTION
Let me explain the specific changes made to rpc.md and their purposes:

1. The main change in rpc.md was to improve the documentation for the `eth_subscribe` method. Here's the before and after:

Before:
```markdown
| `eth_subscribe` | `subscribe` | Subscribes to events. Only "newHeads" is currently supported. | `client.subscribe(&self, event_type: &str)` |
```

After:
```markdown
| `eth_subscribe` | `subscribe` | Subscribes to specified event types. Currently supports "newHeads" event type, which notifies about new block headers being added to the chain. Additional event types may be supported in future versions. | `client.subscribe(&self, event_type: &str)` |
```


This change is particularly important because `eth_subscribe` is a crucial method for developers who need to monitor blockchain state changes in real-time. The improved documentation helps them better understand:  what they can subscribe to (currently only "newHeads"), what information they'll receive (new block headers), that the API might expand in the future
