### PR TITLE
docs: fix README.md for Hoodi testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,15 @@ Checkpoints may be obtained from the following links:
 
 It is recommended to use a block hash as a checkpoint that is less than two weeks old, however you can actually use older checkpoints and it will still work but will give you a warning. Using a checkpoint that is less than two weeks old prevents a few attacks that are pretty hard to pull off.
 
-For example, to obtain a recent checkpoint for Holesky Testnet go to https://holesky.beaconcha.in/ and get the block hash of the first block in any finalized epoch. At the time of writing, the [first block hash in epoch 78425](https://holesky.beaconcha.in/epoch/78425) is the [oldest slot 2509600](https://holesky.beaconcha.in/slot/2509600) that has a Block Root of 0x60409a013161b33c8c68c6183c7753e779ec6c24be2f3c50c6036c30e13b34a6 and is the latest checkpoint value to use.
+For example, to obtain a recent checkpoint for Holesky Testnet go to https://hoodi.beaconcha.in/ and get the block hash of the first block in any finalized epoch. At the time of writing, the [first block hash in epoch 36682](https://hoodi.beaconcha.in/epoch/36682) is the [oldest slot 1173824](https://hoodi.beaconcha.in/slot/1173824) that has a Block Root of 0xc9570fa6d92877773edf83824c9840301373785aef015f95ba633183580b3ef7 and is the latest checkpoint value to use.
 
 This latest checkpoint may be provided as an [Additional CLI Option](#additional-cli-options) at the command line to run a Helios Light Client node on Ethereum Holesky Testnet:
 ```bash
 helios ethereum \
-    --network holesky \
-    --consensus-rpc http://testing.holesky.beacon-api.nimbus.team \
-    --execution-rpc https://ethereum-holesky.g.allthatnode.com \
-    --checkpoint 0x60409a013161b33c8c68c6183c7753e779ec6c24be2f3c50c6036c30e13b34a6
+    --network hoodi \
+    --consensus-rpc https://rpc.ankr.com/eth_hoodi_beacon 
+    --execution-rpc https://eth-hoodi.g.alchemy.com/public 
+    --checkpoint 0xc9570fa6d92877773edf83824c9840301373785aef015f95ba633183580b3ef7
 ```
 
 For example, to obtain a recent checkpoint for Ethereum Mainnet go to https://beaconcha.in and get the block hash of the first block in any finalized epoch. At the time of writing the [first block hash in epoch 222705](https://beaconcha.in/epoch/222705) is the [oldest slot 7126560](https://beaconcha.in/slot/7126560) that has a Block Root of 0xe1912ca8ca3b45dac497cae7825bab055b0f60285533721b046e8fefb5b076f2 and is the latest checkpoint value to use.


### PR DESCRIPTION
## Summary
Replaces Holesky RPC endpoints with Hoodi-specific ones in the documentation example, as Holesky testnet support will be discontinued soon.

## Changes
- Updated consensus RPC to Hoodi beacon API endpoint
- Updated execution RPC to Hoodi-specific endpoint
- Fixed links

## Rationale
Holesky testnet is being deprecated, so examples should use the appropriate network-specific endpoints for Hoodi.