### PR TITLE
feat: implement state overrides for EVM calls

### DIFF
--- a/common/src/network_spec.rs
+++ b/common/src/network_spec.rs
@@ -1,6 +1,11 @@
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
-use alloy::{eips::BlockId, network::Network, primitives::Address, rpc::types::Log};
+use alloy::{
+    eips::BlockId,
+    network::Network,
+    primitives::Address,
+    rpc::types::{state::StateOverride, Log},
+};
 use async_trait::async_trait;
 use revm::context::result::ExecutionResult;
 
@@ -27,5 +32,6 @@ pub trait NetworkSpec: Network {
         chain_id: u64,
         fork_schedule: ForkSchedule,
         block_id: BlockId,
+        state_overrides: Option<StateOverride>,
     ) -> Result<(ExecutionResult<Self::HaltReason>, HashMap<Address, Account>), EvmError>;
 }

--- a/core/src/client/api.rs
+++ b/core/src/client/api.rs
@@ -1,7 +1,10 @@
 use alloy::{
     eips::BlockId,
     primitives::{Address, Bytes, B256, U256},
-    rpc::types::{AccessListResult, EIP1186AccountProofResponse, Filter, Log, SyncStatus},
+    rpc::types::{
+        state::StateOverride, AccessListResult, EIP1186AccountProofResponse, Filter, Log,
+        SyncStatus,
+    },
 };
 use async_trait::async_trait;
 use eyre::Result;
@@ -53,12 +56,23 @@ pub trait HeliosApi<N: NetworkSpec>: Send + Sync + 'static {
         block_id: BlockId,
     ) -> Result<Option<Vec<N::ReceiptResponse>>>;
     // evm
-    async fn call(&self, tx: &N::TransactionRequest, block_id: BlockId) -> Result<Bytes>;
-    async fn estimate_gas(&self, tx: &N::TransactionRequest, block_id: BlockId) -> Result<u64>;
+    async fn call(
+        &self,
+        tx: &N::TransactionRequest,
+        block_id: BlockId,
+        state_overrides: Option<StateOverride>,
+    ) -> Result<Bytes>;
+    async fn estimate_gas(
+        &self,
+        tx: &N::TransactionRequest,
+        block_id: BlockId,
+        state_overrides: Option<StateOverride>,
+    ) -> Result<u64>;
     async fn create_access_list(
         &self,
         tx: &N::TransactionRequest,
         block_id: BlockId,
+        state_overrides: Option<StateOverride>,
     ) -> Result<AccessListResult>;
     // logs
     async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>>;

--- a/ethereum/src/evm.rs
+++ b/ethereum/src/evm.rs
@@ -4,7 +4,7 @@ use alloy::{
     consensus::{BlockHeader, TxType},
     eips::BlockId,
     network::TransactionBuilder,
-    rpc::types::{Block, Header, Transaction, TransactionRequest},
+    rpc::types::{state::StateOverride, Block, Header, Transaction, TransactionRequest},
 };
 use eyre::Result;
 use revm::{
@@ -53,8 +53,9 @@ impl<E: ExecutionProvider<Ethereum>> EthereumEvm<E> {
         &mut self,
         tx: &TransactionRequest,
         validate_tx: bool,
+        state_overrides: Option<StateOverride>,
     ) -> Result<(ExecutionResult, HashMap<Address, Account>), EvmError> {
-        let mut db = ProofDB::new(self.block_id, self.execution.clone());
+        let mut db = ProofDB::new(self.block_id, self.execution.clone(), state_overrides);
         _ = db.state.prefetch_state(tx, validate_tx).await;
 
         // Track iterations for debugging

--- a/ethereum/src/spec.rs
+++ b/ethereum/src/spec.rs
@@ -8,7 +8,7 @@ use alloy::{
     eips::{BlockId, Encodable2718},
     network::{BuildResult, Network, NetworkWallet, TransactionBuilder, TransactionBuilderError},
     primitives::{Address, Bytes, ChainId, TxKind, U256},
-    rpc::types::{AccessList, Log, TransactionRequest},
+    rpc::types::{state::StateOverride, AccessList, Log, TransactionRequest},
 };
 use async_trait::async_trait;
 use revm::context::result::{ExecutionResult, HaltReason};
@@ -104,10 +104,11 @@ impl NetworkSpec for Ethereum {
         chain_id: u64,
         fork_schedule: ForkSchedule,
         block_id: BlockId,
+        state_overrides: Option<StateOverride>,
     ) -> Result<(ExecutionResult, HashMap<Address, Account>), EvmError> {
         let mut evm = EthereumEvm::new(execution, chain_id, fork_schedule, block_id);
 
-        evm.transact_inner(tx, validate_tx).await
+        evm.transact_inner(tx, validate_tx, state_overrides).await
     }
 }
 

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -65,7 +65,9 @@ async fn main() -> eyre::Result<()> {
         ..Default::default()
     };
 
-    let result = client.call(&tx, BlockNumberOrTag::Latest.into()).await?;
+    let result = client
+        .call(&tx, BlockNumberOrTag::Latest.into(), None)
+        .await?;
     info!("[HELIOS] DAI total supply: {:?}", result);
 
     Ok(())

--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -211,13 +211,13 @@ export class HeliosProvider {
         return this.#client.get_proof(req.params[0], req.params[1], req.params[2]);
       }
       case "eth_call": {
-        return this.#client.call(req.params[0], req.params[1]);
+        return this.#client.call(req.params[0], req.params[1], req.params[2]);
       }
       case "eth_estimateGas": {
-        return this.#client.estimate_gas(req.params[0], req.params[1]);
+        return this.#client.estimate_gas(req.params[0], req.params[1], req.params[2]);
       }
       case "eth_createAccessList": {
-        return this.#client.create_access_list(req.params[0], req.params[1]);
+        return this.#client.create_access_list(req.params[0], req.params[1], req.params[2]);
       }
       case "eth_gasPrice": {
         return this.#client.gas_price();

--- a/helios-ts/src/ethereum.rs
+++ b/helios-ts/src/ethereum.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::hex::{self, FromHex};
 use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::{Filter, TransactionRequest};
+use alloy::rpc::types::{state::StateOverride, Filter, TransactionRequest};
 use eyre::Result;
 use url::Url;
 use wasm_bindgen::prelude::*;
@@ -321,18 +321,32 @@ impl EthereumClient {
     }
 
     #[wasm_bindgen]
-    pub async fn call(&self, opts: JsValue, block: JsValue) -> Result<String, JsError> {
+    pub async fn call(
+        &self,
+        opts: JsValue,
+        block: JsValue,
+        state_overrides: JsValue,
+    ) -> Result<String, JsError> {
         let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockId = serde_wasm_bindgen::from_value(block)?;
-        let res = map_err(self.inner.call(&opts, block).await)?;
+        let state_overrides: Option<StateOverride> =
+            serde_wasm_bindgen::from_value(state_overrides)?;
+        let res = map_err(self.inner.call(&opts, block, state_overrides).await)?;
         Ok(format!("0x{}", hex::encode(res)))
     }
 
     #[wasm_bindgen]
-    pub async fn estimate_gas(&self, opts: JsValue, block: JsValue) -> Result<u32, JsError> {
+    pub async fn estimate_gas(
+        &self,
+        opts: JsValue,
+        block: JsValue,
+        state_overrides: JsValue,
+    ) -> Result<u32, JsError> {
         let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockId = serde_wasm_bindgen::from_value(block)?;
-        Ok(map_err(self.inner.estimate_gas(&opts, block).await)? as u32)
+        let state_overrides: Option<StateOverride> =
+            serde_wasm_bindgen::from_value(state_overrides)?;
+        Ok(map_err(self.inner.estimate_gas(&opts, block, state_overrides).await)? as u32)
     }
 
     #[wasm_bindgen]
@@ -340,10 +354,17 @@ impl EthereumClient {
         &self,
         opts: JsValue,
         block: JsValue,
+        state_overrides: JsValue,
     ) -> Result<JsValue, JsError> {
         let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockId = serde_wasm_bindgen::from_value(block)?;
-        let access_list_result = map_err(self.inner.create_access_list(&opts, block).await)?;
+        let state_overrides: Option<StateOverride> =
+            serde_wasm_bindgen::from_value(state_overrides)?;
+        let access_list_result = map_err(
+            self.inner
+                .create_access_list(&opts, block, state_overrides)
+                .await,
+        )?;
         Ok(serde_wasm_bindgen::to_value(&access_list_result)?)
     }
 

--- a/helios-ts/src/linea.rs
+++ b/helios-ts/src/linea.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::hex;
 use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::{Filter, TransactionRequest};
+use alloy::rpc::types::{state::StateOverride, Filter, TransactionRequest};
 use url::Url;
 use wasm_bindgen::prelude::*;
 use web_sys::js_sys::Function;
@@ -245,18 +245,32 @@ impl LineaClient {
     }
 
     #[wasm_bindgen]
-    pub async fn call(&self, opts: JsValue, block: JsValue) -> Result<String, JsError> {
+    pub async fn call(
+        &self,
+        opts: JsValue,
+        block: JsValue,
+        state_overrides: JsValue,
+    ) -> Result<String, JsError> {
         let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockId = serde_wasm_bindgen::from_value(block)?;
-        let res = map_err(self.inner.call(&opts, block).await)?;
+        let state_overrides: Option<StateOverride> =
+            serde_wasm_bindgen::from_value(state_overrides)?;
+        let res = map_err(self.inner.call(&opts, block, state_overrides).await)?;
         Ok(format!("0x{}", hex::encode(res)))
     }
 
     #[wasm_bindgen]
-    pub async fn estimate_gas(&self, opts: JsValue, block: JsValue) -> Result<u32, JsError> {
+    pub async fn estimate_gas(
+        &self,
+        opts: JsValue,
+        block: JsValue,
+        state_overrides: JsValue,
+    ) -> Result<u32, JsError> {
         let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockId = serde_wasm_bindgen::from_value(block)?;
-        Ok(map_err(self.inner.estimate_gas(&opts, block).await)? as u32)
+        let state_overrides: Option<StateOverride> =
+            serde_wasm_bindgen::from_value(state_overrides)?;
+        Ok(map_err(self.inner.estimate_gas(&opts, block, state_overrides).await)? as u32)
     }
 
     #[wasm_bindgen]
@@ -264,10 +278,17 @@ impl LineaClient {
         &self,
         opts: JsValue,
         block: JsValue,
+        state_overrides: JsValue,
     ) -> Result<JsValue, JsError> {
         let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockId = serde_wasm_bindgen::from_value(block)?;
-        let access_list_result = map_err(self.inner.create_access_list(&opts, block).await)?;
+        let state_overrides: Option<StateOverride> =
+            serde_wasm_bindgen::from_value(state_overrides)?;
+        let access_list_result = map_err(
+            self.inner
+                .create_access_list(&opts, block, state_overrides)
+                .await,
+        )?;
         Ok(serde_wasm_bindgen::to_value(&access_list_result)?)
     }
 

--- a/helios-ts/src/opstack.rs
+++ b/helios-ts/src/opstack.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::hex;
 use alloy::primitives::{Address, B256, U256};
-use alloy::rpc::types::Filter;
+use alloy::rpc::types::{state::StateOverride, Filter};
 use url::Url;
 use wasm_bindgen::prelude::*;
 use web_sys::js_sys::Function;
@@ -262,18 +262,32 @@ impl OpStackClient {
     }
 
     #[wasm_bindgen]
-    pub async fn call(&self, opts: JsValue, block: JsValue) -> Result<String, JsError> {
+    pub async fn call(
+        &self,
+        opts: JsValue,
+        block: JsValue,
+        state_overrides: JsValue,
+    ) -> Result<String, JsError> {
         let opts: OpTransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockId = serde_wasm_bindgen::from_value(block)?;
-        let res = map_err(self.inner.call(&opts, block).await)?;
+        let state_overrides: Option<StateOverride> =
+            serde_wasm_bindgen::from_value(state_overrides)?;
+        let res = map_err(self.inner.call(&opts, block, state_overrides).await)?;
         Ok(format!("0x{}", hex::encode(res)))
     }
 
     #[wasm_bindgen]
-    pub async fn estimate_gas(&self, opts: JsValue, block: JsValue) -> Result<u32, JsError> {
+    pub async fn estimate_gas(
+        &self,
+        opts: JsValue,
+        block: JsValue,
+        state_overrides: JsValue,
+    ) -> Result<u32, JsError> {
         let opts: OpTransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockId = serde_wasm_bindgen::from_value(block)?;
-        Ok(map_err(self.inner.estimate_gas(&opts, block).await)? as u32)
+        let state_overrides: Option<StateOverride> =
+            serde_wasm_bindgen::from_value(state_overrides)?;
+        Ok(map_err(self.inner.estimate_gas(&opts, block, state_overrides).await)? as u32)
     }
 
     #[wasm_bindgen]
@@ -281,10 +295,17 @@ impl OpStackClient {
         &self,
         opts: JsValue,
         block: JsValue,
+        state_overrides: JsValue,
     ) -> Result<JsValue, JsError> {
         let opts: OpTransactionRequest = serde_wasm_bindgen::from_value(opts)?;
         let block: BlockId = serde_wasm_bindgen::from_value(block)?;
-        let access_list_result = map_err(self.inner.create_access_list(&opts, block).await)?;
+        let state_overrides: Option<StateOverride> =
+            serde_wasm_bindgen::from_value(state_overrides)?;
+        let access_list_result = map_err(
+            self.inner
+                .create_access_list(&opts, block, state_overrides)
+                .await,
+        )?;
         Ok(serde_wasm_bindgen::to_value(&access_list_result)?)
     }
 

--- a/opstack/src/evm.rs
+++ b/opstack/src/evm.rs
@@ -4,7 +4,7 @@ use alloy::{
     consensus::BlockHeader,
     eips::BlockId,
     network::TransactionBuilder,
-    rpc::types::{Block, Header},
+    rpc::types::{state::StateOverride, Block, Header},
 };
 use eyre::Result;
 use op_alloy_consensus::OpTxType;
@@ -57,8 +57,9 @@ impl<E: ExecutionProvider<OpStack>> OpStackEvm<E> {
         &mut self,
         tx: &OpTransactionRequest,
         validate_tx: bool,
+        state_overrides: Option<StateOverride>,
     ) -> Result<(ExecutionResult<OpHaltReason>, HashMap<Address, Account>), EvmError> {
-        let mut db = ProofDB::new(self.block_id, self.execution.clone());
+        let mut db = ProofDB::new(self.block_id, self.execution.clone(), state_overrides);
         _ = db.state.prefetch_state(tx, validate_tx).await;
 
         // Track iterations for debugging

--- a/opstack/src/spec.rs
+++ b/opstack/src/spec.rs
@@ -4,7 +4,7 @@ use alloy::{
     consensus::{proofs::calculate_transaction_root, Receipt, ReceiptWithBloom, TxReceipt, TxType},
     eips::{BlockId, Encodable2718},
     primitives::{Address, Bytes, ChainId, TxKind, U256},
-    rpc::types::{AccessList, Log, TransactionRequest},
+    rpc::types::{state::StateOverride, AccessList, Log, TransactionRequest},
 };
 
 use async_trait::async_trait;
@@ -133,10 +133,11 @@ impl NetworkSpec for OpStack {
         chain_id: u64,
         fork_schedule: ForkSchedule,
         block_id: BlockId,
+        state_overrides: Option<StateOverride>,
     ) -> Result<(ExecutionResult<Self::HaltReason>, HashMap<Address, Account>), EvmError> {
         let mut evm = OpStackEvm::new(execution, chain_id, fork_schedule, block_id);
 
-        evm.transact_inner(tx, validate_tx).await
+        evm.transact_inner(tx, validate_tx, state_overrides).await
     }
 }
 

--- a/revm-utils/src/types.rs
+++ b/revm-utils/src/types.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum DatabaseError {
     #[error("state missing")]
     StateMissing,
+    #[error("invalid state override: {0}")]
+    InvalidStateOverride(String),
     #[error("should never be called")]
     Unimplemented,
 }

--- a/verifiable-api/server/src/service.rs
+++ b/verifiable-api/server/src/service.rs
@@ -242,6 +242,7 @@ impl<N: NetworkSpec> VerifiableApi<N> for ApiService<N> {
             self.rpc.get_chain_id().await?,
             ForkSchedule::default(),
             block_id,
+            None, // state overrides not supported for execution hints
         )
         .await?;
 


### PR DESCRIPTION
This PR implements state overrides for RPC calls that support them. State overrides are not part of the JSON-RPC spec and implementations may vary.

This implementation:
- Errors if both `state` and `stateDiff` are provided, consistent with Geth and Reth
- Does not support `movePrecompileToAddress` (nor does Reth seem to). I don't believe it's a good idea to use Helios for such simulations anyway.