### PR TITLE
Remove redundant HashSet lookup in receipt proof collection

### DIFF
--- a/verifiable-api/server/src/service.rs
+++ b/verifiable-api/server/src/service.rs
@@ -317,9 +317,7 @@ impl<N: NetworkSpec> ApiService<N> {
                     log.transaction_hash.unwrap(),
                     log.transaction_index.unwrap(),
                 );
-                if !receipts_to_prove.contains(&entry) {
-                    receipts_to_prove.insert(entry);
-                }
+                receipts_to_prove.insert(entry);
             }
 
             receipts_to_prove


### PR DESCRIPTION


### PR Description
- Simplifies dedup logic by removing HashSet contains + insert double lookup
- Reduces double hashing and improves micro-performance in a hot path
- No behavior change; HashSet insert already ensures uniqueness

- Location: `verifiable-api/server/src/service.rs`
- Scope: `create_receipt_proofs_for_logs` — building `receipts_to_prove`

Why
- Avoids unnecessary work (two lookups vs one)
- Improves readability

