### PR TITLE
perf: eliminate redundant clones and allocations

### DIFF
--- a/benches/file_db.rs
+++ b/benches/file_db.rs
@@ -45,12 +45,12 @@ pub fn load_checkpoint(c: &mut Criterion) {
         let db = FileDB::new(&config).unwrap();
         let written_checkpoint =
             b256!("c7fc7b2f4b548bfc9305fa80bc1865ddc6eea4557f0a80507af5dc34db7bd9ce");
-        db.save_checkpoint(written_checkpoint.clone()).unwrap();
+        db.save_checkpoint(written_checkpoint).unwrap();
 
         // Then read from the db
         b.iter(|| {
             let checkpoint = db.load_checkpoint().unwrap();
-            assert_eq!(checkpoint, written_checkpoint.clone());
+            assert_eq!(checkpoint, written_checkpoint);
         })
     });
 }

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -204,7 +204,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
 
         save_new_checkpoints(
             checkpoint_recv.clone(),
-            db.clone(),
+            db,
             initial_checkpoint,
             shutdown_recv,
         );

--- a/tests/rpc_equivalence.rs
+++ b/tests/rpc_equivalence.rs
@@ -188,7 +188,7 @@ async fn setup() -> (
         let port = get_available_port();
         let helios_client = EthereumClientBuilder::new()
             .network(Network::Mainnet)
-            .verifiable_api(&format!("http://localhost:{api_port}"))
+            .verifiable_api(format!("http://localhost:{api_port}"))
             .unwrap()
             .consensus_rpc(consensus_rpc)
             .unwrap()

--- a/verifiable-api/client/src/http.rs
+++ b/verifiable-api/client/src/http.rs
@@ -280,7 +280,7 @@ async fn handle_response<T: DeserializeOwned>(response: Response) -> Result<T> {
         Ok(serde_json::from_slice(&bytes)?)
     } else {
         let error_response = response.json::<ErrorResponse>().await?;
-        Err(eyre!(error_response.error.to_string()))
+        Err(eyre!(error_response.error))
     }
 }
 


### PR DESCRIPTION
Removed unnecessary clone operations and reference borrows across the codebase that were causing extra allocations. Changes include removing redundant string conversions, clones on Copy types, and unnecessary borrows where owned values can be moved directly.

