### PR TITLE
perf: remove extra allocations in BLS point decoding

### DIFF
--- a/ethereum/consensus-core/src/types/bls.rs
+++ b/ethereum/consensus-core/src/types/bls.rs
@@ -25,8 +25,8 @@ pub struct Signature {
 
 impl PublicKey {
     pub(crate) fn point(&self) -> Result<G1Affine> {
-        let bytes = self.inner.inner.to_vec();
-        let bytes = bytes.as_slice().try_into()?;
+        let bytes: &[u8] = &self.inner.inner;
+        let bytes = bytes.try_into()?;
         let point_opt = G1Affine::from_compressed(bytes);
         if point_opt.is_some().into() {
             Ok(point_opt.unwrap())
@@ -53,8 +53,8 @@ impl Signature {
     }
 
     fn point(&self) -> Result<G2Affine> {
-        let bytes = self.inner.inner.to_vec();
-        let bytes = bytes.as_slice().try_into()?;
+        let bytes: &[u8] = &self.inner.inner;
+        let bytes = bytes.try_into()?;
         let point_opt = G2Affine::from_compressed(bytes);
         if point_opt.is_some().into() {
             Ok(point_opt.unwrap())


### PR DESCRIPTION
Previously, `PublicKey::point` and `Signature::point` converted the underlying `FixedVector<u8, N>` into a` Vec<u8>` on every call just to feed compressed bytes into `G1Affine::from_compressed` / `G2Affine::from_compressed`. This added unnecessary heap allocations and copies on the hot path of BLS signature verification. This change updates both helpers to borrow the bytes directly from the `FixedVector` via a slice and convert that slice into the fixed-size array expected by `from_compressed`, keeping behavior identical while eliminating the extra allocations.