### PR TITLE
chore: improve logging system for block updates

### DIFF
--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -369,7 +369,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
         self.verify_finality_update(&finality_update)?;
         self.apply_finality_update(&finality_update);
 
-        info!(
+        debug!(
             target: "helios::consensus",
             "consensus client in sync with checkpoint: 0x{}",
             hex::encode(checkpoint)
@@ -425,7 +425,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
                 let res = self.verify_update(update);
 
                 if res.is_ok() {
-                    info!(target: "helios::consensus", "updating sync committee");
+                    debug!(target: "helios::consensus", "updating sync committee");
                     self.apply_update(update);
                 }
             }
@@ -540,7 +540,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
         let decimals = if participation == 100.0 { 1 } else { 2 };
         let age = self.age(self.store.finalized_header.beacon().slot);
 
-        info!(
+        debug!(
             target: "helios::consensus",
             "finalized slot             slot={}  confidence={:.decimals$}%  age={:02}:{:02}:{:02}:{:02}",
             self.store.finalized_header.beacon().slot,
@@ -559,7 +559,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
         let decimals = if participation == 100.0 { 1 } else { 2 };
         let age = self.age(self.store.optimistic_header.beacon().slot);
 
-        info!(
+        debug!(
             target: "helios::consensus",
             "updated head               slot={}  confidence={:.decimals$}%  age={:02}:{:02}:{:02}:{:02}",
             self.store.optimistic_header.beacon().slot,

--- a/linea/src/consensus.rs
+++ b/linea/src/consensus.rs
@@ -135,7 +135,7 @@ impl Inner {
                 self.latest_block = Some(number);
                 _ = self.block_send.send(block).await;
 
-                tracing::info!(
+                tracing::debug!(
                     "unsafe head updated: block={} age={}s",
                     number,
                     age.as_secs()

--- a/opstack/src/consensus.rs
+++ b/opstack/src/consensus.rs
@@ -22,7 +22,7 @@ use tokio::sync::{
     mpsc::{channel, Receiver},
     watch,
 };
-use tracing::{error, info, warn};
+use tracing::{debug, error, warn};
 
 use helios_consensus_core::consensus_spec::MainnetConsensusSpec;
 use helios_core::consensus::Consensus;
@@ -153,7 +153,7 @@ impl Inner {
                     self.latest_block = Some(block.header.number);
                     _ = self.block_send.send(block).await;
 
-                    tracing::info!(
+                    tracing::debug!(
                         "unsafe head updated: block={} age={}s",
                         number,
                         age.as_secs()
@@ -246,7 +246,7 @@ fn verify_unsafe_signer(config: Config, signer: Arc<Mutex<Address>>) {
             {
                 let mut curr_signer = signer.lock().map_err(|_| eyre!("failed to lock signer"))?;
                 if verified_signer != *curr_signer {
-                    info!(target: "helios::opstack", "unsafe signer updated: {}", verified_signer);
+                    debug!(target: "helios::opstack", "unsafe signer updated: {}", verified_signer);
                     *curr_signer = verified_signer;
                 }
             }


### PR DESCRIPTION
## Summary

This PR improves the logging system in Helios to provide more uniform and cleaner logging output for block updates.

## Changes

- **Unified logging location**: Moved block sync logging from individual consensus modules to helios-core for consistency
- **Cleaner log format**: 
  - Latest blocks: `latest block     number=X age=Xs`
  - Finalized blocks: `finalized block  number=X`
- **Reduced noise**: Changed consensus module logs from info to debug level
- **Deduplication**: Added tracking to prevent duplicate finalized block logs
- **Better alignment**: Block numbers are aligned between latest and finalized logs for easier reading

## Before
```
INFO helios::consensus: finalized slot             slot=10406016  confidence=100.0%  age=00:00:04:00
INFO helios::consensus: updated head               slot=10406048  confidence=100.0%  age=00:00:00:00
INFO helios::consensus::op_stack: unsafe head updated: block=22681448 age=0s
```

## After
```
INFO helios::client: latest block     number=22681448 age=0s
INFO helios::client: finalized block  number=22681416
```

The new logging provides a cleaner, more consistent view of block updates across all consensus implementations (Ethereum, OpStack, Linea), making it easier to monitor Helios's sync status.