### PR TITLE
fix: compute EIP-4844 as eip1559 && sidecar

### DIFF
--- a/ethereum/src/spec.rs
+++ b/ethereum/src/spec.rs
@@ -251,7 +251,7 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
 
         let eip1559 = self.max_fee_per_gas.is_some() && self.max_priority_fee_per_gas.is_some();
 
-        let eip4844 = eip1559 && self.sidecar.is_some() && self.to.is_some();
+        let eip4844 = eip1559 && self.sidecar.is_some();
         common && (legacy || eip2930 || eip1559 || eip4844)
     }
 


### PR DESCRIPTION
Change: In ethereum/src/spec.rs, set eip4844 = eip1559 && self.sidecar.is_some(); (removed && self.to.is_some()).
Reason: EIP-4844 inherits EIP-1559 semantics where contract creation (to == null) is valid. The to.is_some() guard incorrectly rejected valid blob contract-creation txs.
Goal: Allow building EIP-4844 blob transactions for contract creation and align with TxEnv, which maps None to Create.