### PR TITLE
fix: verify consensus rpc chain_id during startup

### DIFF
--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -171,6 +171,12 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
                 }
             }
 
+            if let Err(err) = inner.check_rpc().await {
+                error!(target: "helios::consensus", err = %err, "chain id mismatch with consensus rpc");
+                _ = sync_status_send.send(ConsensusSyncStatus::Error(err.to_string()));
+                return;
+            }
+
             _ = inner.send_blocks().await;
             _ = sync_status_send.send(ConsensusSyncStatus::Synced);
 


### PR DESCRIPTION
## Summary
Calls the existing but unused `Inner::check_rpc()` method after sync completes. If the consensus RPC serves a different chain than configured, the client stops with `IncorrectRpcNetwork` instead of silently returning the wrong chain_id.

## Changes
- `ethereum/src/consensus.rs` — call `check_rpc()` after sync, before marking client as synced

Closes #544