### PR TITLE
fix: check_head_age() to avoid bogus OutOfSync when latest block is missing

### DIFF
--- a/core/src/client/node.rs
+++ b/core/src/client/node.rs
@@ -143,7 +143,7 @@ impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> No
             .get_block(tag, false)
             .await
             .map_err(|_| ClientError::BlockNotFound(tag))?
-            .ok_or_else(|| ClientError::OutOfSync(timestamp))?
+            .ok_or(ClientError::BlockNotFound(tag))?
             .header()
             .timestamp();
 


### PR DESCRIPTION
The previous implementation returned OutOfSync with the current epoch seconds when the Latest block was missing, which misrepresented the delay as an enormous number of seconds behind and produced misleading RPC errors. OutOfSync(u64) is meant to carry the computed delay, not a timestamp. This change treats the absence of the Latest block as BlockNotFound(latest), preserving accurate semantics while leaving the computed-delay path intact for cases where a head timestamp exists. Callers do not rely on the numeric delay value in this branch, so the change is behaviorally correct and improves diagnostics.