### PR TITLE
refactor: remove alloy-trie direct dependency and use alloy::trie feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ alloy = { version = "1.0.3", features = [
     "ssz",
     "json-rpc",
     "signers",
+    "trie",
 ] }
-alloy-trie = { version = "0.9", features = ["ethereum"] }
 op-alloy-rpc-types = "0.18.0"
 revm = { version = "22.0.1", default-features = false, features = [
     "std",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ tokio.workspace = true
 eyre.workspace = true
 tracing.workspace = true
 futures.workspace = true
-alloy.workspace = true
+alloy = { workspace = true, features = ["trie"] }
 figment = { version = "0.10.7", features = ["toml", "env"] }
 
 clap = { version = "4.5.4", features = ["derive", "env"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-alloy.workspace = true
+alloy = { workspace = true, features = ["trie"] }
 serde.workspace = true
 serde_json.workspace = true
 revm.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,8 +9,7 @@ helios-common = { path = "../common" }
 helios-verifiable-api-client = { path = "../verifiable-api/client" }
 
 # execution
-alloy = { workspace = true, features = ["rand"] }
-alloy-trie.workspace = true
+alloy = { workspace = true, features = ["rand", "trie"] }
 revm.workspace = true
 
 # async/futures

--- a/core/src/execution/proof.rs
+++ b/core/src/execution/proof.rs
@@ -3,8 +3,8 @@ use alloy::network::{BlockResponse, ReceiptResponse, TransactionResponse};
 use alloy::primitives::{keccak256, Bytes, B256, U256};
 use alloy::rlp;
 use alloy::rpc::types::EIP1186AccountProofResponse;
-use alloy_trie::root::ordered_trie_root_with_encoder;
-use alloy_trie::{
+use alloy::trie::root::ordered_trie_root_with_encoder;
+use alloy::trie::{
     proof::{verify_proof, ProofRetainer},
     root::adjust_index_for_rlp,
     HashBuilder, Nibbles, KECCAK_EMPTY,
@@ -61,7 +61,7 @@ pub fn verify_code_hash_proof(proof: &EIP1186AccountProofResponse, code: &Bytes)
 }
 
 /// Verifies a MPT proof for a given key-value pair against the provided root hash.
-/// This function wraps `alloy_trie::proof::verify_proof` and checks
+/// This function wraps `alloy::trie::proof::verify_proof` and checks
 /// if the value represents an empty account or slot to support exclusion proofs.
 ///
 /// # Parameters

--- a/core/src/execution/providers/rpc.rs
+++ b/core/src/execution/providers/rpc.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use alloy::{
-    consensus::BlockHeader,
+    consensus::{Account as TrieAccount, BlockHeader},
     eips::{BlockId, BlockNumberOrTag},
     network::{
         primitives::HeaderResponse, BlockResponse, ReceiptResponse, TransactionBuilder,
@@ -16,7 +16,6 @@ use alloy::{
     },
     transports::layers::RetryBackoffLayer,
 };
-use alloy_trie::TrieAccount;
 use async_trait::async_trait;
 use eyre::{eyre, Result};
 use futures::future::{join_all, try_join_all};

--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 # consensus
-alloy-trie.workspace = true
 tree_hash.workspace = true
 revm.workspace = true
 

--- a/helios-ts/Cargo.toml
+++ b/helios-ts/Cargo.toml
@@ -16,7 +16,7 @@ serde-wasm-bindgen = "0.6.5"
 console_error_panic_hook = "0.1.7"
 
 eyre.workspace = true
-alloy.workspace = true
+alloy = { workspace = true, features = ["trie"] }
 op-alloy-rpc-types.workspace = true
 
 hex = "0.4.3"

--- a/linea/Cargo.toml
+++ b/linea/Cargo.toml
@@ -14,7 +14,7 @@ tokio.workspace = true
 serde.workspace = true
 
 #misc
-alloy.workspace = true
+alloy = { workspace = true, features = ["trie"] }
 async-trait.workspace = true
 eyre.workspace = true
 tracing.workspace = true

--- a/opstack/Cargo.toml
+++ b/opstack/Cargo.toml
@@ -21,8 +21,7 @@ futures.workspace = true
 async-trait.workspace = true
 
 # consensus
-alloy.workspace = true
-alloy-trie.workspace = true
+alloy = { workspace = true, features = ["trie"] }
 revm.workspace = true
 op-revm = { version = "3.0.0", default-features = false, features = [
     "std",

--- a/revm-utils/Cargo.toml
+++ b/revm-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Utilities for integrating REVM with Helios"
 
 [dependencies]
-alloy.workspace = true 
+alloy = { workspace = true, features = ["trie"] } 
 eyre.workspace = true 
 hex.workspace = true 
 revm.workspace = true 

--- a/tests/test-utils/Cargo.toml
+++ b/tests/test-utils/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-alloy.workspace = true
+alloy = { workspace = true, features = ["trie"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/verifiable-api/client/Cargo.toml
+++ b/verifiable-api/client/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-alloy.workspace = true
+alloy = { workspace = true, features = ["trie"] }
 eyre.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/verifiable-api/server/Cargo.toml
+++ b/verifiable-api/server/Cargo.toml
@@ -8,7 +8,7 @@ name = "verifiable-api-server"
 path = "./bin/server.rs"
 
 [dependencies]
-alloy.workspace = true
+alloy = { workspace = true, features = ["trie"] }
 tokio.workspace = true
 eyre.workspace = true
 serde.workspace = true

--- a/verifiable-api/types/Cargo.toml
+++ b/verifiable-api/types/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-alloy.workspace = true
+alloy = { workspace = true, features = ["trie"] }
 serde.workspace = true
 serde_json.workspace = true
 


### PR DESCRIPTION
## Problem
Direct dependency on `alloy-trie` caused version conflicts when `alloy` umbrella package updated to a new minor version of `alloy-trie`, requiring tricky patching from dependent projects.

## Solution
- Remove direct `alloy-trie` dependency from workspace
- Add `"trie"` feature to `alloy` dependency
- Update all module Cargo.toml files to use `alloy = { workspace = true, features = ["trie"] }`
- Change imports from `alloy_trie::` to `alloy::trie::` and `alloy::consensus::`

## Changes
- **13 Cargo.toml files**: Updated alloy dependency configuration
- **2 source files**: Updated import statements in `core/src/execution/proof.rs` and `core/src/execution/providers/rpc.rs`

Closes #658