### PR TITLE
chore: fix unused import warnings in WASM builds

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -1,5 +1,8 @@
-use std::{net::SocketAddr, ops::Deref, sync::Arc};
+use std::{ops::Deref, sync::Arc};
+#[cfg(not(target_arch = "wasm32"))]
+use std::net::SocketAddr;
 
+#[cfg(not(target_arch = "wasm32"))]
 use futures::future::pending;
 use helios_common::{
     execution_provider::ExecutionProivder, fork_schedule::ForkSchedule, network_spec::NetworkSpec,
@@ -26,10 +29,10 @@ impl<N: NetworkSpec> HeliosClient<N> {
         #[cfg(not(target_arch = "wasm32"))] rpc_address: Option<SocketAddr>,
     ) -> Self {
         let inner = Arc::new(Node::new(consensus, execution, fork_schedule));
-        let inner_ref = inner.clone();
 
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(rpc_address) = rpc_address {
+            let inner_ref = inner.clone();
             tokio::spawn(async move {
                 let _handle = jsonrpc::start(inner_ref, rpc_address).await;
                 let () = pending().await;

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -1,6 +1,6 @@
-use std::{ops::Deref, sync::Arc};
 #[cfg(not(target_arch = "wasm32"))]
 use std::net::SocketAddr;
+use std::{ops::Deref, sync::Arc};
 
 #[cfg(not(target_arch = "wasm32"))]
 use futures::future::pending;

--- a/ethereum/src/config/checkpoints.rs
+++ b/ethereum/src/config/checkpoints.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Duration;
 
 use alloy::primitives::B256;
 use eyre::Result;


### PR DESCRIPTION
## Summary
- Fixes unused import warnings when building for WASM targets
- Adds conditional compilation attributes to imports only used in non-WASM code paths

## Changes
- **core/src/client/mod.rs**: 
  - Conditionally import `SocketAddr` with `#[cfg(not(target_arch = "wasm32"))]`
  - Move `inner_ref` clone inside the non-WASM block where it's used
- **ethereum/src/config/checkpoints.rs**: 
  - Conditionally import `Duration` which is only used in non-WASM code
- **verifiable-api/client/src/http.rs**: 
  - Conditionally import `Duration`
  - Scope `client_ref` and `base_url_str` variables inside non-WASM block

## Impact
This change eliminates compiler warnings when building for WASM targets, improving the development experience and ensuring cleaner builds. No functional changes are made - this is purely a code hygiene improvement.