### PR TITLE
Replace Vec::new() with vec![] in poller.rs

### DIFF
--- a/opstack/src/server/poller.rs
+++ b/opstack/src/server/poller.rs
@@ -17,7 +17,7 @@ pub fn start(urls: Vec<Url>, signer: Address, chain_id: u64, sender: Sender<Sequ
             .build()
             .unwrap();
 
-        let mut final_urls = Vec::new();
+        let mut final_urls = vec![];
         for url in urls {
             if let Ok(replica_chain_id) = get_chain_id(&client, &url).await {
                 if chain_id == replica_chain_id {


### PR DESCRIPTION
Replaced Vec::new() with vec![] to follow Rust idiomatic style for creating empty vectors. This change improves code readability while maintaining identical functionality.