### PR TITLE
Refactor: Rename ExecutionProvider Type Parameter in proof_db.rs

### DIFF
--- a/revm-utils/src/proof_db.rs
+++ b/revm-utils/src/proof_db.rs
@@ -13,7 +13,7 @@ use revm::{
 use tracing::trace;
 
 use helios_common::{
-    execution_provider::ExecutionProivder,
+    execution_provider::ExecutionProvider,
     network_spec::NetworkSpec,
     types::{Account, EvmError},
 };
@@ -21,11 +21,11 @@ use helios_core::execution::errors::ExecutionError;
 
 use crate::types::DatabaseError;
 
-pub struct ProofDB<N: NetworkSpec, E: ExecutionProivder<N>> {
+pub struct ProofDB<N: NetworkSpec, E: ExecutionProvider<N>> {
     pub state: EvmState<N, E>,
 }
 
-impl<N: NetworkSpec, E: ExecutionProivder<N>> ProofDB<N, E> {
+impl<N: NetworkSpec, E: ExecutionProvider<N>> ProofDB<N, E> {
     pub fn new(block_id: BlockId, execution: Arc<E>) -> Self {
         let state = EvmState::new(execution, block_id);
         ProofDB { state }
@@ -39,7 +39,7 @@ pub enum StateAccess {
     Storage(Address, U256),
 }
 
-pub struct EvmState<N: NetworkSpec, E: ExecutionProivder<N>> {
+pub struct EvmState<N: NetworkSpec, E: ExecutionProvider<N>> {
     pub accounts: HashMap<Address, Account>,
     pub block_hash: HashMap<u64, B256>,
     pub block: BlockId,
@@ -48,7 +48,7 @@ pub struct EvmState<N: NetworkSpec, E: ExecutionProivder<N>> {
     pub phantom: PhantomData<N>,
 }
 
-impl<N: NetworkSpec, E: ExecutionProivder<N>> EvmState<N, E> {
+impl<N: NetworkSpec, E: ExecutionProvider<N>> EvmState<N, E> {
     pub fn new(execution: Arc<E>, block: BlockId) -> Self {
         Self {
             execution,
@@ -162,7 +162,7 @@ impl<N: NetworkSpec, E: ExecutionProivder<N>> EvmState<N, E> {
     }
 }
 
-impl<N: NetworkSpec, E: ExecutionProivder<N>> Database for ProofDB<N, E> {
+impl<N: NetworkSpec, E: ExecutionProvider<N>> Database for ProofDB<N, E> {
     type Error = DatabaseError;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, DatabaseError> {


### PR DESCRIPTION



**Description:**  
- Updated all references from `ExecutionProvider` to `ExecutionProvider` in `proof_db.rs` for improved clarity and consistency.
- Adjusted struct and impl definitions accordingly.
