### PR TITLE
feat: optimistic block notifications

### DIFF
--- a/core/src/client/api.rs
+++ b/core/src/client/api.rs
@@ -90,4 +90,9 @@ pub trait HeliosApi<N: NetworkSpec>: Send + Sync + 'static {
     // checkpoint
     async fn current_checkpoint(&self) -> Result<Option<B256>>;
     fn new_checkpoints_recv(&self) -> Result<tokio::sync::watch::Receiver<Option<B256>>>;
+    // optimistic block (head attested by current sync committee)
+    async fn current_optimistic_block(&self) -> Result<Option<N::BlockResponse>>;
+    fn new_optimistic_blocks_recv(
+        &self,
+    ) -> Result<tokio::sync::watch::Receiver<Option<N::BlockResponse>>>;
 }

--- a/core/src/client/node.rs
+++ b/core/src/client/node.rs
@@ -522,4 +522,19 @@ impl<N: NetworkSpec, C: Consensus<N::BlockResponse>, E: ExecutionProvider<N>> He
             .checkpoint_recv()
             .ok_or_else(|| eyre!("Checkpoints not supported"))
     }
+
+    async fn current_optimistic_block(&self) -> Result<Option<N::BlockResponse>> {
+        self.consensus
+            .optimistic_block_recv()
+            .map(|recv| recv.borrow().clone())
+            .ok_or_else(|| eyre!("Optimistic block updates not supported"))
+    }
+
+    fn new_optimistic_blocks_recv(
+        &self,
+    ) -> Result<tokio::sync::watch::Receiver<Option<N::BlockResponse>>> {
+        self.consensus
+            .optimistic_block_recv()
+            .ok_or_else(|| eyre!("Optimistic block updates not supported"))
+    }
 }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -12,6 +12,7 @@ pub trait Consensus<
 {
     fn block_recv(&mut self) -> Option<mpsc::Receiver<B>>;
     fn finalized_block_recv(&mut self) -> Option<watch::Receiver<Option<B>>>;
+    fn optimistic_block_recv(&self) -> Option<watch::Receiver<Option<B>>>;
     fn checkpoint_recv(&self) -> Option<watch::Receiver<Option<B256>>>;
     fn expected_highest_block(&self) -> u64;
     fn chain_id(&self) -> u64;

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -49,6 +49,7 @@ pub enum ConsensusSyncStatus {
 pub struct ConsensusClient<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> {
     pub block_recv: Option<Receiver<Block<Transaction>>>,
     pub finalized_block_recv: Option<watch::Receiver<Option<Block<Transaction>>>>,
+    pub optimistic_block_recv: watch::Receiver<Option<Block<Transaction>>>,
     pub checkpoint_recv: watch::Receiver<Option<B256>>,
     sync_status_recv: Mutex<watch::Receiver<ConsensusSyncStatus>>,
     shutdown_send: watch::Sender<bool>,
@@ -64,6 +65,7 @@ pub struct Inner<S: ConsensusSpec, R: ConsensusRpc<S>> {
     last_checkpoint: Option<B256>,
     block_send: Sender<Block<Transaction>>,
     finalized_block_send: watch::Sender<Option<Block<Transaction>>>,
+    optimistic_block_send: watch::Sender<Option<Block<Transaction>>>,
     checkpoint_send: watch::Sender<Option<B256>>,
     pub config: Arc<Config>,
     phantom: PhantomData<S>,
@@ -79,6 +81,10 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> Consensus<Block>
 
     fn finalized_block_recv(&mut self) -> Option<watch::Receiver<Option<Block<Transaction>>>> {
         self.finalized_block_recv.take()
+    }
+
+    fn optimistic_block_recv(&self) -> Option<watch::Receiver<Option<Block<Transaction>>>> {
+        Some(self.optimistic_block_recv.clone())
     }
 
     fn checkpoint_recv(&self) -> Option<watch::Receiver<Option<B256>>> {
@@ -119,6 +125,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
     pub fn new(rpc: &Url, config: Arc<Config>) -> Result<ConsensusClient<S, R, DB>> {
         let (block_send, block_recv) = channel(256);
         let (finalized_block_send, finalized_block_recv) = watch::channel(None);
+        let (optimistic_block_send, optimistic_block_recv) = watch::channel(None);
         let (checkpoint_send, checkpoint_recv) = watch::channel(None);
         let (sync_status_send, sync_status_recv) = watch::channel(ConsensusSyncStatus::Syncing);
         let (shutdown_send, shutdown_recv) = watch::channel(false);
@@ -144,6 +151,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
                 &rpc,
                 block_send,
                 finalized_block_send,
+                optimistic_block_send,
                 checkpoint_send,
                 config.clone(),
             );
@@ -212,6 +220,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
         Ok(ConsensusClient {
             block_recv: Some(block_recv),
             finalized_block_recv: Some(finalized_block_recv),
+            optimistic_block_recv,
             checkpoint_recv,
             sync_status_recv: Mutex::new(sync_status_recv),
             shutdown_send,
@@ -297,6 +306,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
         rpc: &str,
         block_send: Sender<Block<Transaction>>,
         finalized_block_send: watch::Sender<Option<Block<Transaction>>>,
+        optimistic_block_send: watch::Sender<Option<Block<Transaction>>>,
         checkpoint_send: watch::Sender<Option<B256>>,
         config: Arc<Config>,
     ) -> Inner<S, R> {
@@ -308,6 +318,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
             last_checkpoint: None,
             block_send,
             finalized_block_send,
+            optimistic_block_send,
             checkpoint_send,
             config,
             phantom: PhantomData,
@@ -505,11 +516,13 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
             let block = payload_to_block(payload);
             let finalized_block = payload_to_block(finalized_payload);
 
+            let _ = self.optimistic_block_send.send(Some(block.clone()));
             self.block_send.send(block).await?;
             self.finalized_block_send.send(Some(finalized_block))?;
         } else {
             let payload = self.get_execution_payload(&slot).await?;
             let block = payload_to_block(payload);
+            let _ = self.optimistic_block_send.send(Some(block.clone()));
             self.block_send.send(block).await?;
         }
 
@@ -800,12 +813,14 @@ mod tests {
 
         let (block_send, _) = channel(256);
         let (finalized_block_send, _) = watch::channel(None);
+        let (optimistic_block_send, _) = watch::channel(None);
         let (channel_send, _) = watch::channel(None);
 
         let mut client = Inner::new(
             "testdata/",
             block_send,
             finalized_block_send,
+            optimistic_block_send,
             channel_send,
             Arc::new(config),
         );

--- a/linea/src/consensus.rs
+++ b/linea/src/consensus.rs
@@ -89,6 +89,10 @@ impl Consensus<Block<Transaction>> for ConsensusClient {
         self.finalized_block_recv.take()
     }
 
+    fn optimistic_block_recv(&self) -> Option<watch::Receiver<Option<Block<Transaction>>>> {
+        None
+    }
+
     fn checkpoint_recv(&self) -> Option<watch::Receiver<Option<B256>>> {
         None
     }

--- a/opstack/src/consensus.rs
+++ b/opstack/src/consensus.rs
@@ -105,6 +105,10 @@ impl Consensus<Block<Transaction>> for ConsensusClient {
         self.finalized_block_recv.take()
     }
 
+    fn optimistic_block_recv(&self) -> Option<watch::Receiver<Option<Block<Transaction>>>> {
+        None
+    }
+
     fn checkpoint_recv(&self) -> Option<watch::Receiver<Option<B256>>> {
         None
     }


### PR DESCRIPTION
## Summary

Adds a `watch`-channel notification path for the latest optimistic-header-derived block, mirroring the shape of #738's checkpoint notifications. Builds on the consensus client's already-tracked `optimistic_header` state — no new sync logic, just exposes data that the light client already maintains.

```rust
// new on the Consensus trait
fn optimistic_block_recv(&self) -> Option<watch::Receiver<Option<B>>>;

// new on HeliosApi
async fn current_optimistic_block(&self) -> Result<Option<N::BlockResponse>>;
fn new_optimistic_blocks_recv(&self) -> Result<watch::Receiver<Option<N::BlockResponse>>>;
```

## Motivation

#302 originally asked for "tracking and getting notified when a new update is applied" with a concrete use case of "setting a hook on new optimistic update, to do some action (e.g. re-check a list of balances)". #738 addressed the checkpoint half of that — the finalized side. This addresses the optimistic side.

`block_recv` already streams the same blocks via mpsc, but the watch variant lets multiple subscribers each see the latest value without coordinating a single consumer. Concrete external use cases:

- A data indexer that needs to react to chain-tip advances under sync-committee attestation without waiting for full finality (~12.8min).
- A dashboard / SSE service that fans out updates to many connected clients — each subscriber holds its own `watch::Receiver` clone of the same channel.
- A monitoring tool tracking "what does Helios think is the head right now?" for health checks.

For comparison: `block_recv` (mpsc) is a stream meant for a single consumer; the new watch channel is meant for many lightweight observers that only care about the latest value.

## Changes

- `core/src/consensus.rs` — add `optimistic_block_recv` to the `Consensus` trait
- `core/src/client/api.rs` — add `current_optimistic_block` + `new_optimistic_blocks_recv` to `HeliosApi`
- `core/src/client/node.rs` — implement the new `HeliosApi` methods (delegate to `Consensus::optimistic_block_recv`)
- `ethereum/src/consensus.rs` — wire `optimistic_block_send` into `ConsensusClient` + `Inner`, publish in both branches of `send_blocks` (matching how `block_send` was already invoked)
- `opstack/src/consensus.rs`, `linea/src/consensus.rs` — implement the trait method returning `None`, matching how they already handle `checkpoint_recv`

44 lines added across 6 files. `cargo test --workspace --lib` clean (23 tests passing), `cargo clippy --workspace --lib` clean, `cargo fmt --check` clean.

## What's deliberately NOT in this PR

- **JSON-RPC method + subscription.** Would mirror `helios_getCurrentCheckpoint` / `helios_subscribeNewCheckpoints` from #738, but doing so cleanly requires making the `HeliosRpc` trait generic over `N::BlockResponse` (the current shape returns concrete `Option<B256>` for checkpoints, which works because B256 is concrete; blocks are network-specific). That's a bigger trait-surface change that the maintainers may prefer to design themselves. Happy to follow up in a separate PR if you want this — the Rust-API additions in this PR work standalone for crate consumers.
- **`helios-ts` bindings.** Depend on the JSON-RPC layer, so deferred along with that.

## Note on tests

There's no test directly observing the new channel — there's no analogous test for `finalized_block_send` either, since exercising `send_blocks` end-to-end needs richer mock-RPC fixture work than the existing tests do. The channel wiring is mechanical (mirrors `finalized_block_send` exactly). Happy to add a test if reviewers prefer — pointer to the right test pattern would help.