### PR TITLE
fix: correct InvalidHeaderHash usage in consensus verification

### DIFF
--- a/ethereum/consensus-core/src/consensus_core.rs
+++ b/ethereum/consensus-core/src/consensus_core.rs
@@ -47,7 +47,7 @@ pub fn verify_bootstrap<S: ConsensusSpec>(
     let header_valid = header_hash == checkpoint;
 
     if !header_valid {
-        return Err(ConsensusError::InvalidHeaderHash(checkpoint, header_hash).into());
+        return Err(ConsensusError::InvalidHeaderHash(header_hash, checkpoint).into());
     }
 
     if !committee_valid {


### PR DESCRIPTION
The InvalidHeaderHash error is defined as "invalid header hash found: {0}, expected: {1}", but two call sites were passing arguments in a way that did not match this contract. In verify_bootstrap the checkpoint and computed header hash were swapped, which inverted the meaning of "found" and "expected". In the backfill warning in get_payloads the log referenced the parent hash instead of the actual block hash being compared to the previous parent hash. This change makes both call sites consistent with the error's semantics by treating the computed header or block hash as the found value and the trusted checkpoint or expected parent hash as the expected value, improving the clarity and usefulness of logs when header mismatches occur.