### PR TITLE
fix: missing execution_forks in WASM client config

### DIFF
--- a/helios-ts/src/ethereum.rs
+++ b/helios-ts/src/ethereum.rs
@@ -125,6 +125,7 @@ impl EthereumClient {
 
             chain: base.chain,
             forks: base.forks,
+            execution_forks: base.execution_forks,
 
             database_type: Some(db_type),
             ..Default::default()


### PR DESCRIPTION
The WASM client was not copying execution_forks from the base network config, falling back to ForkSchedule::default() which sets all fork timestamps to u64::MAX. This caused the EVM to run in FRONTIER mode instead of the correct fork (Cancun/Prague), breaking eth_call, eth_estimateGas and eth_createAccessList results.