### PR TITLE
chore: update gitignore with development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,15 @@ helios-ts/pkg
 helios-ts/LICENSE
 
 .vscode
+
 CLAUDE.md
+.dockerignore
+.CLAUDE_SESIONS.md
+CLAUDE_DOCKER_README.md
+CLAUDE_SESSIONS.md
+Dockerfile.claude
+claude-docker.sh
+docker-compose.claude.yml
+worktrees/
+
+RELEASE_NOTES_*


### PR DESCRIPTION
## Summary

Update .gitignore to exclude various development-related files from version control.

## Changes

- Added Docker configuration files used for development environments
- Added session tracking and release notes files
- Added worktrees directory exclusion
- Properly formatted existing entries

## Motivation

These files are specific to individual development setups and should not be tracked in the repository to keep it clean and avoid unnecessary commits.