### PR TITLE
Remove unused execution_rpc CLI parameter from opstack server

### DIFF
--- a/opstack/bin/server.rs
+++ b/opstack/bin/server.rs
@@ -67,6 +67,4 @@ struct Cli {
     gossip_address: SocketAddr,
     #[arg(short, long, value_delimiter = ',')]
     replica_urls: Option<Vec<Url>>,
-    #[arg(short, long)]
-    execution_rpc: Url,
 }


### PR DESCRIPTION

## PR Description


Removes unused `execution_rpc` CLI parameter from the opstack server binary that was declared but never used.

### Problem
The `execution_rpc` field in the `Cli` struct was defined as a required CLI argument but was never referenced in the code. This created a misleading interface where users could pass a flag that would be silently ignored.

### Solution
- Removed the unused `execution_rpc: Url` field from the `Cli` struct
- CLI interface now accurately reflects the actual functionality

### Impact
- Improves CLI usability by removing confusing unused parameters
- Reduces technical debt
- No breaking changes (parameter was unused)

