### PR TITLE
fix(ethereum): add consensus_rpc fallback cascade; error on missing execution_rpc

### DIFF
--- a/ethereum/src/builder.rs
+++ b/ethereum/src/builder.rs
@@ -152,13 +152,15 @@ impl<DB: Database> EthereumClientBuilder<DB> {
             config.to_base_config()
         };
 
-        let consensus_rpc = self.consensus_rpc.unwrap_or_else(|| {
-            self.config
-                .as_ref()
-                .expect("missing consensus rpc")
-                .consensus_rpc
-                .clone()
-        });
+        let consensus_rpc = if let Some(url) = self.consensus_rpc {
+            url
+        } else if let Some(cfg) = &self.config {
+            cfg.consensus_rpc.clone()
+        } else if let Some(url) = base_config.consensus_rpc.clone() {
+            url
+        } else {
+            return Err(eyre!("missing consensus rpc"));
+        };
 
         let execution_rpc = self
             .execution_rpc
@@ -269,9 +271,16 @@ impl<DB: Database> EthereumClientBuilder<DB> {
                 rpc_address,
             ))
         } else {
+            // Ensure execution rpc is present when verifiable API is not configured
+            let rpc_url = config
+                .execution_rpc
+                .as_ref()
+                .ok_or_else(|| {
+                    eyre!("missing execution rpc; provide execution_rpc or verifiable_api")
+                })?
+                .clone();
             let block_provider = BlockCache::<Ethereum>::new();
             // Create EIP-2935 historical block provider
-            let rpc_url = config.execution_rpc.as_ref().unwrap().clone();
             let historical_provider = Eip2935Provider::new();
             let execution = RpcExecutionProvider::with_historical_provider(
                 rpc_url,


### PR DESCRIPTION
Problem: When only network was provided (no explicit consensus_rpc or full config), the builder ignored base_config.consensus_rpc and panicked via expect, despite networks supplying default consensus endpoints. Additionally, in the non-verifiable API path, the code unwrapped execution_rpc, causing a panic if it was missing, instead of returning a clear configuration error.
Why these changes are needed: The builder should honor network defaults and never panic in library code for expected misconfigurations. Using base_config.consensus_rpc as a fallback aligns with the network presets and documentation, and returning an explicit error for missing execution_rpc (when verifiable_api is not set) provides a clear, recoverable signal to callers.