### PR TITLE
fix: throw proper `Error` object instead of raw string

### DIFF
--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -290,7 +290,7 @@ export class HeliosProvider {
         return this.#client.unsubscribe(req.params[0]);
       }
       default: {
-        throw `method not supported: ${req.method}`;
+        throw new Error(`method not supported: ${req.method}`);
       }
     }
   }


### PR DESCRIPTION
noticed we were throwing a plain string - switched it to a real `Error` object.
strings don’t carry stack traces, mess with `instanceof`, and make debugging harder than it should be. 

this should clean that up.
