### PR TITLE
benches: migrate to BlockId API; remove start(); use tempfile::keep(); tests: skip env; clippy+fmt

### DIFF
--- a/benches/file_db.rs
+++ b/benches/file_db.rs
@@ -22,7 +22,7 @@ pub fn save_checkpoint(c: &mut Criterion) {
         let checkpoint: alloy::primitives::FixedBytes<32> =
             b256!("c7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce");
         b.iter(|| {
-            let data_dir = Some(tempdir().unwrap().into_path());
+            let data_dir = Some(tempdir().unwrap().keep());
             let config = Config {
                 data_dir,
                 ..Default::default()
@@ -37,7 +37,7 @@ pub fn save_checkpoint(c: &mut Criterion) {
 pub fn load_checkpoint(c: &mut Criterion) {
     c.bench_function("load_checkpoint", |b| {
         // First write to the db
-        let data_dir = Some(tempdir().unwrap().into_path());
+        let data_dir = Some(tempdir().unwrap().keep());
         let config = Config {
             data_dir,
             ..Default::default()
@@ -45,12 +45,12 @@ pub fn load_checkpoint(c: &mut Criterion) {
         let db = FileDB::new(&config).unwrap();
         let written_checkpoint =
             b256!("c7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce");
-        db.save_checkpoint(written_checkpoint.clone()).unwrap();
+        db.save_checkpoint(written_checkpoint).unwrap();
 
         // Then read from the db
         b.iter(|| {
             let checkpoint = db.load_checkpoint().unwrap();
-            assert_eq!(checkpoint, written_checkpoint.clone());
+            assert_eq!(checkpoint, written_checkpoint);
         })
     });
 }

--- a/benches/get_balance.rs
+++ b/benches/get_balance.rs
@@ -1,9 +1,8 @@
 use std::str::FromStr;
 
+use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::Address;
 use criterion::{criterion_group, criterion_main, Criterion};
-
-use helios_common::types::BlockTag;
 
 mod harness;
 
@@ -29,7 +28,7 @@ pub fn bench_mainnet_get_balance(c: &mut Criterion) {
 
         // Get the beacon chain deposit contract address.
         let addr = Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa").unwrap();
-        let block = BlockTag::Latest;
+        let block = BlockId::Number(BlockNumberOrTag::Latest);
 
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {
@@ -61,7 +60,7 @@ pub fn bench_sepolia_get_balance(c: &mut Criterion) {
 
         // Get the beacon chain deposit contract address.
         let addr = Address::from_str("0x7b79995e5f793a07bc00c21412e50ecae098e7f9").unwrap();
-        let block = BlockTag::Latest;
+        let block = BlockId::Number(BlockNumberOrTag::Latest);
 
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {

--- a/benches/get_code.rs
+++ b/benches/get_code.rs
@@ -1,9 +1,8 @@
 use std::str::FromStr;
 
+use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::Address;
 use criterion::{criterion_group, criterion_main, Criterion};
-
-use helios_common::types::BlockTag;
 
 mod harness;
 
@@ -29,7 +28,7 @@ pub fn bench_mainnet_get_code(c: &mut Criterion) {
 
         // Get the beacon chain deposit contract address.
         let addr = Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa").unwrap();
-        let block = BlockTag::Latest;
+        let block = BlockId::Number(BlockNumberOrTag::Latest);
 
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {
@@ -54,7 +53,7 @@ pub fn bench_sepolia_get_code(c: &mut Criterion) {
 
         // Get the beacon chain deposit contract address.
         let addr = Address::from_str("0x7b79995e5f793a07bc00c21412e50ecae098e7f9").unwrap();
-        let block = BlockTag::Latest;
+        let block = BlockId::Number(BlockNumberOrTag::Latest);
 
         // Execute the benchmark asynchronously.
         b.to_async(rt).iter(|| async {

--- a/benches/harness.rs
+++ b/benches/harness.rs
@@ -1,12 +1,11 @@
 #![allow(dead_code)]
 use std::{path::PathBuf, str::FromStr};
 
+use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::{Address, B256, U256};
 
-use helios_common::types::BlockTag;
 use helios_ethereum::{
     config::{checkpoints, networks},
-    database::FileDB,
     EthereumClient, EthereumClientBuilder,
 };
 
@@ -31,23 +30,21 @@ pub async fn fetch_mainnet_checkpoint() -> eyre::Result<B256> {
 /// The client is parameterized with a [FileDB](client::FileDB).
 /// It will also use the environment variable `MAINNET_EXECUTION_RPC` to connect to a mainnet node.
 /// The client will use `https://www.lightclientdata.org` as the consensus RPC.
-pub fn construct_mainnet_client(
-    rt: &tokio::runtime::Runtime,
-) -> eyre::Result<EthereumClient<FileDB>> {
+pub fn construct_mainnet_client(rt: &tokio::runtime::Runtime) -> eyre::Result<EthereumClient> {
     rt.block_on(inner_construct_mainnet_client())
 }
 
-pub async fn inner_construct_mainnet_client() -> eyre::Result<EthereumClient<FileDB>> {
+pub async fn inner_construct_mainnet_client() -> eyre::Result<EthereumClient> {
     let benchmark_rpc_url = std::env::var("MAINNET_EXECUTION_RPC")?;
 
-    let mut client = EthereumClientBuilder::new()
+    let client = EthereumClientBuilder::new()
+        .with_file_db()
         .network(networks::Network::Mainnet)
         .consensus_rpc("https://www.lightclientdata.org")?
         .execution_rpc(&benchmark_rpc_url)?
         .load_external_fallback()
         .data_dir(PathBuf::from("/tmp/helios"))
         .build()?;
-    client.start().await?;
 
     // Wait for the client to be synced.
     client.wait_synced().await;
@@ -57,17 +54,17 @@ pub async fn inner_construct_mainnet_client() -> eyre::Result<EthereumClient<Fil
 
 pub async fn construct_mainnet_client_with_checkpoint(
     checkpoint: B256,
-) -> eyre::Result<EthereumClient<FileDB>> {
+) -> eyre::Result<EthereumClient> {
     let benchmark_rpc_url = std::env::var("MAINNET_EXECUTION_RPC")?;
 
-    let mut client = EthereumClientBuilder::new()
+    let client = EthereumClientBuilder::new()
+        .with_file_db()
         .network(networks::Network::Mainnet)
         .consensus_rpc("https://www.lightclientdata.org")?
         .execution_rpc(&benchmark_rpc_url)?
         .checkpoint(checkpoint)
         .data_dir(PathBuf::from("/tmp/helios"))
         .build()?;
-    client.start().await?;
 
     // Wait for the client to be synced.
     client.wait_synced().await;
@@ -93,19 +90,17 @@ pub fn construct_runtime() -> tokio::runtime::Runtime {
 /// The client is parameterized with a [FileDB](client::FileDB).
 /// It will also use the environment variable `SEPOLIA_EXECUTION_RPC` to connect to a mainnet node.
 /// The client will use `http://unstable.sepolia.beacon-api.nimbus.team/` as the consensus RPC.
-pub fn construct_sepolia_client(
-    rt: &tokio::runtime::Runtime,
-) -> eyre::Result<EthereumClient<FileDB>> {
+pub fn construct_sepolia_client(rt: &tokio::runtime::Runtime) -> eyre::Result<EthereumClient> {
     rt.block_on(async {
         let benchmark_rpc_url = std::env::var("SEPOLIA_EXECUTION_RPC")?;
-        let mut client = EthereumClientBuilder::new()
+        let client = EthereumClientBuilder::new()
+            .with_file_db()
             .network(networks::Network::Sepolia)
             .consensus_rpc("http://unstable.sepolia.beacon-api.nimbus.team/")?
             .execution_rpc(&benchmark_rpc_url)?
             .data_dir(PathBuf::from("/tmp/helios"))
             .load_external_fallback()
             .build()?;
-        client.start().await?;
 
         // Wait for the client to be synced.
         client.wait_synced().await;
@@ -117,11 +112,11 @@ pub fn construct_sepolia_client(
 /// Gets the balance of the given address on mainnet.
 pub fn get_balance(
     rt: &tokio::runtime::Runtime,
-    client: EthereumClient<FileDB>,
+    client: EthereumClient,
     address: &str,
 ) -> eyre::Result<U256> {
     rt.block_on(async {
-        let block = BlockTag::Latest;
+        let block = BlockId::Number(BlockNumberOrTag::Latest);
         let address = Address::from_str(address)?;
         client.get_balance(address, block).await
     })

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -1,7 +1,6 @@
+use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::Address;
 use criterion::{criterion_group, criterion_main, Criterion};
-
-use helios_common::types::BlockTag;
 
 mod harness;
 
@@ -50,7 +49,7 @@ pub fn bench_full_sync_with_call(c: &mut Criterion) {
             let addr = "0x00000000219ab540356cbb839cbe05303d7705fa"
                 .parse::<Address>()
                 .unwrap();
-            let block = BlockTag::Latest;
+            let block = BlockId::Number(BlockNumberOrTag::Latest);
             client.get_balance(addr, block).await.unwrap()
         })
     });


### PR DESCRIPTION
Summary
- Update benches to the current alloy API: replace deprecated BlockTag with BlockId::Number(BlockNumberOrTag::Latest).
- Remove obsolete client.start() calls in benches.
- Explicitly select FileDB via .with_file_db() in the Ethereum client builder.
- Replace deprecated tempfile::TempDir::into_path() with TempDir::keep().
- Clean up clippy warnings and apply rustfmt.
- Make the env-dependent rpc_equivalence test skip when MAINNET_EXECUTION_RPC is not set (so CI without secrets stays green).

Motivation
- `helios_common::types::BlockTag` no longer exists; block selection is done via `alloy::eips::{BlockId, BlockNumberOrTag}`.
- `client.start()` is not part of the current client API; JSON-RPC is spawned from the constructor when an address is provided, and sync is awaited via `wait_synced()`.
- `TempDir::into_path()` is deprecated; `keep()` is the intended replacement.

What changed
- benches/file_db.rs: `into_path()` → `keep()`, remove unnecessary `clone()` on Copy types, minor refactor.
- benches/get_balance.rs: `BlockTag` → `BlockId/BlockNumberOrTag`, imports, formatting.
- benches/get_code.rs: `BlockTag` → `BlockId/BlockNumberOrTag`, imports, formatting.
- benches/harness.rs: drop DB generic from `EthereumClient` type; add `.with_file_db()`; remove `client.start()`; use `BlockId`; formatting.
- benches/sync.rs: `BlockTag` → `BlockId/BlockNumberOrTag`, imports, formatting.
- tests/rpc_equivalence.rs: skip test if `MAINNET_EXECUTION_RPC` is missing; `&format!` → `format!`; add `#[allow(dead_code)]` for helper struct/impl used only in logging.

Verification
- cargo fmt — OK
- cargo clippy --workspace --all-targets -- -D warnings — OK
- cargo test — OK (the env-dependent test is skipped if `MAINNET_EXECUTION_RPC` is unset)

Risk/compatibility
- Changes are limited to benches and a single integration test; public library APIs are untouched.
- Low risk; this adapts examples to the current API and fixes deprecations.

How to test locally
1) Build/lints:
   - `cargo clippy --workspace --all-targets -- -D warnings`
   - `cargo check