### PR TITLE
fix: incorrect Block type in formatBlock and renderBlock

### DIFF
--- a/helios-ts/example/src/main.ts
+++ b/helios-ts/example/src/main.ts
@@ -17,7 +17,7 @@ interface NetworkConfig {
 }
 
 // Build display string for a block
-function formatBlock(block: Block): string {
+function formatBlock(block: Block<true>): string {
   const ts = new Date(Number(block.timestamp) * 1000);
   const date = ts.toLocaleDateString();
   const time = ts.toLocaleTimeString([], {
@@ -31,7 +31,7 @@ function formatBlock(block: Block): string {
 }
 
 // Render a block and start animations
-function renderBlock(network: string, blockTime: number, block: Block): void {
+function renderBlock(network: string, blockTime: number, block: Block<true>): void {
   const el = document.getElementById(`${network}-latest`);
   if (!el) return;
   


### PR DESCRIPTION
updated the type in both `formatBlock` and `renderBlock` from `Block` to `Block<true>`.

this matters because `getBlock({ includeTransactions: true })` actually returns a `Block<true>` where `transactions` is an array of full transactions rather than just hashes.

with this change, the code is now fully type-safe and avoids potential runtime mismatches.
