### PR TITLE
feat: shut down consensus client after repeated failures

### DIFF
--- a/core/src/client/node.rs
+++ b/core/src/client/node.rs
@@ -87,15 +87,14 @@ impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> No
                                 _ = block_broadcast_ref.send(SubscriptionEvent::NewHeads(block));
                             }
                             None => {
-                                // Sender dropped, consensus task has exited - client is no longer usable
-                                warn!(target: "helios::client", "consensus client stopped, shut Helios down manually");
+                                warn!(target: "helios::client", "consensus client stopped");
                                 break;
                             }
                         }
                     },
                     finalized_changed = finalized_block_recv.changed() => {
                         if finalized_changed.is_err() {
-                            warn!(target: "helios::client", "consensus client stopped, shut Helios down manually");
+                            warn!(target: "helios::client", "consensus client stopped");
                             break;
                         }
                         let block = finalized_block_recv.borrow_and_update().clone();

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -176,6 +176,8 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
 
             let start = Instant::now() + inner.duration_until_next_update().to_std().unwrap();
             let mut interval = interval_at(start, std::time::Duration::from_secs(12));
+            let max_consecutive_failures = 5;
+            let mut consecutive_failures: u64 = 0;
 
             loop {
                 tokio::select! {
@@ -188,15 +190,53 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
                     _ = interval.tick() => {
                         let res = inner.advance().await;
                         if let Err(err) = res {
-                            warn!(target: "helios::consensus", "advance error: {}", err);
+                            consecutive_failures += 1;
+                            warn!(
+                                target: "helios::consensus",
+                                "advance error ({}/{}): {}",
+                                consecutive_failures,
+                                max_consecutive_failures,
+                                err,
+                            );
+
+                            if consecutive_failures >= max_consecutive_failures {
+                                error!(
+                                    target: "helios::consensus",
+                                    "too many consecutive failures, shutting down"
+                                );
+                                _ = sync_status_send.send(
+                                    ConsensusSyncStatus::Error(err.to_string()),
+                                );
+                                return;
+                            }
                             continue;
                         }
 
                         let res = inner.send_blocks().await;
                         if let Err(err) = res {
-                            warn!(target: "helios::consensus", "send error: {}", err);
+                            consecutive_failures += 1;
+                            warn!(
+                                target: "helios::consensus",
+                                "send error ({}/{}): {}",
+                                consecutive_failures,
+                                max_consecutive_failures,
+                                err,
+                            );
+
+                            if consecutive_failures >= max_consecutive_failures {
+                                error!(
+                                    target: "helios::consensus",
+                                    "too many consecutive failures, shutting down"
+                                );
+                                _ = sync_status_send.send(
+                                    ConsensusSyncStatus::Error(err.to_string()),
+                                );
+                                return;
+                            }
                             continue;
                         }
+
+                        consecutive_failures = 0;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Track consecutive failures in the Ethereum consensus main loop. After 5 consecutive `advance()` or `send_blocks()` errors, update `ConsensusSyncStatus` to `Error` and exit the task. This drops the block senders, which Node already detects and stops its own loop.

A successful iteration resets the failure counter, so transient network errors are tolerated.

## Problem
Previously the consensus task would log warnings and keep looping forever even when permanently broken, leaving helios running in a silently unusable state (as described in #773).

## Changes
- `ethereum/src/consensus.rs` — consecutive failure tracking and shutdown after 5 failures
- `core/src/client/node.rs` — cleaned up warn messages

Closes #773