### PR TITLE
perf: deduplicate execution hint access list entries

### DIFF
--- a/core/src/execution/providers/rpc.rs
+++ b/core/src/execution/providers/rpc.rs
@@ -452,15 +452,15 @@ impl<N: NetworkSpec, B: BlockProvider<N>, H: HistoricalBlockProvider<N>> Executi
             storage_keys: Vec::default(),
         };
 
-        let list_addresses = list.iter().map(|elem| elem.address).collect::<Vec<_>>();
+        let mut list_addresses = list.iter().map(|elem| elem.address).collect::<HashSet<_>>();
 
-        if !list_addresses.contains(&from_access_entry.address) {
+        if list_addresses.insert(from_access_entry.address) {
             list.push(from_access_entry)
         }
-        if !list_addresses.contains(&to_access_entry.address) {
+        if list_addresses.insert(to_access_entry.address) {
             list.push(to_access_entry)
         }
-        if !list_addresses.contains(&producer_access_entry.address) {
+        if list_addresses.insert(producer_access_entry.address) {
             list.push(producer_access_entry)
         }
 


### PR DESCRIPTION
Removed duplicate access list entries for from/to/beneficiary in `RpcExecutionProvider::get_execution_hint` by tracking addresses in a `HashSet` instead of a static vector snapshot. The behavior of including these accounts is preserved, but we avoid issuing redundant `get_account` RPC calls when the same address appears multiple times. This reduces unnecessary work and allocations without affecting the resulting execution hint state.