### PR TITLE
Remove deprecated CDN links from README

### DIFF
--- a/helios-ts/README.md
+++ b/helios-ts/README.md
@@ -42,7 +42,7 @@ For a quick test, you can try Helios directly in an HTML file using a CDN like u
 <html>
 <head>
   <title>Helios UMD Test</title>
-  <script src="https://unpkg.com/@a16z/helios/dist/lib.umd.js"></script>
+  <script src=""></script>
 </head>
 <body>
   <script>
@@ -62,7 +62,7 @@ For a quick test, you can try Helios directly in an HTML file using a CDN like u
 </head>
 <body>
   <script type="module">
-    import { init, HeliosProvider } from 'https://unpkg.com/@a16z/helios/dist/lib.mjs';
+    import { init, HeliosProvider } from '';
     // your code here
   </script>
 </body>


### PR DESCRIPTION
Remove non-functioning unpkg.com CDN links from the documentation. These links are no longer accessible as the package is not available through CDN.
Changes:
Removed https://unpkg.com/@a16z/helios/dist/lib.umd.js from UMD example
Removed https://unpkg.com/@a16z/helios/dist/lib.mjs from ESM example
Updated import statements to use empty source paths