### PR TITLE
fix: fix remaining examples

### DIFF
--- a/examples/call.rs
+++ b/examples/call.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use std::path::PathBuf;
 
 use alloy::eips::BlockNumberOrTag;
@@ -28,8 +26,8 @@ async fn main() -> eyre::Result<()> {
     // Load the rpc url using the `MAINNET_EXECUTION_RPC` environment variable
     dotenv().ok();
     let eth_rpc_url = std::env::var("MAINNET_EXECUTION_RPC")?;
-    let consensus_rpc = "https://www.lightclientdata.org";
-    info!("Consensus RPC URL: {}", consensus_rpc);
+    let consensus_rpc = "http://testing.mainnet.beacon-api.nimbus.team";
+    info!("Using consensus RPC URL: {}", consensus_rpc);
 
     // Construct the client
     let data_dir = PathBuf::from("/tmp/helios");

--- a/examples/checkpoints.rs
+++ b/examples/checkpoints.rs
@@ -9,30 +9,24 @@ async fn main() -> Result<()> {
     // The `build` method will fetch a list of [CheckpointFallbackService]s from a community-maintained list by ethPandaOps.
     // This list is NOT guaranteed to be secure, but is provided in good faith.
     // The raw list can be found here: https://github.com/ethpandaops/checkpoint-sync-health-checks/blob/master/_data/endpoints.yaml
-    let cf = checkpoints::CheckpointFallback::new()
-        .build()
-        .await
-        .unwrap();
+    let cf = checkpoints::CheckpointFallback::new().build().await?;
 
     // Fetch the latest sepolia checkpoint
     let sepolia_checkpoint = cf
         .fetch_latest_checkpoint(&networks::Network::Sepolia)
-        .await
-        .unwrap();
+        .await?;
     println!("Fetched latest sepolia checkpoint: {sepolia_checkpoint}");
 
     // Fetch the latest holesky checkpoint
     let holesky_checkpoint = cf
         .fetch_latest_checkpoint(&networks::Network::Holesky)
-        .await
-        .unwrap();
+        .await?;
     println!("Fetched latest holesky checkpoint: {holesky_checkpoint}");
 
     // Fetch the latest mainnet checkpoint
     let mainnet_checkpoint = cf
         .fetch_latest_checkpoint(&networks::Network::Mainnet)
-        .await
-        .unwrap();
+        .await?;
     println!("Fetched latest mainnet checkpoint: {mainnet_checkpoint}");
 
     // Let's get a list of all the fallback service endpoints for mainnet

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -12,15 +12,15 @@ async fn main() -> Result<()> {
         // Set the network to mainnet
         .network(Network::Mainnet)
         // Set the consensus rpc url
-        .consensus_rpc("https://www.lightclientdata.org")?
+        .consensus_rpc("http://testing.mainnet.beacon-api.nimbus.team")?
         // Set the execution rpc url
-        .execution_rpc("https://eth-mainnet.g.alchemy.com/v2/XXXXX")?
+        .execution_rpc("https://eth-mainnet.g.alchemy.com/v2/<YOUR_API_KEY>")?
         // Set the checkpoint to the last known checkpoint
         .checkpoint(b256!(
             "85e6151a246e8fdba36db27a0c7678a575346272fe978c9281e13a8b26cdfa68"
         ))
         // Set the rpc address
-        .rpc_address("127.0.0.1:8545".parse().unwrap())
+        .rpc_address("127.0.0.1:8545".parse()?)
         // Set the data dir
         .data_dir(PathBuf::from("/tmp/helios"))
         // Set the fallback service
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
         .with_file_db();
 
     // Build the client
-    let _client: EthereumClient = builder.build().unwrap();
+    let _client: EthereumClient = builder.build()?;
     println!("Constructed client!");
 
     Ok(())

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -6,7 +6,8 @@ use helios::ethereum::config::{cli::CliConfig, Config};
 #[tokio::main]
 async fn main() -> Result<()> {
     // Load the config from the global config file
-    let config_path = home_dir().unwrap().join(".helios/helios.toml");
+    let home = home_dir().ok_or_else(|| eyre::eyre!("Could not find home directory"))?;
+    let config_path = home.join(".helios/helios.toml");
     let config = Config::from_file(&config_path, "mainnet", &CliConfig::default());
     println!("Constructed config: {config:#?}");
 


### PR DESCRIPTION
 Fixed examples:

  1. call.rs:
    - Updated consensus RPC from https://www.lightclientdata.org to http://testing.mainnet.beacon-api.nimbus.team
    - Removed unnecessary #![allow(deprecated)] attribute
    - Made log message consistent with basic.rs
  2. checkpoints.rs:
    - Replaced .unwrap() with ? for proper error propagation (4 instances)
  3. client.rs:
    - Updated consensus RPC from https://www.lightclientdata.org to http://testing.mainnet.beacon-api.nimbus.team
    - Changed execution RPC placeholder from XXXXX to <YOUR_API_KEY> for clarity
    - Replaced .unwrap() with ? for proper error handling (2 instances)
  4. config.rs:
    - Fixed home_dir().unwrap() to properly handle the case where home directory cannot be found using ok_or_else