### PR TITLE
fix: return an error instead of panicking on a receipt or tx without an index

### DIFF
--- a/core/src/execution/errors.rs
+++ b/core/src/execution/errors.rs
@@ -21,6 +21,8 @@ pub enum ExecutionError {
     MissingLog(B256, U256),
     #[error("too many logs to prove: {0} spanning {1} blocks current limit is: {2} blocks")]
     TooManyLogsToProve(usize, usize, usize),
+    #[error("transaction {0} is not included in a block")]
+    TransactionNotIncluded(B256),
     #[error("execution rpc is for the incorrect network")]
     IncorrectRpcNetwork(),
     #[error("block not found: {0}")]

--- a/core/src/execution/proof.rs
+++ b/core/src/execution/proof.rs
@@ -143,7 +143,11 @@ pub fn verify_receipt_proof<N: NetworkSpec>(
     proof: &[Bytes],
 ) -> Result<()> {
     let key = {
-        let index = receipt.transaction_index().unwrap() as usize;
+        let index = receipt
+            .transaction_index()
+            .ok_or(ExecutionError::TransactionNotIncluded(
+                receipt.transaction_hash(),
+            ))? as usize;
         let index_buffer = rlp::encode_fixed_size(&index);
         Nibbles::unpack(&index_buffer)
     };
@@ -190,7 +194,9 @@ pub fn verify_transaction_proof<N: NetworkSpec>(
     proof: &[Bytes],
 ) -> Result<()> {
     let key = {
-        let index = tx.transaction_index().unwrap() as usize;
+        let index =
+            tx.transaction_index()
+                .ok_or(ExecutionError::TransactionNotIncluded(tx.tx_hash()))? as usize;
         let index_buffer = rlp::encode_fixed_size(&index);
         Nibbles::unpack(&index_buffer)
     };
@@ -315,6 +321,29 @@ mod tests {
 
             assert!(result.is_ok());
         }
+    }
+
+    #[test]
+    fn test_verify_receipt_proof_without_transaction_index() {
+        // A receipt that is not included in a block carries no index. Verification
+        // must reject it rather than panic, since the receipt comes from a server
+        // whose responses are exactly what this proof is meant to check.
+        let mut receipt = rpc_tx_receipt();
+        receipt.transaction_index = None;
+
+        let result = verify_receipt_proof::<EthereumSpec>(&receipt, B256::ZERO, &[]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_transaction_proof_without_transaction_index() {
+        let mut tx = rpc_tx();
+        tx.transaction_index = None;
+
+        let result = verify_transaction_proof::<EthereumSpec>(&tx, B256::ZERO, &[]);
+
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
`verify_receipt_proof` and `verify_transaction_proof` unwrapped `transaction_index()`:

```rust
let index = receipt.transaction_index().unwrap() as usize;
```

That field is `None` for anything not included in a block, and both functions are called on responses that come straight off a verifiable-api server, before any of that server's data has been proven:

```rust
// providers/verifiable_api.rs
let Some(block_hash) = receipt_response.receipt.block_hash() else { ... };
// ...
verify_receipt_proof::<N>(&receipt_response.receipt, receipts_root, &receipt_response.receipt_proof)?;
```

Only `block_hash` is checked there. A response with `"transactionIndex": null` panics, and since release builds set `panic = "abort"` that takes the whole process down. It is the wrong outcome for a function whose job is to decide whether to trust that server in the first place.

`get_transaction_by_location` already handles the same Option properly with `ok_or(eyre!("transaction not included"))`, so this is really the two call sites that were missed.

Both now return `ExecutionError::TransactionNotIncluded` and the response gets rejected like any other invalid one.

Added two tests. I checked they fail on the current code for the right reason — both panic at `proof.rs` with `called Option::unwrap() on a None value` — and pass after the change.

`cargo fmt --all --check` is clean and the change introduces no new clippy findings. `cargo test -p helios-core` passes (16). Two tests in the workspace fail for me both with and without this change, since I have no credentials for them: `rpc_equivalence` needs `MAINNET_EXECUTION_RPC`, and `checkpoints::test_fetch_latest_checkpoints` calls out to live checkpoint services.

The same pattern exists in a few other spots I noticed while reading (`storage_proof[0]` in the opstack unsafe-signer check, the `TxEnvelope::decode().unwrap()` calls in `payload_to_block`). Happy to send those separately if you want them fixed.
