### PR TITLE
fix(TS): replace numeric response with hex string for blockNumber and chainId

### DIFF
--- a/helios-ts/lib.ts
+++ b/helios-ts/lib.ts
@@ -188,7 +188,7 @@ export class HeliosProvider {
         return this.#client.get_balance(req.params[0], req.params[1]);
       }
       case "eth_chainId": {
-        return this.#chainId;
+        return `0x${this.#chainId.toString(16)}`;
       }
       case "eth_blockNumber": {
         return this.#client.get_block_number();

--- a/helios-ts/src/ethereum.rs
+++ b/helios-ts/src/ethereum.rs
@@ -178,8 +178,9 @@ impl EthereumClient {
     }
 
     #[wasm_bindgen]
-    pub async fn get_block_number(&self) -> Result<u32, JsError> {
-        map_err(self.inner.get_block_number().await).map(|v| v.to())
+    pub async fn get_block_number(&self) -> Result<String, JsError> {
+        let v = map_err(self.inner.get_block_number().await)?;
+        Ok(format!("0x{:x}", v))
     }
 
     #[wasm_bindgen]

--- a/helios-ts/src/linea.rs
+++ b/helios-ts/src/linea.rs
@@ -100,8 +100,9 @@ impl LineaClient {
     }
 
     #[wasm_bindgen]
-    pub async fn get_block_number(&self) -> Result<u32, JsError> {
-        map_err(self.inner.get_block_number().await).map(|v| v.to())
+    pub async fn get_block_number(&self) -> Result<String, JsError> {
+        let v = map_err(self.inner.get_block_number().await)?;
+        Ok(format!("0x{:x}", v))
     }
 
     #[wasm_bindgen]

--- a/helios-ts/src/opstack.rs
+++ b/helios-ts/src/opstack.rs
@@ -118,8 +118,9 @@ impl OpStackClient {
     }
 
     #[wasm_bindgen]
-    pub async fn get_block_number(&self) -> Result<u32, JsError> {
-        map_err(self.inner.get_block_number().await).map(|v| v.to())
+    pub async fn get_block_number(&self) -> Result<String, JsError> {
+        let v = map_err(self.inner.get_block_number().await)?;
+        Ok(format!("0x{:x}", v))
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
Per JSON-RPC spec, `eth_blockNumber` and `eth_chainId` should return a hex string. This PR fixes it as currently Helios returns numbers in TS bindings. While it didn't cause any errors I know of (ethers accepts both a number and a hex string), it's more compliant to the spec and future-proof.

Note that I added the fix to `eth_chainId` in a different place because `chain_id` field is also used by `net_version` method and it returns a decimal string.