### PR TITLE
feat: make seconds per slot a ConsensusSpec parameter

### DIFF
--- a/ethereum/consensus-core/src/consensus_core.rs
+++ b/ethereum/consensus-core/src/consensus_core.rs
@@ -386,12 +386,12 @@ pub fn force_update<S: ConsensusSpec>(store: &mut LightClientStore<S>, current_s
     }
 }
 
-pub fn expected_current_slot(now: SystemTime, genesis_time: u64) -> u64 {
+pub fn expected_current_slot<S: ConsensusSpec>(now: SystemTime, genesis_time: u64) -> u64 {
     let now = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
 
     let since_genesis = now - genesis_time;
 
-    since_genesis / 12
+    since_genesis / S::seconds_per_slot()
 }
 
 pub fn calc_sync_period<S: ConsensusSpec>(slot: u64) -> u64 {
@@ -518,5 +518,28 @@ fn is_valid_header<S: ConsensusSpec>(header: &LightClientHeader, forks: &Forks) 
         is_execution_payload_proof_valid(header.beacon(), execution, execution_branch)
     } else {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{expected_current_slot, UNIX_EPOCH};
+    use crate::consensus_spec::{MainnetConsensusSpec, MinimalConsensusSpec};
+
+    #[test]
+    fn expected_current_slot_uses_spec_slot_duration() {
+        let genesis_time = 1_606_824_023;
+        let now = UNIX_EPOCH + Duration::from_secs(genesis_time + 60);
+
+        assert_eq!(
+            expected_current_slot::<MainnetConsensusSpec>(now, genesis_time),
+            5
+        );
+        assert_eq!(
+            expected_current_slot::<MinimalConsensusSpec>(now, genesis_time),
+            10
+        );
     }
 }

--- a/ethereum/consensus-core/src/consensus_spec.rs
+++ b/ethereum/consensus-core/src/consensus_spec.rs
@@ -39,6 +39,10 @@ pub trait ConsensusSpec: 'static + Default + Sync + Send + Clone + Debug + Parti
     fn sync_committee_size() -> u64 {
         Self::SyncCommitteeSize::to_u64()
     }
+
+    fn seconds_per_slot() -> u64 {
+        12
+    }
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
@@ -89,4 +93,8 @@ impl ConsensusSpec for MinimalConsensusSpec {
     type MaxDepositRequests = typenum::U4;
     type MaxWithdrawalRequests = typenum::U2;
     type MaxConsolidationRequests = typenum::U1;
+
+    fn seconds_per_slot() -> u64 {
+        6
+    }
 }

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -175,7 +175,8 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
             _ = sync_status_send.send(ConsensusSyncStatus::Synced);
 
             let start = Instant::now() + inner.duration_until_next_update().to_std().unwrap();
-            let mut interval = interval_at(start, std::time::Duration::from_secs(12));
+            let mut interval =
+                interval_at(start, std::time::Duration::from_secs(S::seconds_per_slot()));
 
             loop {
                 tokio::select! {
@@ -224,7 +225,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
     pub fn expected_current_slot(&self) -> u64 {
         let now = SystemTime::now();
 
-        expected_current_slot(now, self.genesis_time)
+        expected_current_slot::<S>(now, self.genesis_time)
     }
 }
 
@@ -517,7 +518,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
     }
 
     /// Gets the duration until the next update
-    /// Updates are scheduled for 4 seconds into each slot
+    /// Updates are scheduled for one third of a slot into each slot (4 seconds on mainnet)
     pub fn duration_until_next_update(&self) -> Duration {
         let current_slot = self.expected_current_slot();
         let next_slot = current_slot + 1;
@@ -529,7 +530,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
             .as_secs();
 
         let time_to_next_slot = next_slot_timestamp - now;
-        let next_update = time_to_next_slot + 4;
+        let next_update = time_to_next_slot + S::seconds_per_slot() / 3;
 
         Duration::try_seconds(next_update as i64).unwrap()
     }
@@ -654,11 +655,11 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
     pub fn expected_current_slot(&self) -> u64 {
         let now = SystemTime::now();
 
-        expected_current_slot(now, self.config.chain.genesis_time)
+        expected_current_slot::<S>(now, self.config.chain.genesis_time)
     }
 
     fn slot_timestamp(&self, slot: u64) -> u64 {
-        slot * 12 + self.config.chain.genesis_time
+        slot * S::seconds_per_slot() + self.config.chain.genesis_time
     }
 
     // Determines blockhash_slot age and returns true if it is less than 14 days old


### PR DESCRIPTION
Makes every wall-clock slot computation use the spec's slot duration instead of a hardcoded 12 seconds, so a `ConsensusSpec` for a chain with a different slot time gets correct slot arithmetic without any change to helios's networks or config. Mainnet and every existing network are untouched: the default stays 12.

## Why

`ConsensusSpec` already parameterizes everything that differs between presets (slots per epoch, sync-committee size and period, container bounds), which is what makes `helios-consensus-core` usable as a library on other beacon chains purely as data. The one exception was the slot duration, assumed to be 12 s in three places:

- `consensus_core::expected_current_slot`: `since_genesis / 12`
- `Inner::slot_timestamp` in `ethereum/src/consensus.rs`: `slot * 12`, which feeds `is_valid_checkpoint` and the head-age log line
- the advance loop in `ConsensusClient::new`: a `Duration::from_secs(12)` period, phased 4 s (one third of a 12 s slot) into each slot by `duration_until_next_update`

For a 5-second chain such as Gnosis the effect is not a small drift. `expected_current_slot` comes out 2.4x too low, so `verify_generic_update` fails its `expected_current_slot >= update.signature_slot` check and every fresh update is rejected with `InvalidTimestamp`. `slot_timestamp` ages checkpoints 2.4x too fast, so a checkpoint that is 6 days old is judged 14.4 days old and rejected by the default `max_checkpoint_age`. The `minimal` preset that the consensus-core test vectors are generated from also declares `SECONDS_PER_SLOT: 6` (`testdata/*/config.yaml`), which `MinimalConsensusSpec` could not express.

We hit this building a Gnosis finalized-state anchor on `helios-consensus-core`: the whole integration was data (a spec impl, a fork schedule, genesis constants) plus a four-line local copy of `expected_current_slot` to get around this constant. This change removes the need for that copy and adds no chain to helios.

## What changes

- `ConsensusSpec::seconds_per_slot()`: a new default method returning 12, in the style of `slots_per_epoch()`. `MainnetConsensusSpec` keeps the default; `MinimalConsensusSpec` overrides to 6 to match its `config.yaml`.
- `expected_current_slot` becomes `expected_current_slot::<S>` and divides by `S::seconds_per_slot()`.
- `ethereum/src/consensus.rs`: the two `expected_current_slot` wrappers pass `S`; `slot_timestamp`, the advance interval, and the one-third-slot update offset use `S::seconds_per_slot()`.

Wall-clock slot at genesis + 60 s, and the age the checkpoint rule computes for a checkpoint that is actually 6 days old:

| spec | seconds per slot | expected slot, before → after | 6-day-old checkpoint, before → after |
|---|---|---|---|
| Mainnet | 12 | 5 → 5 | 6.0 d → 6.0 d |
| Minimal (test vectors) | 6 | 5 → 10 | 12.0 d → 6.0 d |
| Gnosis (downstream impl) | 5 | 5 → 12 | 14.4 d, rejected → 6.0 d |

## Compatibility

One public signature changes: `helios_consensus_core::expected_current_slot` now takes the spec as a type parameter. Inside helios every caller is already generic over `S`, so the call sites only gain `::<S>`; an external caller writes `expected_current_slot::<MainnetConsensusSpec>(now, genesis_time)`. No config field is added and nothing else in the API moves.

## Tests

- New unit test `expected_current_slot_uses_spec_slot_duration`: at genesis + 60 s, mainnet (12 s) yields slot 5 and minimal (6 s) yields slot 10.
- The existing consensus-core sync vectors are unaffected; they receive the expected slot as a parameter.
- Ran locally: `cargo fmt --all -- --check`, `codespell`, `cargo check --workspace`, `cargo check --target wasm32-unknown-unknown -p helios-ts`, and `cargo test --all`. The only test failures are the two live-network tests (`rpc_equivalence_tests`, which needs `MAINNET_EXECUTION_RPC`, and `test_fetch_latest_checkpoints`), and they fail the same way on master.
- `cargo clippy --all -- -D warnings` is red on master with current stable (`manual_saturating_arithmetic` at `core/src/client/node.rs:161`, and the same pattern in `is_valid_checkpoint`); this PR does not touch either line.

Related: #455 adds full Gnosis support and threads a `block_time` through `ChainConfig` to address the same problem. This PR is only the spec-level slice, so it stays small and adds no chain; a Gnosis network config could later build on it.

Closes #808.

Assisted-by: Claude-Fable-5.1
