### PR TITLE
chore: update string formatting to use inline variables

### DIFF
--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -166,6 +166,6 @@ fn get_chain_name(chain_id: u64) -> String {
         84532 => "Base Sepolia".to_string(),
         59144 => "Linea Mainnet".to_string(),
         59141 => "Linea Sepolia".to_string(),
-        _ => format!("Chain {}", chain_id),
+        _ => format!("Chain {chain_id}"),
     }
 }

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -60,7 +60,7 @@ pub async fn run<N: NetworkSpec>(client: HeliosClient<N>) -> Result<(), io::Erro
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        eprintln!("{:?}", err);
+        eprintln!("{err:?}");
     }
 
     Ok(())

--- a/cli/src/tui/ui.rs
+++ b/cli/src/tui/ui.rs
@@ -58,8 +58,8 @@ fn draw_header<N: NetworkSpec>(f: &mut Frame, app: &App<N>, area: Rect) {
         Span::raw("Helios - "),
         Span::styled(&app.chain_name, Style::default().fg(Color::Cyan)),
         Span::raw("  |  Status: "),
-        Span::styled(format!("{} {}", status_text, status_symbol), status_style),
-        Span::raw(format!("  |  Uptime: {}h {}m {}s", hours, minutes, seconds)),
+        Span::styled(format!("{status_text} {status_symbol}"), status_style),
+        Span::raw(format!("  |  Uptime: {hours}h {minutes}m {seconds}s")),
     ])];
 
     let header = Paragraph::new(header_text)
@@ -307,10 +307,7 @@ fn create_gas_line(gas_percentage: u8, gas_used: u64, gas_limit: u64) -> Line<'s
     let gas_color = get_gas_color(gas_percentage);
     Line::from(vec![
         Span::raw("Gas:      "),
-        Span::styled(
-            format!("{}%", gas_percentage),
-            Style::default().fg(gas_color),
-        ),
+        Span::styled(format!("{gas_percentage}%"), Style::default().fg(gas_color)),
         Span::raw(" "),
         Span::styled(
             format!("({}/{})", format_gas(gas_used), format_gas(gas_limit)),

--- a/ethereum/src/config/networks.rs
+++ b/ethereum/src/config/networks.rs
@@ -261,9 +261,7 @@ pub fn hoodi() -> BaseConfig {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn data_dir(network: Network) -> PathBuf {
-    home_dir()
-        .unwrap()
-        .join(format!(".helios/data/{}", network))
+    home_dir().unwrap().join(format!(".helios/data/{network}"))
 }
 
 pub struct EthereumForkSchedule;

--- a/ethereum/src/evm.rs
+++ b/ethereum/src/evm.rs
@@ -80,7 +80,7 @@ impl<E: ExecutionProivder<Ethereum>> EthereumEvm<E> {
             }
         };
 
-        tx_res.map_err(|err| EvmError::Generic(format!("generic: {}", err)))
+        tx_res.map_err(|err| EvmError::Generic(format!("generic: {err}")))
     }
 
     async fn get_context(

--- a/ethereum/src/rpc/mock_rpc.rs
+++ b/ethereum/src/rpc/mock_rpc.rs
@@ -67,7 +67,7 @@ impl<S: ConsensusSpec> ConsensusRpc<S> for MockRpc {
     }
 
     async fn get_block(&self, slot: u64) -> Result<BeaconBlock<S>> {
-        let path = self.testdata.join(format!("blocks/{}.json", slot));
+        let path = self.testdata.join(format!("blocks/{slot}.json"));
         let res = read_to_string(path)?;
         let block: BeaconBlockResponse<S> = serde_json::from_str(&res)?;
         Ok(block.data.message)

--- a/helios-ts/src/ethereum.rs
+++ b/helios-ts/src/ethereum.rs
@@ -77,7 +77,7 @@ impl EthereumClient {
             "mainnet" => networks::mainnet(),
             "sepolia" => networks::sepolia(),
             "holesky" => networks::holesky(),
-            other => Err(JsError::new(&format!("invalid network: {}", other)))?,
+            other => Err(JsError::new(&format!("invalid network: {other}")))?,
         };
 
         let chain_id = base.chain.chain_id;
@@ -92,7 +92,7 @@ impl EthereumClient {
 
         let consensus_rpc = if let Some(rpc) = consensus_rpc {
             Url::parse(&rpc)
-                .map_err(|e| JsError::new(&format!("Invalid consensus RPC URL: {}", e)))?
+                .map_err(|e| JsError::new(&format!("Invalid consensus RPC URL: {e}")))?
         } else {
             base.consensus_rpc
                 .ok_or(JsError::new("consensus rpc not found"))?
@@ -101,12 +101,12 @@ impl EthereumClient {
         let execution_rpc = execution_rpc
             .map(|url| Url::parse(&url))
             .transpose()
-            .map_err(|e| JsError::new(&format!("Invalid execution RPC URL: {}", e)))?;
+            .map_err(|e| JsError::new(&format!("Invalid execution RPC URL: {e}")))?;
 
         let verifiable_api = verifiable_api
             .map(|url| Url::parse(&url))
             .transpose()
-            .map_err(|e| JsError::new(&format!("Invalid verifiable API URL: {}", e)))?;
+            .map_err(|e| JsError::new(&format!("Invalid verifiable API URL: {e}")))?;
 
         let config = Config {
             execution_rpc,

--- a/helios-ts/src/linea.rs
+++ b/helios-ts/src/linea.rs
@@ -38,7 +38,7 @@ impl LineaClient {
             "sepolia" => helios_linea::config::sepolia(),
             "linea-mainnet" => helios_linea::config::mainnet(),
             "linea-sepolia" => helios_linea::config::sepolia(),
-            other => Err(JsError::new(&format!("invalid network: {}", other)))?,
+            other => Err(JsError::new(&format!("invalid network: {other}")))?,
         };
 
         let chain_id = network_config.chain.chain_id;
@@ -47,7 +47,7 @@ impl LineaClient {
         };
 
         let execution_rpc = Url::parse(&execution_rpc_str)
-            .map_err(|e| JsError::new(&format!("Invalid execution RPC URL: {}", e)))?;
+            .map_err(|e| JsError::new(&format!("Invalid execution RPC URL: {e}")))?;
 
         let config = Config {
             execution_rpc,

--- a/helios-ts/src/opstack.rs
+++ b/helios-ts/src/opstack.rs
@@ -44,7 +44,7 @@ impl OpStackClient {
             "worldchain" => NetworkConfig::from(Network::Worldchain),
             "zora" => NetworkConfig::from(Network::Zora),
             "unichain" => NetworkConfig::from(Network::Unichain),
-            other => Err(JsError::new(&format!("invalid network: {}", other)))?,
+            other => Err(JsError::new(&format!("invalid network: {other}")))?,
         };
 
         let chain_id = network_config.chain.chain_id;
@@ -55,12 +55,12 @@ impl OpStackClient {
         let execution_rpc = execution_rpc
             .map(|url| Url::parse(&url))
             .transpose()
-            .map_err(|e| JsError::new(&format!("Invalid execution RPC URL: {}", e)))?;
+            .map_err(|e| JsError::new(&format!("Invalid execution RPC URL: {e}")))?;
 
         let verifiable_api = verifiable_api
             .map(|url| Url::parse(&url))
             .transpose()
-            .map_err(|e| JsError::new(&format!("Invalid verifiable API URL: {}", e)))?;
+            .map_err(|e| JsError::new(&format!("Invalid verifiable API URL: {e}")))?;
 
         let config = Config {
             execution_rpc,

--- a/opstack/src/evm.rs
+++ b/opstack/src/evm.rs
@@ -84,7 +84,7 @@ impl<E: ExecutionProivder<OpStack>> OpStackEvm<E> {
             }
         };
 
-        tx_res.map_err(|err| EvmError::Generic(format!("generic: {}", err)))
+        tx_res.map_err(|err| EvmError::Generic(format!("generic: {err}")))
     }
 
     async fn get_context(

--- a/opstack/src/server/net/block_handler.rs
+++ b/opstack/src/server/net/block_handler.rs
@@ -17,7 +17,7 @@ impl BlockHandler {
             chain_id,
             signer,
             commitment_sender: sender,
-            blocks_v3_topic: IdentTopic::new(format!("/optimism/{}/2/blocks", chain_id)),
+            blocks_v3_topic: IdentTopic::new(format!("/optimism/{chain_id}/2/blocks")),
         }
     }
 

--- a/verifiable-api/client/src/http.rs
+++ b/verifiable-api/client/src/http.rs
@@ -91,7 +91,7 @@ impl<N: NetworkSpec> VerifiableApi<N> for HttpVerifiableApi<N> {
     ) -> Result<AccountResponse> {
         let url = self
             .base_url
-            .join(&format!("eth/v1/proof/account/{}", address))
+            .join(&format!("eth/v1/proof/account/{address}"))
             .map_err(|e| eyre!("Failed to construct account URL: {}", e))?;
         let mut request = self.client.get(url.as_str());
         if let Some(block_id) = block_id {
@@ -111,7 +111,7 @@ impl<N: NetworkSpec> VerifiableApi<N> for HttpVerifiableApi<N> {
     ) -> Result<Option<TransactionReceiptResponse<N>>> {
         let url = self
             .base_url
-            .join(&format!("eth/v1/proof/receipt/{}", tx_hash))
+            .join(&format!("eth/v1/proof/receipt/{tx_hash}"))
             .map_err(|e| eyre!("Failed to construct receipt URL: {}", e))?;
         let response = self.client.get(url.as_str()).send().await?;
         handle_response(response).await
@@ -120,7 +120,7 @@ impl<N: NetworkSpec> VerifiableApi<N> for HttpVerifiableApi<N> {
     async fn get_transaction(&self, tx_hash: B256) -> Result<Option<TransactionResponse<N>>> {
         let url = self
             .base_url
-            .join(&format!("eth/v1/proof/transaction/{}", tx_hash))
+            .join(&format!("eth/v1/proof/transaction/{tx_hash}"))
             .map_err(|e| eyre!("Failed to construct transaction URL: {}", e))?;
         let response = self.client.get(url.as_str()).send().await?;
         handle_response(response).await
@@ -175,11 +175,11 @@ impl<N: NetworkSpec> VerifiableApi<N> for HttpVerifiableApi<N> {
             if let Some(topics) = filter.topics[idx].to_value_or_array() {
                 match topics {
                     ValueOrArray::Value(topic) => {
-                        request = request.query(&[(format!("topic{}", idx), topic)]);
+                        request = request.query(&[(format!("topic{idx}"), topic)]);
                     }
                     ValueOrArray::Array(topics) => {
                         for topic in topics {
-                            request = request.query(&[(format!("topic{}", idx), topic)]);
+                            request = request.query(&[(format!("topic{idx}"), topic)]);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Updated format\! macro calls to use inline variable syntax as recommended by latest Rust clippy lints
- Replaced manual parameter passing with cleaner inline formatting across multiple modules
- Improves code readability and follows modern Rust conventions

## Changes
- Updated format\! calls in cli/src/tui modules
- Fixed string formatting in ethereum/src modules
- Updated opstack/src modules to use inline variables
- Applied consistent formatting in verifiable-api/client/src/http.rs