### PR TITLE
expose eyre

### DIFF
--- a/ethereum/src/lib.rs
+++ b/ethereum/src/lib.rs
@@ -13,3 +13,4 @@ mod constants;
 
 pub use builder::EthereumClientBuilder;
 pub type EthereumClient = HeliosClient<Ethereum>;
+pub use eyre;


### PR DESCRIPTION
Currently dependents have to add a `eyre` dependency for [handling](https://github.com/zemse/gm/blob/abeaccaf058d83358faba08dacee140871b5bc51/src/error.rs#L50) the errors.

Exposing the error library would be very helpful.