### PR TITLE
fix: handle nested Maps in mapToObj helper

### DIFF
--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -496,27 +496,16 @@ function mapToObj(map: Map<any, any> | undefined): Record<string, any> | undefin
     if (value instanceof Map) {
       result[key] = mapToObj(value);
     } else if (Array.isArray(value)) {
-      let hasMap = false;
       for (let i = 0; i < value.length; i++) {
         if (value[i] instanceof Map) {
-          hasMap = true;
-          break;
-        }
-      }
-      
-      if (hasMap) {
-        // Mutate in-place instead of creating new array
-        for (let i = 0; i < value.length; i++) {
-          if (value[i] instanceof Map) {
-            value[i] = mapToObj(value[i]);
-          }
+          // Mutate in-place
+          value[i] = mapToObj(value[i]);
         }
       }
       result[key] = value;
     } else {
       result[key] = value;
     }
-    }
-
+  }
   return result;
 }


### PR DESCRIPTION
For nested `transactions` in `Block` responses, we can have `Map`s instead of objects because `mapToObj` helper currently does handle `Map`s when they are nested.

<img width="508" height="662" alt="image" src="https://github.com/user-attachments/assets/90e1baaa-410b-470d-bddf-941d9604f50e" />

`viem` and `ethers` v5 handle it gracefully -- even though it's not an expected behavior. However, `ethers` v6 fails to parse transactions

<img width="523" height="179" alt="image" src="https://github.com/user-attachments/assets/3d30544a-c607-44b5-a518-5660817b594b" />

In this fix I propose a recursive `mapToObj` function that handles nested `Map`s to make sure that a JSON-serializable response is returned.