### PR TITLE
fix: raw transaction decode

### DIFF
--- a/helios-ts/Cargo.toml
+++ b/helios-ts/Cargo.toml
@@ -19,7 +19,6 @@ eyre.workspace = true
 alloy.workspace = true
 op-alloy-rpc-types.workspace = true
 
-hex = "0.4.3"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.85"
 url = "2.5.0"

--- a/helios-ts/src/ethereum.rs
+++ b/helios-ts/src/ethereum.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use alloy::eips::{BlockId, BlockNumberOrTag};
-use alloy::hex::FromHex;
+use alloy::hex::{self, FromHex};
 use alloy::primitives::{Address, B256, U256};
 use alloy::rpc::types::{Filter, TransactionRequest};
 use eyre::Result;

--- a/helios-ts/src/linea.rs
+++ b/helios-ts/src/linea.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use alloy::eips::{BlockId, BlockNumberOrTag};
+use alloy::hex;
 use alloy::primitives::{Address, B256, U256};
 use alloy::rpc::types::{Filter, TransactionRequest};
 use url::Url;

--- a/helios-ts/src/opstack.rs
+++ b/helios-ts/src/opstack.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use alloy::eips::{BlockId, BlockNumberOrTag};
+use alloy::hex;
 use alloy::primitives::{Address, B256, U256};
 use alloy::rpc::types::Filter;
 use url::Url;

--- a/helios-ts/src/storage.rs
+++ b/helios-ts/src/storage.rs
@@ -1,7 +1,7 @@
 extern crate console_error_panic_hook;
 extern crate web_sys;
 
-use alloy::{hex::FromHex, primitives::B256};
+use alloy::{hex, hex::FromHex, primitives::B256};
 use eyre::Result;
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
Usually, there's a `0x` prefix in transaction data but here we don't strip it:
https://github.com/a16z/helios/blob/daffbbbf4367a1fb1baff717ebc3452b7d950909/helios-ts/src/ethereum.rs#L355-L359 

`hex` lib used here is 0.4.3 which [does not strip](https://docs.rs/hex/0.4.3/hex/fn.decode.html) `0x` prefix itself, which causes a bug for us.

The `hex` re-exported by alloy, [does](https://docs.rs/const-hex/1.14.1/const_hex/fn.decode.html).

In this PR I removed the unnecessary dated `hex` dependency and use alloy's re-export instead, fixing raw transaction submission.