### PR TITLE
fix(example): avoid potential API key exposure in debug output

### DIFF
--- a/examples/config.rs
+++ b/examples/config.rs
@@ -8,8 +8,8 @@ async fn main() -> Result<()> {
     // Load the config from the global config file
     let home = home_dir().ok_or_else(|| eyre::eyre!("Could not find home directory"))?;
     let config_path = home.join(".helios/helios.toml");
-    let config = Config::from_file(&config_path, "mainnet", &CliConfig::default());
-    println!("Constructed config: {config:#?}");
+    let _config = Config::from_file(&config_path, "mainnet", &CliConfig::default());
+    println!("Config loaded successfully");
 
     Ok(())
 }


### PR DESCRIPTION
The example printed the entire Config struct via {config:#?}. Since Config derives Debug and contains URL fields like execution_rpc, this could expose API keys embedded in RPC URLs. Replaced with a generic success message.

Fixes #799