### PR TITLE
fix: avoid panic when checkpoint API returns no slots

### DIFF
--- a/ethereum/src/config/checkpoints.rs
+++ b/ethereum/src/config/checkpoints.rs
@@ -235,7 +235,12 @@ impl CheckpointFallback {
         let constructed_url = Self::construct_url(url);
         let res = get(&constructed_url).await?;
         let raw: RawSlotResponse = res.json().await?;
-        let slot = raw.data.slots[0].clone();
+        let slot = raw
+            .data
+            .slots
+            .first()
+            .ok_or_else(|| eyre::eyre!("no slots"))?
+            .clone();
         slot.block_root
             .ok_or_else(|| eyre::eyre!("Checkpoint not in returned slot"))
     }


### PR DESCRIPTION
fetch_checkpoint_from_api accessed raw.data.slots[0] without checking if the slice is empty, causing a panic if a fallback endpoint returns no slots. This aligns the function with the existing defensive pattern already used in fetch_latest_checkpoint_from_services.