### PR TITLE
fix: update basic example with working consensus RPC and sync workaround

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr, time::Duration};
 
 use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::{utils::format_ether, Address};
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     let untrusted_rpc_url = "https://eth-mainnet.g.alchemy.com/v2/<YOUR_API_KEY>";
     info!("Using untrusted RPC URL [REDACTED]");
 
-    let consensus_rpc = "https://www.lightclientdata.org";
+    let consensus_rpc = "http://testing.mainnet.beacon-api.nimbus.team";
     info!("Using consensus RPC URL: {}", consensus_rpc);
 
     let client: EthereumClient = EthereumClientBuilder::new()
@@ -43,6 +43,9 @@ async fn main() -> Result<()> {
     );
 
     client.wait_synced().await?;
+
+    // Wait for a fresh block (Ethereum produces blocks every ~12 seconds)
+    tokio::time::sleep(Duration::from_secs(15)).await;
 
     let client_version = client.get_client_version().await;
     let head_block_num = client.get_block_number().await?;


### PR DESCRIPTION
## Summary
  - Updated consensus RPC from lightclientdata.org (down) to testing.mainnet.beacon-api.nimbus.team
  - Added 15-second sleep after wait_synced() to work around race condition where block may not be in cache yet

Note: The sleep is a workaround for a race condition where wait_synced() returns as soon as the consensus layer is synced, but the block may not have been pushed to the execution cache yet. A proper fix would be to make wait_synced() wait until at least one block is confirmed in the execution cache.


## Test plan
  - Run \`cargo run --example basic -p helios\` with a valid execution RPC API key"
  