### PR TITLE
fix: unsupported place in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To run Helios on Ethereum, run the command below, replacing `$ETH_RPC_URL` with 
 helios ethereum --execution-rpc $ETH_RPC_URL
 ```
 
-`$ETH_RPC_URL` must be a supported Ethereum Execution API Provider that provides the `eth_getProof` endpoint. Infura does not currently support this. We recommend using Alchemy.
+`$ETH_RPC_URL` must be a supported Ethereum Execution API Provider that provides the `eth_getProof` endpoint. We recommend using providers like Alchemy or Infura.
 
 Helios will now run a local RPC server at `http://127.0.0.1:8545`.
 


### PR DESCRIPTION
There was a broken link in README.md that led to a non-existent doc fragment.