### PR TITLE
fix: add timeouts to HTTP client to prevent freezing

### DIFF
--- a/ethereum/src/rpc/http_rpc.rs
+++ b/ethereum/src/rpc/http_rpc.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
 use alloy::primitives::B256;
@@ -69,13 +70,19 @@ impl HttpRpc {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: ConsensusSpec> ConsensusRpc<S> for HttpRpc {
     fn new(rpc: &str) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30)) // Add request timeout
+            .connect_timeout(Duration::from_secs(10)) // Add connection timeout
+            .pool_idle_timeout(Duration::from_secs(60)) // Clean up idle connections
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::Client::new();
+
         HttpRpc {
-            client: reqwest::Client::builder()
-                .timeout(Duration::from_secs(30)) // Add request timeout
-                .connect_timeout(Duration::from_secs(10)) // Add connection timeout
-                .pool_idle_timeout(Duration::from_secs(60)) // Clean up idle connections
-                .build()
-                .unwrap_or_else(|_| reqwest::Client::new()),
+            client,
             rpc: rpc.trim_end_matches('/').to_string(),
         }
     }

--- a/ethereum/src/rpc/http_rpc.rs
+++ b/ethereum/src/rpc/http_rpc.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::time::Duration;
 
 use alloy::primitives::B256;
 use async_trait::async_trait;
@@ -69,7 +70,12 @@ impl HttpRpc {
 impl<S: ConsensusSpec> ConsensusRpc<S> for HttpRpc {
     fn new(rpc: &str) -> Self {
         HttpRpc {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30)) // Add request timeout
+                .connect_timeout(Duration::from_secs(10)) // Add connection timeout
+                .pool_idle_timeout(Duration::from_secs(60)) // Clean up idle connections
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             rpc: rpc.trim_end_matches('/').to_string(),
         }
     }


### PR DESCRIPTION
## Summary
- Adds proper timeout configuration to the HTTP client in `HttpRpc` to prevent indefinite hangs
- Fixes issue where Helios could freeze when running for extended periods

## Problem
When running Helios (specifically with Ethereum) for long periods, it sometimes freezes and stops following the chain. Analysis revealed that the HTTP client could hang indefinitely on network requests if the beacon node becomes unresponsive or network issues occur.

## Solution
Added timeout configuration to the reqwest HTTP client:
- **Request timeout**: 30 seconds - prevents individual requests from hanging indefinitely
- **Connection timeout**: 10 seconds - ensures connection establishment doesn't block forever  
- **Idle connection cleanup**: 60 seconds - prevents resource exhaustion from stale connections