### PR TITLE
fix: pin `get_code_at` to proof block in `RpcExecutionProvider`

### DIFF
--- a/core/src/execution/providers/rpc.rs
+++ b/core/src/execution/providers/rpc.rs
@@ -227,7 +227,11 @@ impl<N: NetworkSpec, B: BlockProvider<N>, H: HistoricalBlockProvider<N>> Account
             if proof.code_hash == KECCAK_EMPTY || proof.code_hash == B256::ZERO {
                 Some(Bytes::new())
             } else {
-                let code = self.provider.get_code_at(address).await?;
+                let code = self
+                    .provider
+                    .get_code_at(address)
+                    .block_id(block.header().hash().into())
+                    .await?;
                 verify_code_hash_proof(&proof, &code)?;
                 Some(code)
             }


### PR DESCRIPTION
## Why

`get_code_at` in [RpcExecutionProvider::get_account]https://github.com/a16z/helios/blob/4a32ac1a9fbcf46386a497e4e0a7232ad1388762/verifiable-api/server/src/service.rs#L58-L111 was called without `.block_id()`, defaulting to `latest`. Meanwhile `get_proof` right above
it was pinned to a specific block hash. If a new block arrived between the two RPC calls, the returned code could belong to a different state than the proof, causing a spurious `CodeHashMismatch` error.

## What

Added `.block_id(block.header().hash().into())` to the `get_code_at` call so it queries the same block as `get_proof`. This matches how every other callsite in the codebase already uses `get_code_at`.