### PR TITLE
refactor(consensus): Align MaxBlsToExecutionChanges naming for consistency

### DIFF
--- a/ethereum/consensus-core/src/consensus_spec.rs
+++ b/ethereum/consensus-core/src/consensus_spec.rs
@@ -79,7 +79,7 @@ impl ConsensusSpec for MinimalConsensusSpec {
     type MaxValidatorsPerSlot = typenum::U8192;
     type MaxDeposits = typenum::U16;
     type MaxVoluntaryExits = typenum::U16;
-    type MaxBlsToExecutionChanged = typenum::U16;
+    type MaxBlsToExecutionChanges = typenum::U16;
     type MaxBlobKzgCommitments = typenum::U4096;
     type MaxWithdrawals = typenum::U16;
     type MaxValidatorsPerCommittee = typenum::U2048;

--- a/ethereum/consensus-core/src/types/mod.rs
+++ b/ethereum/consensus-core/src/types/mod.rs
@@ -87,7 +87,7 @@ pub struct BeaconBlockBody<S: ConsensusSpec> {
     sync_aggregate: SyncAggregate<S>,
     pub execution_payload: ExecutionPayload<S>,
     #[superstruct(only(Capella, Deneb, Electra))]
-    bls_to_execution_changes: VariableList<SignedBlsToExecutionChange, S::MaxBlsToExecutionChanged>,
+    bls_to_execution_changes: VariableList<SignedBlsToExecutionChange, S::MaxBlsToExecutionChanges>,
     #[superstruct(only(Deneb, Electra))]
     blob_kzg_commitments: VariableList<KZGCommitment, S::MaxBlobKzgCommitments>,
     #[superstruct(only(Electra))]


### PR DESCRIPTION
The generic type _`S::MaxBlsToExecutionChanged`_ was inconsistent with its corresponding field, _`bls_to_execution_changes`_. This broke the established naming pattern used by all other list-based fields in `BeaconBlockBody `(e.g., `MaxProposerSlashings`, [MaxAttestations](url)).