### PR TITLE
fix: use BlockNotFound instead of OutOfSync with timestamp

### DIFF
--- a/core/src/client/node.rs
+++ b/core/src/client/node.rs
@@ -143,11 +143,11 @@ impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> No
             .get_block(tag, false)
             .await
             .map_err(|_| ClientError::BlockNotFound(tag))?
-            .ok_or_else(|| ClientError::OutOfSync(timestamp))?
+            .ok_or_else(|| ClientError::BlockNotFound(tag))?
             .header()
             .timestamp();
 
-        let delay = timestamp.checked_sub(block_timestamp).unwrap_or_default();
+        let delay = timestamp.saturating_sub(block_timestamp);
         if delay > 60 {
             return Err(ClientError::OutOfSync(delay));
         }


### PR DESCRIPTION
When get_block returns None for Latest block, return BlockNotFound
error instead of OutOfSync with absolute timestamp. The previous
implementation would produce misleading error messages like "out of
sync: 1700000000 seconds behind" instead of a proper delay value.

Also replaced checked_sub().unwrap_or_default() with saturating_sub()
to satisfy clippy warnings.