### PR TITLE
fix: handle `err` as unknown in TS 4.4+

### DIFF
--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -170,8 +170,8 @@ export class HeliosProvider {
   async request(req: Request): Promise<any> {
     try {
       return await this.#req(req);
-    } catch (err) {
-      throw new Error(err.toString());
+    } catch (err: any) {
+      throw new Error(String(err));
     }
   }
 
@@ -310,8 +310,8 @@ export class HeliosProvider {
         this.#eventEmitter.emit("message", payload);
       });
       return id;
-    } catch (err) {
-      throw new Error(err.toString());
+    } catch (err: any) {
+      throw new Error(String(err));
     }
   }
 


### PR DESCRIPTION
`err` is `unknown` by default in newer TS, fixed the typing so it doesn’t break.
