### PR TITLE
fix: prevent historical provider queries for block tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3582,7 +3582,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helios"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "criterion",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "helios-cli"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "helios-common"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "helios-consensus-core"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "helios-core"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "alloy-trie",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "helios-ethereum"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "alloy-trie",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "helios-linea"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "helios-opstack"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "helios-revm-utils"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "eyre",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "helios-test-utils"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "helios-common",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "helios-ts"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "console_error_panic_hook",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "helios-verifiable-api-client"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "helios-verifiable-api-server"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "helios-verifiable-api-types"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "alloy",
  "helios-common",

--- a/core/src/execution/providers/rpc.rs
+++ b/core/src/execution/providers/rpc.rs
@@ -260,9 +260,9 @@ impl<N: NetworkSpec, B: BlockProvider<N>, H: HistoricalBlockProvider<N>> BlockPr
             return Ok(Some(block));
         }
 
-        // 2. Try historical provider if available and not requesting latest
+        // 2. Try historical provider if available and only for block numbers or hashes (not tags)
         if let Some(historical) = &self.historical_provider {
-            if block_id != BlockNumberOrTag::Latest.into() {
+            if super::utils::should_use_historical_provider(&block_id) {
                 if let Some(block) = historical
                     .get_historical_block(block_id, full_tx, self)
                     .await?
@@ -273,7 +273,6 @@ impl<N: NetworkSpec, B: BlockProvider<N>, H: HistoricalBlockProvider<N>> BlockPr
             }
         }
 
-        // 3. No historical block found
         Ok(None)
     }
 

--- a/core/src/execution/providers/utils.rs
+++ b/core/src/execution/providers/utils.rs
@@ -1,7 +1,18 @@
-use alloy::rpc::types::{Filter, Log};
+use alloy::rpc::types::{BlockId, BlockNumberOrTag, Filter, Log};
 use eyre::Result;
 
 use crate::execution::errors::ExecutionError;
+
+/// Determines if a block ID should be fetched from the historical provider.
+/// Historical providers should only be used for specific block numbers or hashes,
+/// never for block tags like Latest, Safe, Finalized, etc.
+pub fn should_use_historical_provider(block_id: &BlockId) -> bool {
+    match block_id {
+        BlockId::Number(BlockNumberOrTag::Number(_)) => true,
+        BlockId::Hash(_) => true,
+        _ => false, // Don't use for Latest, Safe, Finalized, Pending, Earliest
+    }
+}
 
 pub fn ensure_logs_match_filter(logs: &[Log], filter: &Filter) -> Result<()> {
     fn log_matches_filter(log: &Log, filter: &Filter) -> bool {

--- a/core/src/execution/providers/verifiable_api.rs
+++ b/core/src/execution/providers/verifiable_api.rs
@@ -2,7 +2,7 @@ use std::collections::{hash_map::Entry, HashMap, HashSet};
 
 use alloy::{
     consensus::BlockHeader,
-    eips::{BlockId, BlockNumberOrTag},
+    eips::BlockId,
     network::{primitives::HeaderResponse, BlockResponse, ReceiptResponse, TransactionResponse},
     primitives::{Address, B256, U256},
     rlp,
@@ -150,9 +150,9 @@ impl<N: NetworkSpec, B: BlockProvider<N>, H: HistoricalBlockProvider<N>> BlockPr
             return Ok(Some(block));
         }
 
-        // 2. Try historical provider if available and not requesting latest
+        // 2. Try historical provider if available and only for block numbers or hashes (not tags)
         if let Some(historical) = &self.historical_provider {
-            if block_id != BlockNumberOrTag::Latest.into() {
+            if super::utils::should_use_historical_provider(&block_id) {
                 if let Some(block) = historical
                     .get_historical_block(block_id, full_tx, self)
                     .await?


### PR DESCRIPTION
## Summary
This PR fixes an issue where block tag queries (Latest, Safe, Finalized, etc.) were being routed to historical providers, which could return outdated information. Historical providers should only be used for specific block numbers or hashes.

## Changes
- Added `should_use_historical_provider` utility function to determine when to use historical providers
- Updated `rpc.rs` to use the new utility function instead of checking only for Latest
- Updated `verifiable_api.rs` to use the same logic for consistency
- Historical providers are now only used for:
  - Specific block numbers (BlockId::Number with a numeric value)
  - Block hashes (BlockId::Hash)
- Block tags (Latest, Safe, Finalized, Pending, Earliest) now always use the current provider

## Test plan
- [x] Run `cargo fmt` to ensure consistent formatting
- [x] Run all tests with `MAINNET_EXECUTION_RPC` to verify functionality
- [x] All existing tests pass without modification