### PR TITLE
Replace deprecated actions-rs/toolchain@v1 with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,11 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,11 +24,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
+        uses: dtolnay/rust-toolchain@stable
         
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          default: true
-          override: true
-
-      - name: install target
-        run: rustup target add aarch64-apple-darwin
+          targets: aarch64-apple-darwin
 
       - uses: Swatinem/rust-cache@v2
 
@@ -50,14 +45,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          default: true
-          override: true
-
-      - name: install target
-        run: rustup target add x86_64-apple-darwin
+          targets: x86_64-apple-darwin
 
       - uses: Swatinem/rust-cache@v2
 
@@ -89,14 +79,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          default: true
-          override: true
-
-      - name: install target
-        run: rustup target add aarch64-unknown-linux-gnu
+          targets: aarch64-unknown-linux-gnu
 
       - name: install dependencies
         run: |
@@ -134,14 +119,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          default: true
-          override: true
-
-      - name: install target
-        run: rustup target add x86_64-unknown-linux-gnu
+          targets: x86_64-unknown-linux-gnu
 
       - uses: Swatinem/rust-cache@v2
 
@@ -173,14 +153,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          default: true
-          override: true
-
-      - name: install target
-        run: rustup target add armv7-unknown-linux-gnueabihf
+          targets: armv7-unknown-linux-gnueabihf
 
       - name: install dependencies
         run: |
@@ -221,14 +196,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          default: true
-          override: true
-
-      - name: install target
-        run: rustup target add riscv64gc-unknown-linux-gnu
+          targets: riscv64gc-unknown-linux-gnu
 
       - name: install dependencies
         run: |
@@ -274,11 +244,7 @@ jobs:
           node-version: '20'
 
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
@@ -30,11 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install libfont
         run: sudo apt install libfontconfig libfontconfig1-dev
@@ -47,11 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
@@ -63,11 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
@@ -78,14 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - name: Add wasm target
-        run: rustup target add wasm32-unknown-unknown
       - name: Check wasm compatibility
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Replace deprecated actions-rs/toolchain@v1 with dtolnay/rust-toolchain

The actions-rs/toolchain@v1 action is deprecated and uses Node.js 12. This PR replaces it with the maintained dtolnay/rust-toolchain action across all GitHub workflows.