### PR TITLE
Handle missing HOME in data_dir: fallback to temp_dir instead of unwrap

### DIFF
--- a/ethereum/src/config/networks.rs
+++ b/ethereum/src/config/networks.rs
@@ -261,7 +261,10 @@ pub fn hoodi() -> BaseConfig {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn data_dir(network: Network) -> PathBuf {
-    home_dir().unwrap().join(format!(".helios/data/{network}"))
+    match home_dir() {
+        Some(home) => home.join(format!(".helios/data/{network}")),
+        None => std::env::temp_dir().join(format!("helios/data/{network}")),
+    }
 }
 
 pub struct EthereumForkSchedule;


### PR DESCRIPTION


### Summary
- Replace `home_dir().unwrap()` with a safe match to prevent startup panics when `HOME` is unset.
- Default path remains `~/.helios/data/{network}`; when `HOME` is missing, use `tmp/helios/data/{network}`.
- Scope: `ethereum/src/config/networks.rs`

### Motivation
`dirs::home_dir()` can return `None` in containers, CI, and certain services. Using `unwrap()` caused an immediate panic during default config construction.

### Implementation
- Use `match home_dir()` and fall back to `std::env::temp_dir()` when `HOME` is not available.

