### PR TITLE
fix: optional block id in estimate gas, hex output

### DIFF
--- a/core/src/client/api.rs
+++ b/core/src/client/api.rs
@@ -65,7 +65,7 @@ pub trait HeliosApi<N: NetworkSpec>: Send + Sync + 'static {
     async fn estimate_gas(
         &self,
         tx: &N::TransactionRequest,
-        block_id: BlockId,
+        block_id: Option<BlockId>,
         state_overrides: Option<StateOverride>,
     ) -> Result<u64>;
     async fn create_access_list(

--- a/core/src/client/node.rs
+++ b/core/src/client/node.rs
@@ -215,9 +215,10 @@ impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> He
     async fn estimate_gas(
         &self,
         tx: &N::TransactionRequest,
-        block_id: BlockId,
+        block_id: Option<BlockId>,
         state_overrides: Option<StateOverride>,
     ) -> Result<u64> {
+        let block_id = block_id.unwrap_or(BlockId::latest());
         self.check_blocktag_age(&block_id).await?;
 
         let (result, ..) = N::transact(

--- a/core/src/jsonrpc/mod.rs
+++ b/core/src/jsonrpc/mod.rs
@@ -97,7 +97,7 @@ trait EthRpc<
     async fn estimate_gas(
         &self,
         tx: TXR,
-        block: BlockId,
+        block: Option<BlockId>,
         state_overrides: Option<StateOverride>,
     ) -> Result<U64, ErrorObjectOwned>;
     #[method(name = "createAccessList")]
@@ -268,7 +268,7 @@ impl<N: NetworkSpec>
     async fn estimate_gas(
         &self,
         tx: N::TransactionRequest,
-        block: BlockId,
+        block: Option<BlockId>,
         state_overrides: Option<StateOverride>,
     ) -> Result<U64, ErrorObjectOwned> {
         let res = self

--- a/helios-ts/src/ethereum.rs
+++ b/helios-ts/src/ethereum.rs
@@ -343,12 +343,13 @@ impl EthereumClient {
         opts: JsValue,
         block: JsValue,
         state_overrides: JsValue,
-    ) -> Result<u32, JsError> {
+    ) -> Result<String, JsError> {
         let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
-        let block: BlockId = serde_wasm_bindgen::from_value(block)?;
+        let block: Option<BlockId> = serde_wasm_bindgen::from_value(block)?;
         let state_overrides: Option<StateOverride> =
             serde_wasm_bindgen::from_value(state_overrides)?;
-        Ok(map_err(self.inner.estimate_gas(&opts, block, state_overrides).await)? as u32)
+        let gas = map_err(self.inner.estimate_gas(&opts, block, state_overrides).await)?;
+        Ok(format!("0x{gas:x}"))
     }
 
     #[wasm_bindgen]

--- a/helios-ts/src/linea.rs
+++ b/helios-ts/src/linea.rs
@@ -265,12 +265,13 @@ impl LineaClient {
         opts: JsValue,
         block: JsValue,
         state_overrides: JsValue,
-    ) -> Result<u32, JsError> {
+    ) -> Result<String, JsError> {
         let opts: TransactionRequest = serde_wasm_bindgen::from_value(opts)?;
-        let block: BlockId = serde_wasm_bindgen::from_value(block)?;
+        let block: Option<BlockId> = serde_wasm_bindgen::from_value(block)?;
         let state_overrides: Option<StateOverride> =
             serde_wasm_bindgen::from_value(state_overrides)?;
-        Ok(map_err(self.inner.estimate_gas(&opts, block, state_overrides).await)? as u32)
+        let gas = map_err(self.inner.estimate_gas(&opts, block, state_overrides).await)?;
+        Ok(format!("0x{gas:x}"))
     }
 
     #[wasm_bindgen]

--- a/helios-ts/src/opstack.rs
+++ b/helios-ts/src/opstack.rs
@@ -283,12 +283,13 @@ impl OpStackClient {
         opts: JsValue,
         block: JsValue,
         state_overrides: JsValue,
-    ) -> Result<u32, JsError> {
+    ) -> Result<String, JsError> {
         let opts: OpTransactionRequest = serde_wasm_bindgen::from_value(opts)?;
-        let block: BlockId = serde_wasm_bindgen::from_value(block)?;
+        let block: Option<BlockId> = serde_wasm_bindgen::from_value(block)?;
         let state_overrides: Option<StateOverride> =
             serde_wasm_bindgen::from_value(state_overrides)?;
-        Ok(map_err(self.inner.estimate_gas(&opts, block, state_overrides).await)? as u32)
+        let gas = map_err(self.inner.estimate_gas(&opts, block, state_overrides).await)?;
+        Ok(format!("0x{gas:x}"))
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
This PR makes `eth_estimateGas` more compliant with spec:
- Don't fail when blockId is not provided because it should be optional with default to `latest`
- Return hex, not a decimal