### PR TITLE
chore (TS): update wasmtimer dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -458,7 +458,7 @@ dependencies = [
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -506,7 +506,7 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
- "wasmtimer 0.4.2",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -3325,7 +3325,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
- "gloo-timers 0.2.6",
+ "gloo-timers",
  "send_wrapper 0.4.0",
 ]
 
@@ -3476,16 +3476,6 @@ checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
 dependencies = [
  "futures-channel",
  "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3716,8 +3706,7 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "typenum",
- "wasmtimer 0.2.1",
- "zduny-wasm-timer",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -3730,7 +3719,6 @@ dependencies = [
  "eyre",
  "futures",
  "getrandom 0.3.3",
- "gloo-timers 0.3.0",
  "helios-common",
  "helios-ethereum",
  "helios-test-utils",
@@ -3748,7 +3736,7 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "wasmtimer 0.2.1",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -9268,23 +9256,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtimer"
-version = "0.2.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.12.4",
- "pin-utils",
- "slab",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wasmtimer"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d49b5d6c64e8558d9b1b065014426f35c18de636895d24893dbbd329743446"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
 dependencies = [
  "futures",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,9 @@ chrono = "0.4.23"
 thiserror = "1.0.37"
 superstruct = "0.7.0"
 openssl = { version = "0.10", features = ["vendored"] }
-zduny-wasm-timer = "0.2.8"
 retri = "0.1.1"
 typenum = "1.17.0"
+wasmtimer = "0.4.3"
 
 ######################################
 # Top Level Dependencies

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,8 +36,7 @@ openssl.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4.33"
-gloo-timers = "0.3.0"
-wasmtimer = "0.2.0"
+wasmtimer.workspace = true
 getrandom = { version = "0.3.1", features = ["wasm_js"] }
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/ethereum/consensus-core/Cargo.toml
+++ b/ethereum/consensus-core/Cargo.toml
@@ -27,11 +27,10 @@ serde.workspace = true
 superstruct.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-zduny-wasm-timer.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-wasmtimer = "0.2.0"
+wasmtimer.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
- updated `wasmtimer` version and moved to root
- removed unused `zduny-wasm-timer` and `gloo-timers`

This also seems to have fixed a weird issue of multiple 5-second `setTimeout`s constantly being called without doing notable work