### PR TITLE
fix: remove iterations cap for EVM calls

### DIFF
--- a/ethereum/src/evm.rs
+++ b/ethereum/src/evm.rs
@@ -57,17 +57,11 @@ impl<E: ExecutionProvider<Ethereum>> EthereumEvm<E> {
         let mut db = ProofDB::new(self.block_id, self.execution.clone());
         _ = db.state.prefetch_state(tx, validate_tx).await;
 
-        // Iterative execution with state fetching
-        let mut iteration = 0;
-        const MAX_ITERATIONS: u32 = 50; // Prevent infinite loops
+        // Track iterations for debugging
+        let mut iteration: u32 = 0;
 
         let tx_res = loop {
             iteration += 1;
-            if iteration > MAX_ITERATIONS {
-                return Err(EvmError::Generic(
-                    "Maximum iterations reached while fetching state".to_string(),
-                ));
-            }
 
             // Update state first if needed
             if db.state.needs_update() {

--- a/opstack/src/evm.rs
+++ b/opstack/src/evm.rs
@@ -61,17 +61,11 @@ impl<E: ExecutionProvider<OpStack>> OpStackEvm<E> {
         let mut db = ProofDB::new(self.block_id, self.execution.clone());
         _ = db.state.prefetch_state(tx, validate_tx).await;
 
-        // Iterative execution with state fetching
-        let mut iteration = 0;
-        const MAX_ITERATIONS: u32 = 50; // Prevent infinite loops
+        // Track iterations for debugging
+        let mut iteration: u32 = 0;
 
         let tx_res = loop {
             iteration += 1;
-            if iteration > MAX_ITERATIONS {
-                return Err(EvmError::Generic(
-                    "Maximum iterations reached while fetching state".to_string(),
-                ));
-            }
 
             // Update state first if needed
             if db.state.needs_update() {


### PR DESCRIPTION
An arbitrary cap for iterations proved to be a bad idea. I propose we remove it for now.