### PR TITLE
fix: disable alloy default features on helios-consensus-core

### DIFF
--- a/ethereum/consensus-core/Cargo.toml
+++ b/ethereum/consensus-core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # Don't inherit workspace version to not inherit all of the features defined in the workspace
-alloy = { version = "1.0.3", features = [
+alloy = { version = "1.0.3", default-features = false, features = [
     "consensus",
     "rpc-types",
     "ssz",


### PR DESCRIPTION
Since Alloy v0.11, there is a new default `essentials` feature, that add a dependency to `alloy-provider`, that in turn bring Tokio in the dependency tree.

This cause build to fail in the sp1-helios zkVM client program because it has a dependency to `helios-consensus-core` that bring the above.

So I added  `default-features = false` to `helios-consensus-core` Alloy dep.