### PR TITLE
feat: make sync staleness check configurable via --max-sync-delay

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -242,6 +242,8 @@ struct OpStackArgs {
         help = "Enable fallback for weak subjectivity checkpoint. Use if --ethereum-checkpoint fails."
     )]
     load_external_fallback: bool,
+    #[arg(long, env)]
+    max_sync_delay: Option<u64>,
 }
 
 impl OpStackArgs {
@@ -295,6 +297,10 @@ impl OpStackArgs {
             user_dict.insert("checkpoint", Value::from(hex::encode(checkpoint)));
         }
 
+        if let Some(d) = self.max_sync_delay {
+            user_dict.insert("max_sync_delay", Value::from(d));
+        }
+
         Serialized::from(user_dict, &self.network)
     }
 }
@@ -309,6 +315,8 @@ struct LineaArgs {
     rpc_port: Option<u16>,
     #[arg(short, long, env, value_parser = parse_url)]
     execution_rpc: Option<Url>,
+    #[arg(long, env)]
+    max_sync_delay: Option<u64>,
 }
 
 impl LineaArgs {
@@ -331,6 +339,7 @@ impl LineaArgs {
             execution_rpc: self.execution_rpc.clone(),
             rpc_bind_ip: self.rpc_bind_ip,
             rpc_port: self.rpc_port,
+            max_sync_delay: self.max_sync_delay,
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -171,6 +171,8 @@ struct EthereumArgs {
     load_external_fallback: bool,
     #[arg(short = 's', long, env)]
     strict_checkpoint_age: bool,
+    #[arg(long, env)]
+    max_sync_delay: Option<u64>,
 }
 
 impl EthereumArgs {
@@ -207,6 +209,7 @@ impl EthereumArgs {
             fallback: self.fallback.clone(),
             load_external_fallback: true_or_none(self.load_external_fallback),
             strict_checkpoint_age: true_or_none(self.strict_checkpoint_age),
+            max_sync_delay: self.max_sync_delay,
         }
     }
 }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -26,9 +26,10 @@ impl<N: NetworkSpec> HeliosClient<N> {
         consensus: C,
         execution: E,
         fork_schedule: ForkSchedule,
+        max_sync_delay: u64,
         #[cfg(not(target_arch = "wasm32"))] rpc_address: Option<SocketAddr>,
     ) -> Self {
-        let inner = Arc::new(Node::new(consensus, execution, fork_schedule));
+        let inner = Arc::new(Node::new(consensus, execution, fork_schedule, max_sync_delay));
 
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(rpc_address) = rpc_address {

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -29,7 +29,12 @@ impl<N: NetworkSpec> HeliosClient<N> {
         max_sync_delay: u64,
         #[cfg(not(target_arch = "wasm32"))] rpc_address: Option<SocketAddr>,
     ) -> Self {
-        let inner = Arc::new(Node::new(consensus, execution, fork_schedule, max_sync_delay));
+        let inner = Arc::new(Node::new(
+            consensus,
+            execution,
+            fork_schedule,
+            max_sync_delay,
+        ));
 
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(rpc_address) = rpc_address {

--- a/core/src/client/node.rs
+++ b/core/src/client/node.rs
@@ -41,7 +41,12 @@ pub struct Node<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProv
 }
 
 impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> Node<N, C, E> {
-    pub fn new(mut consensus: C, execution: E, fork_schedule: ForkSchedule, max_sync_delay: u64) -> Self {
+    pub fn new(
+        mut consensus: C,
+        execution: E,
+        fork_schedule: ForkSchedule,
+        max_sync_delay: u64,
+    ) -> Self {
         let mut block_recv = consensus.block_recv().unwrap();
         let mut finalized_block_recv = consensus.finalized_block_recv().unwrap();
         let execution = Arc::new(execution);
@@ -160,7 +165,7 @@ impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> No
             .header()
             .timestamp();
 
-        let delay = timestamp.checked_sub(block_timestamp).unwrap_or_default();
+        let delay = timestamp.saturating_sub(block_timestamp);
         if delay > self.max_sync_delay {
             return Err(ClientError::OutOfSync(delay));
         }

--- a/core/src/client/node.rs
+++ b/core/src/client/node.rs
@@ -36,11 +36,12 @@ pub struct Node<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProv
     filter_state: FilterState,
     block_broadcast: Sender<SubscriptionEvent<N>>,
     fork_schedule: ForkSchedule,
+    max_sync_delay: u64,
     phantom: PhantomData<N>,
 }
 
 impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> Node<N, C, E> {
-    pub fn new(mut consensus: C, execution: E, fork_schedule: ForkSchedule) -> Self {
+    pub fn new(mut consensus: C, execution: E, fork_schedule: ForkSchedule, max_sync_delay: u64) -> Self {
         let mut block_recv = consensus.block_recv().unwrap();
         let mut finalized_block_recv = consensus.finalized_block_recv().unwrap();
         let execution = Arc::new(execution);
@@ -128,6 +129,7 @@ impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> No
             filter_state: FilterState::default(),
             block_broadcast,
             fork_schedule,
+            max_sync_delay,
             phantom: PhantomData,
         }
     }
@@ -159,7 +161,7 @@ impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> No
             .timestamp();
 
         let delay = timestamp.checked_sub(block_timestamp).unwrap_or_default();
-        if delay > 60 {
+        if delay > self.max_sync_delay {
             return Err(ClientError::OutOfSync(delay));
         }
 

--- a/ethereum/src/builder.rs
+++ b/ethereum/src/builder.rs
@@ -230,6 +230,12 @@ impl<DB: Database> EthereumClientBuilder<DB> {
             None
         };
 
+        let max_sync_delay = if let Some(config) = &self.config {
+            config.max_sync_delay
+        } else {
+            60
+        };
+
         let config = Config {
             consensus_rpc,
             execution_rpc,
@@ -250,6 +256,7 @@ impl<DB: Database> EthereumClientBuilder<DB> {
             load_external_fallback,
             strict_checkpoint_age,
             database_type,
+            max_sync_delay,
         };
 
         let config = Arc::new(config);
@@ -273,6 +280,7 @@ impl<DB: Database> EthereumClientBuilder<DB> {
                 consensus,
                 execution,
                 config.execution_forks,
+                max_sync_delay,
                 #[cfg(not(target_arch = "wasm32"))]
                 rpc_address,
             ))
@@ -292,6 +300,7 @@ impl<DB: Database> EthereumClientBuilder<DB> {
                 consensus,
                 execution,
                 config.execution_forks,
+                max_sync_delay,
                 #[cfg(not(target_arch = "wasm32"))]
                 rpc_address,
             ))

--- a/ethereum/src/config/cli.rs
+++ b/ethereum/src/config/cli.rs
@@ -19,6 +19,7 @@ pub struct CliConfig {
     pub fallback: Option<Url>,
     pub load_external_fallback: Option<bool>,
     pub strict_checkpoint_age: Option<bool>,
+    pub max_sync_delay: Option<u64>,
 }
 
 impl CliConfig {
@@ -63,6 +64,10 @@ impl CliConfig {
 
         if let Some(s) = self.strict_checkpoint_age {
             user_dict.insert("strict_checkpoint_age", Value::from(s));
+        }
+
+        if let Some(d) = self.max_sync_delay {
+            user_dict.insert("max_sync_delay", Value::from(d));
         }
 
         Serialized::from(user_dict, network)

--- a/ethereum/src/config/mod.rs
+++ b/ethereum/src/config/mod.rs
@@ -43,6 +43,7 @@ pub struct Config {
     pub load_external_fallback: bool,
     pub strict_checkpoint_age: bool,
     pub database_type: Option<String>,
+    pub max_sync_delay: u64,
 }
 
 impl Config {
@@ -118,6 +119,7 @@ impl From<BaseConfig> for Config {
             load_external_fallback: base.load_external_fallback,
             strict_checkpoint_age: base.strict_checkpoint_age,
             database_type: None,
+            max_sync_delay: 60,
         }
     }
 }
@@ -141,6 +143,7 @@ impl Default for Config {
             load_external_fallback: false,
             strict_checkpoint_age: false,
             database_type: None,
+            max_sync_delay: 60,
         }
     }
 }

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -667,9 +667,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
         let current_slot_timestamp = self.slot_timestamp(current_slot);
         let blockhash_slot_timestamp = self.slot_timestamp(blockhash_slot);
 
-        let slot_age = current_slot_timestamp
-            .checked_sub(blockhash_slot_timestamp)
-            .unwrap_or_default();
+        let slot_age = current_slot_timestamp.saturating_sub(blockhash_slot_timestamp);
 
         slot_age < self.config.max_checkpoint_age
     }

--- a/linea/src/builder.rs
+++ b/linea/src/builder.rs
@@ -99,6 +99,8 @@ impl LineaClientBuilder {
             None
         };
 
+        let max_sync_delay = self.config.as_ref().and_then(|c| c.max_sync_delay);
+
         let config = Config {
             execution_rpc,
             #[cfg(not(target_arch = "wasm32"))]
@@ -110,6 +112,7 @@ impl LineaClientBuilder {
             #[cfg(target_arch = "wasm32")]
             rpc_port: None,
             chain: base_config.chain,
+            max_sync_delay,
         };
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -142,7 +145,7 @@ impl LineaClientBuilder {
             consensus,
             execution,
             fork_schedule,
-            60,
+            config.max_sync_delay.unwrap_or(60),
             #[cfg(not(target_arch = "wasm32"))]
             socket,
         ))

--- a/linea/src/builder.rs
+++ b/linea/src/builder.rs
@@ -142,6 +142,7 @@ impl LineaClientBuilder {
             consensus,
             execution,
             fork_schedule,
+            60,
             #[cfg(not(target_arch = "wasm32"))]
             socket,
         ))

--- a/linea/src/config.rs
+++ b/linea/src/config.rs
@@ -104,6 +104,7 @@ pub struct CliConfig {
     pub execution_rpc: Option<Url>,
     pub rpc_bind_ip: Option<IpAddr>,
     pub rpc_port: Option<u16>,
+    pub max_sync_delay: Option<u64>,
 }
 
 impl CliConfig {
@@ -120,6 +121,10 @@ impl CliConfig {
 
         if let Some(port) = self.rpc_port {
             user_dict.insert("rpc_port", Value::from(port));
+        }
+
+        if let Some(d) = self.max_sync_delay {
+            user_dict.insert("max_sync_delay", Value::from(d));
         }
 
         Serialized::from(user_dict, network)
@@ -150,6 +155,7 @@ pub struct Config {
     pub rpc_bind_ip: Option<IpAddr>,
     pub rpc_port: Option<u16>,
     pub chain: ChainConfig,
+    pub max_sync_delay: Option<u64>,
 }
 
 impl Config {
@@ -203,6 +209,7 @@ impl Default for Config {
             rpc_bind_ip: None,
             rpc_port: None,
             chain: ChainConfig::default(),
+            max_sync_delay: None,
         }
     }
 }
@@ -214,6 +221,7 @@ impl From<BaseConfig> for Config {
             rpc_port: Some(base.rpc_port),
             execution_rpc: Url::parse("http://localhost:8545").unwrap(),
             chain: base.chain,
+            max_sync_delay: None,
         }
     }
 }

--- a/opstack/src/builder.rs
+++ b/opstack/src/builder.rs
@@ -88,6 +88,7 @@ impl OpStackClientBuilder {
                 load_external_fallback: None,
                 checkpoint: None,
                 verify_unsafe_signer: self.verify_unsafe_signer.unwrap_or_default(),
+                max_sync_delay: None,
             }
         };
 
@@ -108,7 +109,7 @@ impl OpStackClientBuilder {
                 consensus,
                 execution,
                 config.chain.forks,
-                60,
+                config.max_sync_delay.unwrap_or(60),
                 #[cfg(not(target_arch = "wasm32"))]
                 config.rpc_socket,
             ))
@@ -128,7 +129,7 @@ impl OpStackClientBuilder {
                 consensus,
                 execution,
                 config.chain.forks,
-                60,
+                config.max_sync_delay.unwrap_or(60),
                 #[cfg(not(target_arch = "wasm32"))]
                 config.rpc_socket,
             ))

--- a/opstack/src/builder.rs
+++ b/opstack/src/builder.rs
@@ -108,6 +108,7 @@ impl OpStackClientBuilder {
                 consensus,
                 execution,
                 config.chain.forks,
+                60,
                 #[cfg(not(target_arch = "wasm32"))]
                 config.rpc_socket,
             ))
@@ -127,6 +128,7 @@ impl OpStackClientBuilder {
                 consensus,
                 execution,
                 config.chain.forks,
+                60,
                 #[cfg(not(target_arch = "wasm32"))]
                 config.rpc_socket,
             ))

--- a/opstack/src/config.rs
+++ b/opstack/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
     pub load_external_fallback: Option<bool>,
     pub checkpoint: Option<B256>,
     pub verify_unsafe_signer: bool,
+    pub max_sync_delay: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## Summary

Adds a `--max-sync-delay` CLI flag and corresponding config option to allow users to configure the maximum age (in seconds) of the latest block before Helios considers itself out of sync.

Previously this was hardcoded to 60 seconds in `core/src/client/node.rs`. The default remains 60s, preserving existing behavior.

## Changes

- **`core/src/client/node.rs`** — replaced hardcoded `60` with configurable `self.max_sync_delay`
- **`core/src/client/mod.rs`** — pass `max_sync_delay` through to `Node::new()`
- **`ethereum/src/config/mod.rs`** — added `max_sync_delay: u64` field to `Config` (default: 60)
- **`ethereum/src/config/cli.rs`** — added `max_sync_delay` to `CliConfig`
- **`ethereum/src/builder.rs`** — thread config value through builder
- **`cli/src/main.rs`** — added `--max-sync-delay` CLI flag
- **`opstack/src/builder.rs`** — pass default (60) to `HeliosClient::new()`
- **`linea/src/builder.rs`** — pass default (60) to `HeliosClient::new()`

## Usage

```bash
# Default behavior (60s)
helios ethereum --execution-rpc http://localhost:8545

# Custom sync delay (120s)
helios ethereum --execution-rpc http://localhost:8545 --max-sync-delay 120
```

Compiles cleanly (`cargo check` passes).