### PR TITLE
fix: resolve import errors in benchmark files

### DIFF
--- a/benches/get_balance.rs
+++ b/benches/get_balance.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use alloy::primitives::Address;
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use helios_common::types::BlockTag;
+use alloy::eips::{BlockId, BlockNumberOrTag};
 
 mod harness;
 
@@ -29,7 +29,7 @@ pub fn bench_mainnet_get_balance(c: &mut Criterion) {
 
         // Get the beacon chain deposit contract address.
         let addr = Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa").unwrap();
-        let block = BlockTag::Latest;
+        let block = BlockId::Number(BlockNumberOrTag::Latest);
 
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {
@@ -61,7 +61,7 @@ pub fn bench_sepolia_get_balance(c: &mut Criterion) {
 
         // Get the beacon chain deposit contract address.
         let addr = Address::from_str("0x7b79995e5f793a07bc00c21412e50ecae098e7f9").unwrap();
-        let block = BlockTag::Latest;
+        let block = BlockId::Number(BlockNumberOrTag::Latest);
 
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {

--- a/benches/get_code.rs
+++ b/benches/get_code.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use alloy::primitives::Address;
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use helios_common::types::BlockTag;
+use alloy::eips::{BlockId, BlockNumberOrTag};
 
 mod harness;
 
@@ -29,7 +29,7 @@ pub fn bench_mainnet_get_code(c: &mut Criterion) {
 
         // Get the beacon chain deposit contract address.
         let addr = Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa").unwrap();
-        let block = BlockTag::Latest;
+        let block = BlockId::Number(BlockNumberOrTag::Latest);
 
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {
@@ -54,12 +54,14 @@ pub fn bench_sepolia_get_code(c: &mut Criterion) {
 
         // Get the beacon chain deposit contract address.
         let addr = Address::from_str("0x7b79995e5f793a07bc00c21412e50ecae098e7f9").unwrap();
-        let block = BlockTag::Latest;
 
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {
             let inner = std::sync::Arc::clone(&client);
-            inner.get_code(addr, block).await.unwrap()
+            inner
+                .get_code(addr, BlockId::Number(BlockNumberOrTag::Latest))
+                .await
+                .unwrap()
         })
     });
 }

--- a/benches/harness.rs
+++ b/benches/harness.rs
@@ -3,10 +3,9 @@ use std::{path::PathBuf, str::FromStr};
 
 use alloy::primitives::{Address, B256, U256};
 
-use helios_common::types::BlockTag;
+use alloy::eips::{BlockId, BlockNumberOrTag};
 use helios_ethereum::{
     config::{checkpoints, networks},
-    database::FileDB,
     EthereumClient, EthereumClientBuilder,
 };
 
@@ -31,23 +30,21 @@ pub async fn fetch_mainnet_checkpoint() -> eyre::Result<B256> {
 /// The client is parameterized with a [FileDB](client::FileDB).
 /// It will also use the environment variable `MAINNET_EXECUTION_RPC` to connect to a mainnet node.
 /// The client will use `https://www.lightclientdata.org` as the consensus RPC.
-pub fn construct_mainnet_client(
-    rt: &tokio::runtime::Runtime,
-) -> eyre::Result<EthereumClient<FileDB>> {
+pub fn construct_mainnet_client(rt: &tokio::runtime::Runtime) -> eyre::Result<EthereumClient> {
     rt.block_on(inner_construct_mainnet_client())
 }
 
-pub async fn inner_construct_mainnet_client() -> eyre::Result<EthereumClient<FileDB>> {
+pub async fn inner_construct_mainnet_client() -> eyre::Result<EthereumClient> {
     let benchmark_rpc_url = std::env::var("MAINNET_EXECUTION_RPC")?;
 
-    let mut client = EthereumClientBuilder::new()
+    let client = EthereumClientBuilder::new()
         .network(networks::Network::Mainnet)
         .consensus_rpc("https://www.lightclientdata.org")?
         .execution_rpc(&benchmark_rpc_url)?
         .load_external_fallback()
         .data_dir(PathBuf::from("/tmp/helios"))
+        .with_file_db()
         .build()?;
-    client.start().await?;
 
     // Wait for the client to be synced.
     client.wait_synced().await;
@@ -57,17 +54,17 @@ pub async fn inner_construct_mainnet_client() -> eyre::Result<EthereumClient<Fil
 
 pub async fn construct_mainnet_client_with_checkpoint(
     checkpoint: B256,
-) -> eyre::Result<EthereumClient<FileDB>> {
+) -> eyre::Result<EthereumClient> {
     let benchmark_rpc_url = std::env::var("MAINNET_EXECUTION_RPC")?;
 
-    let mut client = EthereumClientBuilder::new()
+    let client = EthereumClientBuilder::new()
         .network(networks::Network::Mainnet)
         .consensus_rpc("https://www.lightclientdata.org")?
         .execution_rpc(&benchmark_rpc_url)?
         .checkpoint(checkpoint)
         .data_dir(PathBuf::from("/tmp/helios"))
+        .with_file_db()
         .build()?;
-    client.start().await?;
 
     // Wait for the client to be synced.
     client.wait_synced().await;
@@ -93,19 +90,17 @@ pub fn construct_runtime() -> tokio::runtime::Runtime {
 /// The client is parameterized with a [FileDB](client::FileDB).
 /// It will also use the environment variable `SEPOLIA_EXECUTION_RPC` to connect to a mainnet node.
 /// The client will use `http://unstable.sepolia.beacon-api.nimbus.team/` as the consensus RPC.
-pub fn construct_sepolia_client(
-    rt: &tokio::runtime::Runtime,
-) -> eyre::Result<EthereumClient<FileDB>> {
+pub fn construct_sepolia_client(rt: &tokio::runtime::Runtime) -> eyre::Result<EthereumClient> {
     rt.block_on(async {
         let benchmark_rpc_url = std::env::var("SEPOLIA_EXECUTION_RPC")?;
-        let mut client = EthereumClientBuilder::new()
+        let client = EthereumClientBuilder::new()
             .network(networks::Network::Sepolia)
             .consensus_rpc("http://unstable.sepolia.beacon-api.nimbus.team/")?
             .execution_rpc(&benchmark_rpc_url)?
             .data_dir(PathBuf::from("/tmp/helios"))
+            .with_file_db()
             .load_external_fallback()
             .build()?;
-        client.start().await?;
 
         // Wait for the client to be synced.
         client.wait_synced().await;
@@ -117,11 +112,11 @@ pub fn construct_sepolia_client(
 /// Gets the balance of the given address on mainnet.
 pub fn get_balance(
     rt: &tokio::runtime::Runtime,
-    client: EthereumClient<FileDB>,
+    client: EthereumClient,
     address: &str,
 ) -> eyre::Result<U256> {
     rt.block_on(async {
-        let block = BlockTag::Latest;
+        let block = BlockId::Number(BlockNumberOrTag::Latest);
         let address = Address::from_str(address)?;
         client.get_balance(address, block).await
     })

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -1,7 +1,7 @@
 use alloy::primitives::Address;
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use helios_common::types::BlockTag;
+use alloy::eips::{BlockId, BlockNumberOrTag};
 
 mod harness;
 
@@ -50,7 +50,7 @@ pub fn bench_full_sync_with_call(c: &mut Criterion) {
             let addr = "0x00000000219ab540356cbb839cbe05303d7705fa"
                 .parse::<Address>()
                 .unwrap();
-            let block = BlockTag::Latest;
+            let block = BlockId::Number(BlockNumberOrTag::Latest);
             client.get_balance(addr, block).await.unwrap()
         })
     });


### PR DESCRIPTION
### Summary
This PR resolves compilation errors in the benchmark files that were preventing successful builds. The errors were likely due to API changes or dependency updates that required adjustments in the benchmark code. The old imports have been replaced by built-in types in alloy.

Before adding a new benchmark framework, maybe we should make the benches module of the master branch code meet the basic build requirements to avoid potential conflicts during integration.
### Changes

- Fixed compilation issues in `benches/get_balance.rs`
- Fixed compilation issues in `benches/get_code.rs`
- Fixed compilation issues in `benches/sync.rs`
- Fixed compilation issues in `benches/harness.rs`
- Updated benchmark harness to work with current API

### Testing

The benchmarks now compile and run correctly.

### Related Issue
https://github.com/a16z/helios/issues/677