### PR TITLE
fix: resolve tree hash calculation for IndexedAttestation and Attestation types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot 0.12.4",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -514,7 +514,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "tokio",
@@ -817,7 +817,7 @@ checksum = "0d3615ec64d775fec840f4e9d5c8e1f739eb1854d8d28db093fb3d4805e0cb53"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest",
+ "reqwest 0.12.22",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1497,7 +1497,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
@@ -1531,7 +1531,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
@@ -1554,7 +1554,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1574,7 +1574,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3684,7 +3684,9 @@ dependencies = [
  "ethereum_ssz_derive",
  "eyre",
  "getrandom 0.2.16",
+ "reqwest 0.11.27",
  "serde",
+ "serde_json",
  "serde_yaml",
  "sha2 0.9.9",
  "snap",
@@ -3719,7 +3721,7 @@ dependencies = [
  "jsonrpsee",
  "openssl",
  "parking_lot 0.12.4",
- "reqwest",
+ "reqwest 0.12.22",
  "revm",
  "serde",
  "serde_json",
@@ -3751,7 +3753,7 @@ dependencies = [
  "hex",
  "openssl",
  "parking_lot 0.12.4",
- "reqwest",
+ "reqwest 0.12.22",
  "retri",
  "revm",
  "serde",
@@ -3779,7 +3781,7 @@ dependencies = [
  "helios-common",
  "helios-core",
  "helios-ethereum",
- "reqwest",
+ "reqwest 0.12.22",
  "serde",
  "strum 0.26.3",
  "tokio",
@@ -3818,7 +3820,7 @@ dependencies = [
  "op-alloy-rpc-types",
  "op-revm",
  "parking_lot 0.12.4",
- "reqwest",
+ "reqwest 0.12.22",
  "revm",
  "serde",
  "sha2 0.9.9",
@@ -3892,7 +3894,7 @@ dependencies = [
  "eyre",
  "helios-common",
  "helios-verifiable-api-types",
- "reqwest",
+ "reqwest 0.12.22",
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
@@ -4202,6 +4204,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -4235,7 +4250,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -4418,7 +4433,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "windows",
 ]
@@ -6787,6 +6802,46 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
@@ -6804,7 +6859,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.7",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -6817,7 +6872,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -6839,7 +6894,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.3.1",
- "reqwest",
+ "reqwest 0.12.22",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -6858,7 +6913,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "parking_lot 0.11.2",
- "reqwest",
+ "reqwest 0.12.22",
  "reqwest-middleware",
  "retry-policies",
  "thiserror 1.0.69",
@@ -8093,6 +8148,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -8125,13 +8186,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -8474,7 +8556,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",

--- a/ethereum/consensus-core/Cargo.toml
+++ b/ethereum/consensus-core/Cargo.toml
@@ -37,3 +37,5 @@ wasmtimer = "0.2.0"
 tokio = { version = "1", features = ["full"] }
 snap = "1"
 serde_yaml = "0.9.34"
+reqwest = { version = "0.11", features = ["json"] }
+serde_json = "1.0"

--- a/ethereum/consensus-core/src/types/mod.rs
+++ b/ethereum/consensus-core/src/types/mod.rs
@@ -277,7 +277,7 @@ pub struct AttesterSlashing<S: ConsensusSpec> {
 }
 
 #[superstruct(
-    variants(Base, Electra),
+    variants(Electra, Base),
     variant_attributes(
         derive(Deserialize, Debug, Default, Encode, TreeHash, Clone,),
         serde(deny_unknown_fields),
@@ -288,13 +288,13 @@ pub struct AttesterSlashing<S: ConsensusSpec> {
 #[serde(untagged)]
 #[ssz(enum_behaviour = "transparent")]
 #[tree_hash(enum_behaviour = "transparent")]
-struct IndexedAttestation<S: ConsensusSpec> {
-    #[serde(with = "quoted_u64_var_list")]
-    #[superstruct(only(Base), partial_getter(rename = "attesting_indices_base"))]
-    attesting_indices: VariableList<u64, S::MaxValidatorsPerCommittee>,
+pub struct IndexedAttestation<S: ConsensusSpec> {
     #[serde(with = "quoted_u64_var_list")]
     #[superstruct(only(Electra), partial_getter(rename = "attesting_indices_electra"))]
     attesting_indices: VariableList<u64, S::MaxValidatorsPerSlot>,
+    #[serde(with = "quoted_u64_var_list")]
+    #[superstruct(only(Base), partial_getter(rename = "attesting_indices_base"))]
+    attesting_indices: VariableList<u64, S::MaxValidatorsPerCommittee>,
     data: AttestationData,
     signature: Signature,
 }
@@ -306,7 +306,7 @@ impl<S: ConsensusSpec> Default for IndexedAttestation<S> {
 }
 
 #[superstruct(
-    variants(Base, Electra),
+    variants(Electra, Base),
     variant_attributes(
         derive(Deserialize, Debug, Encode, TreeHash, Clone,),
         serde(deny_unknown_fields),
@@ -318,10 +318,10 @@ impl<S: ConsensusSpec> Default for IndexedAttestation<S> {
 #[ssz(enum_behaviour = "transparent")]
 #[tree_hash(enum_behaviour = "transparent")]
 pub struct Attestation<S: ConsensusSpec> {
-    #[superstruct(only(Base), partial_getter(rename = "aggregation_bits_base"))]
-    aggregation_bits: BitList<S::MaxValidatorsPerCommittee>,
     #[superstruct(only(Electra), partial_getter(rename = "aggregation_bits_electra"))]
     aggregation_bits: BitList<S::MaxValidatorsPerSlot>,
+    #[superstruct(only(Base), partial_getter(rename = "aggregation_bits_base"))]
+    aggregation_bits: BitList<S::MaxValidatorsPerCommittee>,
     data: AttestationData,
     signature: Signature,
     #[superstruct(only(Electra))]

--- a/ethereum/consensus-core/tests/slot_12557247_rpc_test.rs
+++ b/ethereum/consensus-core/tests/slot_12557247_rpc_test.rs
@@ -1,0 +1,52 @@
+use std::str::FromStr;
+
+use alloy::primitives::B256;
+use helios_consensus_core::{consensus_spec::MainnetConsensusSpec, types::BeaconBlock};
+use reqwest::Client;
+use serde_json::Value;
+use tree_hash::TreeHash;
+
+#[tokio::test]
+async fn test_slot_12557247_consensus_rpc() {
+    // Alternative test using consensus layer RPC
+    let expected_hash =
+        B256::from_str("0x9b9141d3c23f02ceb3fd5fac5ac4a299c7fd2ce2f3619270d973e5ce53ed18c9")
+            .expect("Valid hash");
+
+    // Try using a consensus RPC endpoint
+    let consensus_rpc = "http://unstable.mainnet.beacon-api.nimbus.team";
+    let endpoint = format!("{}/eth/v2/beacon/blocks/12557247", consensus_rpc);
+
+    let client = Client::new();
+    let response = client
+        .get(&endpoint)
+        .header("accept", "application/json")
+        .send()
+        .await
+        .expect("rpc fetch failed");
+
+     let json: Value = response.json().await.expect("Failed to parse JSON");
+
+     // The block is under data.message
+     let block_data = &json["data"]["message"];
+
+     // Deserialize the block
+     let beacon_block: BeaconBlock<MainnetConsensusSpec> =
+         serde_json::from_value(block_data.clone())
+             .expect("Failed to deserialize beacon block");
+
+     // Calculate hash
+     let calculated_hash = beacon_block.tree_hash_root();
+
+     println!("Consensus RPC test:");
+     println!("Slot: {}", beacon_block.slot);
+     println!("Expected hash:   {}", expected_hash);
+     println!("Calculated hash: {}", calculated_hash);
+
+     assert_eq!(
+         calculated_hash, expected_hash,
+         "Tree hash root mismatch for slot 12557247"
+     );
+
+     println!("✓ Consensus RPC block hash verification successful!");
+}

--- a/ethereum/consensus-core/tests/slot_12557247_rpc_test.rs
+++ b/ethereum/consensus-core/tests/slot_12557247_rpc_test.rs
@@ -15,7 +15,7 @@ async fn test_slot_12557247_consensus_rpc() {
 
     // Try using a consensus RPC endpoint
     let consensus_rpc = "http://unstable.mainnet.beacon-api.nimbus.team";
-    let endpoint = format!("{}/eth/v2/beacon/blocks/12557247", consensus_rpc);
+    let endpoint = format!("{consensus_rpc}/eth/v2/beacon/blocks/12557247");
 
     let client = Client::new();
     let response = client
@@ -25,28 +25,27 @@ async fn test_slot_12557247_consensus_rpc() {
         .await
         .expect("rpc fetch failed");
 
-     let json: Value = response.json().await.expect("Failed to parse JSON");
+    let json: Value = response.json().await.expect("Failed to parse JSON");
 
-     // The block is under data.message
-     let block_data = &json["data"]["message"];
+    // The block is under data.message
+    let block_data = &json["data"]["message"];
 
-     // Deserialize the block
-     let beacon_block: BeaconBlock<MainnetConsensusSpec> =
-         serde_json::from_value(block_data.clone())
-             .expect("Failed to deserialize beacon block");
+    // Deserialize the block
+    let beacon_block: BeaconBlock<MainnetConsensusSpec> =
+        serde_json::from_value(block_data.clone()).expect("Failed to deserialize beacon block");
 
-     // Calculate hash
-     let calculated_hash = beacon_block.tree_hash_root();
+    // Calculate hash
+    let calculated_hash = beacon_block.tree_hash_root();
 
-     println!("Consensus RPC test:");
-     println!("Slot: {}", beacon_block.slot);
-     println!("Expected hash:   {}", expected_hash);
-     println!("Calculated hash: {}", calculated_hash);
+    println!("Consensus RPC test:");
+    println!("Slot: {}", beacon_block.slot);
+    println!("Expected hash:   {expected_hash}");
+    println!("Calculated hash: {calculated_hash}");
 
-     assert_eq!(
-         calculated_hash, expected_hash,
-         "Tree hash root mismatch for slot 12557247"
-     );
+    assert_eq!(
+        calculated_hash, expected_hash,
+        "Tree hash root mismatch for slot 12557247"
+    );
 
-     println!("✓ Consensus RPC block hash verification successful!");
+    println!("✓ Consensus RPC block hash verification successful!");
 }


### PR DESCRIPTION
## Summary
- Fixed incorrect variant ordering in superstruct definitions causing tree hash mismatches
- Reordered Electra variant to be listed before Base variant in both IndexedAttestation and Attestation types
- Added test case to verify correct tree hash calculation for beacon blocks

## Problem
The tree hash calculation for beacon blocks was failing because the superstruct variants for IndexedAttestation and Attestation types were ordered incorrectly. The Base variant was listed first, but the Electra variant needs to be first for proper deserialization and hash calculation.

## Solution
Reordered the superstruct variants in both `IndexedAttestation` and `Attestation` types to list Electra before Base. This ensures that during deserialization, the correct variant is selected and the tree hash is calculated properly.

## Changes
- Reordered IndexedAttestation variants: Electra now comes before Base
- Reordered Attestation variants: Electra now comes before Base  
- Added new test `slot_12557247_rpc_test.rs` to verify tree hash calculation against consensus RPC
- Added reqwest and serde_json dependencies to support the new test

## Test Plan
- [x] Run the new test to verify tree hash calculation matches expected value
- [x] Ensure all existing tests still pass
- [x] Verify the fix resolves the original issue with beacon block hash verification