### PR TITLE
Fix: avoid panic in `get_context` when `get_block` returns error or None

### DIFF
--- a/tests/rpc_equivalence.rs
+++ b/tests/rpc_equivalence.rs
@@ -991,6 +991,29 @@ async fn test_get_historical_block(helios: &RootProvider, expected: &RootProvide
     Ok(())
 }
 
+async fn test_get_too_old_block(helios: &RootProvider, expected: &RootProvider) -> Result<()> {
+    let latest_block = expected.get_block_number().await?;
+    let latest_block_num = latest_block;
+
+    let old_block_num = latest_block_num.saturating_sub(20000);
+
+    let helios_block = helios.get_block_by_number(old_block_num.into()).await?;
+
+    ensure!(
+        helios_block.is_none(),
+        "Helios should return None for a block outside the proof window"
+    );
+
+    let expected_block = expected.get_block_by_number(old_block_num.into()).await?;
+
+    ensure!(
+        expected_block.is_some(),
+        "The trusted provider should have returned the historical block"
+    );
+
+    Ok(())
+}
+
 async fn test_get_historical_balance(helios: &RootProvider, expected: &RootProvider) -> Result<()> {
     let latest = helios.get_block_number().await?;
     let historical_block_num = latest.saturating_sub(100);
@@ -1430,6 +1453,7 @@ async fn rpc_equivalence_tests() {
         spawn_test!(test_get_logs_block_range, "get_logs_block_range"),
         // Historical Data
         spawn_test!(test_get_historical_block, "get_historical_block"),
+        spawn_test!(test_get_too_old_block, "get_too_old_block"),
     ];
 
     // Collect results


### PR DESCRIPTION
This PR fixes a panic in `get_context` that occurred when the underlying `get_block` call either returned an error or `None`.

Previously, `get_context` called `.unwrap()` on the result of `get_block`, which caused to panic

## Changes

- **ethereum/src/evm.rs**: 
  - Modified `get_context()` to return `Result<Context, EvmError>`
  - Replaced `.unwrap()` calls with proper error handling using `map_err()` and `ok_or_else()`
  - Updated `transact_inner()` to handle the `Result` from `get_context()`
  
  ## Notes
- Existing tests don’t explicitly cover `get_context` failure paths; I would appreciate any feedback on how to handle this.
- This PR does not change the behavior of `get_block` or `get_historical_block`, and respects the existing context where `None` indicates a missing block.
  
  Fixes #627
