### PR TITLE
refactor(consensus): Align naming of MaxBlsToExecutionChanges

### DIFF
--- a/ethereum/consensus-core/src/consensus_spec.rs
+++ b/ethereum/consensus-core/src/consensus_spec.rs
@@ -13,7 +13,7 @@ pub trait ConsensusSpec: 'static + Default + Sync + Send + Clone + Debug + Parti
     type MaxCommitteesPerSlot: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxDeposits: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxVoluntaryExits: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
-    type MaxBlsToExecutionChanged: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
+    type MaxBlsToExecutionChanges: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxBlobKzgCommitments: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxWithdrawals: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxValidatorsPerCommittee: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
@@ -54,7 +54,7 @@ impl ConsensusSpec for MainnetConsensusSpec {
     type MaxValidatorsPerSlot = typenum::U131072;
     type MaxDeposits = typenum::U16;
     type MaxVoluntaryExits = typenum::U16;
-    type MaxBlsToExecutionChanged = typenum::U16;
+    type MaxBlsToExecutionChanges = typenum::U16;
     type MaxBlobKzgCommitments = typenum::U4096;
     type MaxWithdrawals = typenum::U16;
     type MaxValidatorsPerCommittee = typenum::U2048;
@@ -79,7 +79,7 @@ impl ConsensusSpec for MinimalConsensusSpec {
     type MaxValidatorsPerSlot = typenum::U8192;
     type MaxDeposits = typenum::U16;
     type MaxVoluntaryExits = typenum::U16;
-    type MaxBlsToExecutionChanged = typenum::U16;
+    type MaxBlsToExecutionChanges = typenum::U16;
     type MaxBlobKzgCommitments = typenum::U4096;
     type MaxWithdrawals = typenum::U16;
     type MaxValidatorsPerCommittee = typenum::U2048;

--- a/ethereum/consensus-core/src/types/mod.rs
+++ b/ethereum/consensus-core/src/types/mod.rs
@@ -87,7 +87,7 @@ pub struct BeaconBlockBody<S: ConsensusSpec> {
     sync_aggregate: SyncAggregate<S>,
     pub execution_payload: ExecutionPayload<S>,
     #[superstruct(only(Capella, Deneb, Electra))]
-    bls_to_execution_changes: VariableList<SignedBlsToExecutionChange, S::MaxBlsToExecutionChanged>,
+    bls_to_execution_changes: VariableList<SignedBlsToExecutionChange, S::MaxBlsToExecutionChanges>,
     #[superstruct(only(Deneb, Electra))]
     blob_kzg_commitments: VariableList<KZGCommitment, S::MaxBlobKzgCommitments>,
     #[superstruct(only(Electra))]


### PR DESCRIPTION
The generic type _`S::MaxBlsToExecutionChanged`_ was inconsistent with its corresponding field, _`bls_to_execution_changes`_. This broke the established naming pattern used by all other list-based fields in `BeaconBlockBody `(e.g., `MaxProposerSlashings`, `_MaxAttestations_`. 

re-opened #669 