### PR TITLE
refactor: improve TypeScript initialization API

### DIFF
--- a/helios-ts/README.md
+++ b/helios-ts/README.md
@@ -13,23 +13,26 @@ npm install @a16z/helios
 
 Basic usage in your project (e.g., `index.js` or `index.mjs` or `main.ts`):
 ```typescript
-import { init, HeliosProvider } from '@a16z/helios';
+import { createHeliosProvider } from '@a16z/helios';
 
 async function main() {
-  await init(); // Initialize Helios WASM
-  const heliosProvider = new HeliosProvider({
-    network: 'mainnet',
+  // Create provider - WASM initialization is handled automatically
+  const heliosProvider = await createHeliosProvider({
     executionRpc: 'https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY',
+    consensusRpc: 'https://lodestar-mainnet.chainsafe.io',
+    network: 'mainnet',
     checkpoint: "0x..."
-  });
+  }, 'ethereum');
 
   await heliosProvider.waitSynced();
   console.log('Helios is synced and ready!');
   
   // Example: Get latest block number
-  const blockNumber = await heliosProvider.request({ method: 'eth_blockNumber' });
+  const blockNumber = await heliosProvider.request({ method: 'eth_blockNumber', params: [] });
   console.log('Latest block number:', parseInt(blockNumber, 16));
 }
+
+main().catch(console.error);
 ```
 
 ### 2. Loading on a webpage from a CDN
@@ -46,8 +49,20 @@ For a quick test, you can try Helios directly in an HTML file using a CDN like u
 </head>
 <body>
   <script>
-    // Helios will be available via a global variable `helios`, call helios.init() to initialize it
-    // and use helios.HeliosProvider constructor to create a provider
+    async function main() {
+      // Helios is available via global variable `helios`
+      const provider = await helios.createHeliosProvider({
+        executionRpc: 'https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY',
+        consensusRpc: 'https://lodestar-mainnet.chainsafe.io',
+        network: 'mainnet',
+        checkpoint: "0x..."
+      }, 'ethereum');
+      
+      await provider.waitSynced();
+      console.log('Helios is ready!');
+    }
+    
+    main().catch(console.error);
   </script>
 </body>
 </html>
@@ -62,8 +77,21 @@ For a quick test, you can try Helios directly in an HTML file using a CDN like u
 </head>
 <body>
   <script type="module">
-    import { init, HeliosProvider } from 'https://unpkg.com/@a16z/helios/dist/lib.mjs';
-    // your code here
+    import { createHeliosProvider } from 'https://unpkg.com/@a16z/helios/dist/lib.mjs';
+    
+    async function main() {
+      const provider = await createHeliosProvider({
+        executionRpc: 'https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY',
+        consensusRpc: 'https://lodestar-mainnet.chainsafe.io',
+        network: 'mainnet',
+        checkpoint: "0x..."
+      }, 'ethereum');
+      
+      await provider.waitSynced();
+      console.log('Helios is ready!');
+    }
+    
+    main().catch(console.error);
   </script>
 </body>
 </html>
@@ -76,7 +104,19 @@ Helios can be used as an EIP-1193 provider. Once initialized and synced (as show
 Example with ethers.js:
 ```typescript
 import { ethers } from 'ethers';
-// Assuming heliosProvider is initialized and synced as shown in the Node.js/Bundler example
+import { createHeliosProvider } from '@a16z/helios';
+
+// Create and sync Helios provider
+const heliosProvider = await createHeliosProvider({
+  executionRpc: 'https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY',
+  consensusRpc: 'https://lodestar-mainnet.chainsafe.io',
+  network: 'mainnet',
+  checkpoint: "0x..."
+}, 'ethereum');
+
+await heliosProvider.waitSynced();
+
+// Use with ethers.js
 const ethersProvider = new ethers.providers.Web3Provider(heliosProvider);
 const blockNumber = await ethersProvider.getBlockNumber();
 console.log('Latest block number:', blockNumber);

--- a/helios-ts/README.md
+++ b/helios-ts/README.md
@@ -19,7 +19,7 @@ async function main() {
   // Create provider - WASM initialization is handled automatically
   const heliosProvider = await createHeliosProvider({
     executionRpc: 'https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY',
-    consensusRpc: 'https://lodestar-mainnet.chainsafe.io',
+    consensusRpc: 'https://ethereum.operationsolarstorm.org',
     network: 'mainnet',
     checkpoint: "0x..."
   }, 'ethereum');
@@ -53,7 +53,7 @@ For a quick test, you can try Helios directly in an HTML file using a CDN like u
       // Helios is available via global variable `helios`
       const provider = await helios.createHeliosProvider({
         executionRpc: 'https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY',
-        consensusRpc: 'https://lodestar-mainnet.chainsafe.io',
+        consensusRpc: 'https://ethereum.operationsolarstorm.org',
         network: 'mainnet',
         checkpoint: "0x..."
       }, 'ethereum');
@@ -82,7 +82,7 @@ For a quick test, you can try Helios directly in an HTML file using a CDN like u
     async function main() {
       const provider = await createHeliosProvider({
         executionRpc: 'https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY',
-        consensusRpc: 'https://lodestar-mainnet.chainsafe.io',
+        consensusRpc: 'https://ethereum.operationsolarstorm.org',
         network: 'mainnet',
         checkpoint: "0x..."
       }, 'ethereum');

--- a/helios-ts/index.html
+++ b/helios-ts/index.html
@@ -187,7 +187,6 @@
       }
 
       (async () => {
-        await helios.init();
         const key = "<ALCHEMY_KEY>";
 
         window.networks = [
@@ -231,11 +230,11 @@
           },
         ];
 
-        // Sync each network and attach ethers provider
+        // Create providers for each network and attach ethers provider
         await Promise.all(
           window.networks.map((n) =>
             (async () => {
-              n.provider = new helios.HeliosProvider(n.cfg, n.kind);
+              n.provider = await helios.createHeliosProvider(n.cfg, n.kind);
               n.ethers = new ethers.providers.Web3Provider(n.provider);
             })()
           )

--- a/helios-ts/index.html
+++ b/helios-ts/index.html
@@ -196,7 +196,7 @@
             cfg: {
               executionRpc: `https://eth-mainnet.g.alchemy.com/v2/${key}`,
               checkpoint:
-                "0x8272e1969bc4e6f7f90c2510775af261adc153606d4a30b95bf87bbf0ccee712",
+                "0x872dbe854d76a78fd22c8c7f2e157467a1604f585785e5e6fbbc2987c1b1980e",
               dbType: "localstorage",
             },
             kind: "ethereum",

--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -18,7 +18,7 @@ async function ensureInitialized() {
  */
 export async function createHeliosProvider(config: Config, kind: "ethereum" | "opstack"): Promise<HeliosProvider> {
   await ensureInitialized();
-  return HeliosProvider.create(config, kind);
+  return HeliosProvider.createInternal(config, kind);
 }
 
 /// An EIP-1193 compliant Ethereum provider. Treat this the same as you
@@ -60,9 +60,11 @@ export class HeliosProvider {
     this.#eventEmitter = new EventEmitter();
   }
 
-  static create(config: Config, kind: "ethereum" | "opstack"): HeliosProvider {
+  /** @internal */
+  static createInternal(config: Config, kind: "ethereum" | "opstack"): HeliosProvider {
     return new HeliosProvider(config, kind);
   }
+
 
   async waitSynced() {
     await this.#client.wait_synced();

--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -2,13 +2,13 @@ import { EventEmitter } from "eventemitter3";
 import { v4 as uuidv4 } from "uuid";
 import initWasm, { EthereumClient, OpStackClient, LineaClient } from "./pkg";
 
-let isInitialized = false;
+let initPromise: Promise<any> | null = null;
 
 async function ensureInitialized() {
-  if (!isInitialized) {
-    await initWasm();
-    isInitialized = true;
+  if (!initPromise) {
+    initPromise = initWasm();
   }
+  await initPromise;
 }
 
 /**

--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -2,8 +2,23 @@ import { EventEmitter } from "eventemitter3";
 import { v4 as uuidv4 } from "uuid";
 import initWasm, { EthereumClient, OpStackClient, LineaClient } from "./pkg";
 
-export async function init() {
-  await initWasm();
+let isInitialized = false;
+
+async function ensureInitialized() {
+  if (!isInitialized) {
+    await initWasm();
+    isInitialized = true;
+  }
+}
+
+/**
+ * Creates a new HeliosProvider instance.
+ * An EIP-1193 compliant Ethereum provider. Treat this the same as you
+ * would window.ethereum when constructing an ethers or web3 provider.
+ */
+export async function createHeliosProvider(config: Config, kind: "ethereum" | "opstack"): Promise<HeliosProvider> {
+  await ensureInitialized();
+  return HeliosProvider.create(config, kind);
 }
 
 /// An EIP-1193 compliant Ethereum provider. Treat this the same as you
@@ -13,7 +28,7 @@ export class HeliosProvider {
   #chainId;
   #eventEmitter;
 
-  constructor(config: Config, kind: "ethereum" | "opstack") {
+  private constructor(config: Config, kind: "ethereum" | "opstack") {
     const executionRpc = config.executionRpc;
     const verifiableApi = config.verifiableApi;
 
@@ -43,6 +58,10 @@ export class HeliosProvider {
 
     this.#chainId = this.#client.chain_id();
     this.#eventEmitter = new EventEmitter();
+  }
+
+  static create(config: Config, kind: "ethereum" | "opstack"): HeliosProvider {
+    return new HeliosProvider(config, kind);
   }
 
   async waitSynced() {

--- a/helios-ts/package-lock.json
+++ b/helios-ts/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "helios",
-  "version": "0.1.0",
+  "name": "@a16z/helios",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "helios",
-      "version": "0.1.0",
-      "license": "ISC",
+      "name": "@a16z/helios",
+      "version": "0.8.8",
+      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "uuid": "^11.0.5"

--- a/helios-ts/tsconfig.json
+++ b/helios-ts/tsconfig.json
@@ -15,6 +15,6 @@
   "exclude": [
     "node_modules",
     "dist",
-    "src",
+    "src"
   ]
 }


### PR DESCRIPTION
## Summary
- Simplified Helios TypeScript initialization by introducing automatic WASM initialization
- Added `createHeliosProvider` function as the primary entry point for creating providers
- Made `HeliosProvider` constructor private to enforce proper initialization pattern

## Changes
- **New API**: Added `createHeliosProvider` async function that handles WASM initialization internally
- **Automatic initialization**: Implemented singleton pattern to ensure WASM is initialized only once
- **Private constructor**: Made `HeliosProvider` constructor private and added static `create` method
- **Documentation updates**: Updated README.md with clearer examples using the new API pattern
- **Demo updates**: Updated index.html to demonstrate the new initialization approach
- **Package metadata**: Fixed package name and license in package-lock.json
- **Config cleanup**: Removed trailing comma in tsconfig.json

## Benefits
- **Simpler API**: Users no longer need to manually call `init()` before creating providers
- **Better ergonomics**: Single function call to create and initialize providers
- **Prevents errors**: Automatic initialization prevents "WASM not initialized" errors
- **Cleaner code**: Less boilerplate for users integrating Helios