### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ autobenches = false
 exclude = ["benches"]
 
 [workspace.package]
-version = "0.8.8"
+version = "0.9.0"
 
 [workspace]
 members = [

--- a/helios-ts/Cargo.toml
+++ b/helios-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helios-ts"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/helios-ts/package.json
+++ b/helios-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@a16z/helios",
   "description": "A fast, secure, and portable multichain light client for Ethereum",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.mjs",
   "types": "./dist/lib.d.ts",

--- a/revm-utils/Cargo.toml
+++ b/revm-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helios-revm-utils"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Utilities for integrating REVM with Helios"
 

--- a/tests/test-utils/Cargo.toml
+++ b/tests/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helios-test-utils"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/verifiable-api/client/Cargo.toml
+++ b/verifiable-api/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helios-verifiable-api-client"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/verifiable-api/server/Cargo.toml
+++ b/verifiable-api/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helios-verifiable-api-server"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [[bin]]

--- a/verifiable-api/types/Cargo.toml
+++ b/verifiable-api/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helios-verifiable-api-types"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Bump Helios version from 0.8.8 to 0.9.0 across all workspace members.

## Changes

- Updated workspace version in root `Cargo.toml` from 0.8.8 to 0.9.0
- Converted all crate versions to inherit from workspace version:
  - `helios-ts`
  - `helios-revm-utils`
  - `helios-test-utils`
  - `helios-verifiable-api-client`
  - `helios-verifiable-api-server`
  - `helios-verifiable-api-types`
- Updated `helios-ts` npm package version to 0.9.0 in `package.json`

## Benefits

This change standardizes version management across all workspace members, making future version bumps simpler and ensuring all crates stay in sync.