### PR TITLE
fix: remove spawn_blocking for payload_to_block conversions

### DIFF
--- a/helios-ts/index.html
+++ b/helios-ts/index.html
@@ -187,7 +187,7 @@
       }
 
       (async () => {
-        const key = "<ALCHEMY KEY>";
+        const key = "<ALCHEMY_KEY>";
 
         window.networks = [
           {

--- a/helios-ts/index.html
+++ b/helios-ts/index.html
@@ -187,7 +187,7 @@
       }
 
       (async () => {
-        const key = "<ALCHEMY_KEY>";
+        const key = "<ALCHEMY KEY>";
 
         window.networks = [
           {


### PR DESCRIPTION
## Summary
- Removed tokio::task::spawn_blocking usage in consensus module for payload_to_block conversions
- Fixes WASM compatibility issues since spawn_blocking is not supported in WASM environments

## Changes
- **consensus.rs**: Removed spawn_blocking wrappers around payload_to_block calls
- The function is now called directly, simplifying the code

## Context
The `tokio::task::spawn_blocking` function is designed to move CPU-intensive work off the async runtime to dedicated threads. However, this functionality is not available in WASM environments which don't have access to OS-level threads. By removing these spawn_blocking calls, the code now works correctly in both native and WASM builds.