### PR TITLE
fix: localstorage usage for helios-ts

### DIFF
--- a/ethereum/src/builder.rs
+++ b/ethereum/src/builder.rs
@@ -223,6 +223,12 @@ impl<DB: Database> EthereumClientBuilder<DB> {
             self.strict_checkpoint_age
         };
 
+        let database_type = if let Some(config) = &self.config {
+            config.database_type.clone()
+        } else {
+            None
+        };
+
         let config = Config {
             consensus_rpc,
             execution_rpc,
@@ -242,7 +248,7 @@ impl<DB: Database> EthereumClientBuilder<DB> {
             fallback,
             load_external_fallback,
             strict_checkpoint_age,
-            database_type: None,
+            database_type,
         };
 
         let config = Arc::new(config);

--- a/helios-ts/src/ethereum.rs
+++ b/helios-ts/src/ethereum.rs
@@ -33,7 +33,15 @@ impl Database for DatabaseType {
     fn new(config: &Config) -> Result<Self> {
         match config.database_type.as_deref() {
             Some("config") => Ok(DatabaseType::Memory(ConfigDB::new(config)?)),
-            Some("localstorage") => Ok(DatabaseType::LocalStorage(LocalStorageDB::new(config)?)),
+            Some("localstorage") => match LocalStorageDB::new(config) {
+                Ok(db) => Ok(DatabaseType::LocalStorage(db)),
+                Err(_) => {
+                    web_sys::console::warn_1(
+                        &"Helios: localStorage unavailable, falling back to in-memory checkpoint storage".into(),
+                    );
+                    Ok(DatabaseType::Memory(ConfigDB::new(config)?))
+                }
+            },
             _ => Ok(DatabaseType::Memory(ConfigDB::new(config)?)),
         }
     }

--- a/helios-ts/src/storage.rs
+++ b/helios-ts/src/storage.rs
@@ -13,7 +13,7 @@ pub struct LocalStorageDB;
 impl Database for LocalStorageDB {
     fn new(_config: &Config) -> Result<Self> {
         console_error_panic_hook::set_once();
-        let window = web_sys::window().unwrap();
+        let window = web_sys::window().ok_or_else(|| eyre::eyre!("window not available"))?;
         if let Ok(Some(_local_storage)) = window.local_storage() {
             return Ok(Self {});
         }
@@ -22,7 +22,7 @@ impl Database for LocalStorageDB {
     }
 
     fn load_checkpoint(&self) -> Result<B256> {
-        let window = web_sys::window().unwrap();
+        let window = web_sys::window().ok_or_else(|| eyre::eyre!("window not available"))?;
         if let Ok(Some(local_storage)) = window.local_storage() {
             let checkpoint = local_storage.get_item("checkpoint");
             if let Ok(Some(checkpoint)) = checkpoint {
@@ -37,7 +37,7 @@ impl Database for LocalStorageDB {
     }
 
     fn save_checkpoint(&self, checkpoint: B256) -> Result<()> {
-        let window = web_sys::window().unwrap();
+        let window = web_sys::window().ok_or_else(|| eyre::eyre!("window not available"))?;
         if let Ok(Some(local_storage)) = window.local_storage() {
             local_storage
                 .set_item("checkpoint", &hex::encode(checkpoint))


### PR DESCRIPTION
closes #722 

This fixes 2 things:
- when we pass `localstorage` as an option for database, it's not ignored now (the cause of issue #722 )
- also, in some environments `window` object is not available (for example, in browser extensions) which would cause consensus client to panic. This PR handles this and lets Ethereum to gracefully fall back to in-memory storage. It also makes sense to expose a way to get notified about new checkpoints so that it can be used, I created issue #729 